### PR TITLE
Parsing error on as_record when value of a bin is null.

### DIFF
--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -480,6 +480,9 @@ int recordbins_from_jsobject(as_record * rec, Local<Object> obj, LogInfo * log)
             //as_record_get_bytes(rec, *n)->free = true;
 
         }
+        else if ( value->IsNull() ) {
+            as_record_set_nil(rec, *n);
+        }
         else {
             return AS_NODE_PARAM_ERR;
         }


### PR DESCRIPTION
Looked into the documentation for removing a bin from a record and it said to set the bin's value to null.
https://github.com/aerospike/aerospike-client-nodejs/blob/master/docs/client.md#put

When attempting that though, came back with: "Parsing as_record(C structure) from record object failed".

Looking on conversions.cc and saw that it checked for string, number, and object (Buffer) while returning the error for any of data types. Just added an extra conditional for null, and saw the C/C++ client already had as_record_set_nil.

Tested it with the code I was trying to run and it did as I wished. Also, notice operations write null doesn't work either, yet didn't see an already made _nil function or if operations should even do that so I ignored that for now and put will take care of my needs.

to test:

``` javascript
var key = {
    ns: 'test',
    set: 'set',
    key: 'key'
};
client.put(key, {bin: 'hi'}, function(err) {
    client.get(key, function(err, record) {
        console.log('ADDED:', record);
        client.put(key, {bin: null}, function(err) {
            client.get(key, function(err, record) {
                console.log('REMOVED:', record);
            });
        });
    });
});
```
