### PR TITLE
Update aerospike-client-c.sh to support Linux Mint 17

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -61,7 +61,7 @@ detect_linux()
         return 0
         ;;
 
-      "ubuntu12" | "ubuntu13" | "ubuntu14" )
+      "ubuntu12" | "ubuntu13" | "ubuntu14" | "linuxmint17" )
         echo "ubuntu12"  "deb"
         return 0
         ;;


### PR DESCRIPTION
I have seen plenty of discussion about adding support to LinuxMint17. The solution has also been posted. After adding this simple check, it works flawless on LinuxMint17.

Please consider adding this pull request so that when developers try installing aerospoike via NPM the process goes smoothly.