### PR TITLE
Adding Linux mint as supported distro

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -61,7 +61,7 @@ detect_linux()
         return 0
         ;;
 
-      "ubuntu12" | "ubuntu13" | "ubuntu14" )
+      "ubuntu12" | "ubuntu13" | "ubuntu14" | "linuxmint17" )
         echo "ubuntu12"  "deb"
         return 0
         ;;


### PR DESCRIPTION
Linux mint is a derivative Distro based on Ubuntu. Linux Mint 17 is based on Ubuntu 14.04.

http://www.linuxmint.com/release.php?id=22
