### PR TITLE
iojs 2.x support (only UDF fails - any ideas?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,24 +6,24 @@
   "homepage" : "https://github.com/aerospike/aerospike-client-nodejs",
   "main" : "lib/aerospike",
   "engines" : {
-    "node" : ">=0.10"
+	"node" : ">=0.10"
   },
   "os" : [ "linux", "darwin" ],
   "cpu" : [ "x64" ],
   "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/aerospike/aerospike-client-nodejs"
+	"type" : "git",
+	"url" : "https://github.com/aerospike/aerospike-client-nodejs"
   },
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha -R spec"
+	"test": "node_modules/mocha/bin/mocha -R spec"
   },
   "dependencies" : {
-	"nan" : "~1.5.0"
+	"nan" : "~1.8.4"
   },
   "devDependencies": {
-    "mocha": ">0",
-    "expect.js": "0.2.x",
-    "superagent": "0.15.x",
-    "yargs":"1.2.1"
+	"mocha": ">0",
+	"expect.js": "0.2.x",
+	"superagent": "0.15.x",
+	"yargs":"1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-  "name" : "aerospike",
-  "version" : "1.0.40",
-  "description" : "Aerospike Client Library",
-  "tags" : [ "aerospike", "database", "nosql" ],
-  "homepage" : "https://github.com/aerospike/aerospike-client-nodejs",
-  "main" : "lib/aerospike",
-  "engines" : {
-	"node" : ">=0.10"
-  },
-  "os" : [ "linux", "darwin" ],
-  "cpu" : [ "x64" ],
-  "repository" : {
-	"type" : "git",
-	"url" : "https://github.com/aerospike/aerospike-client-nodejs"
-  },
-  "scripts": {
-	"test": "node_modules/mocha/bin/mocha -R spec"
-  },
-  "dependencies" : {
-	"nan" : "~1.8.4"
-  },
-  "devDependencies": {
-	"mocha": ">0",
-	"expect.js": "0.2.x",
-	"superagent": "0.15.x",
-	"yargs":"1.2.1"
-  }
+	"name": "aerospike",
+	"version": "1.0.40",
+	"description": "Aerospike Client Library",
+	"tags": ["aerospike", "database", "nosql"],
+	"homepage": "https://github.com/aerospike/aerospike-client-nodejs",
+	"main": "lib/aerospike",
+	"engines": {
+		"node": ">=0.10"
+	},
+	"os": ["linux", "darwin"],
+	"cpu": ["x64"],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aerospike/aerospike-client-nodejs"
+	},
+	"scripts": {
+		"test": "node_modules/mocha/bin/mocha -R spec"
+	},
+	"dependencies": {
+		"nan": "~1.8.4"
+	},
+	"devDependencies": {
+		"mocha": ">0",
+		"expect.js": "0.2.x",
+		"superagent": "0.15.x",
+		"yargs": "1.2.1"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"homepage": "https://github.com/aerospike/aerospike-client-nodejs",
 	"main": "lib/aerospike",
 	"engines": {
-		"node": ">=0.10"
+		"node": ">=0.10",
+		"iojs": ">=2.0.0"
 	},
 	"os": ["linux", "darwin"],
 	"cpu": ["x64"],

--- a/src/main/client/batch_exists.cc
+++ b/src/main/client/batch_exists.cc
@@ -309,7 +309,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/batch_get.cc
+++ b/src/main/client/batch_get.cc
@@ -314,7 +314,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     as_v8_debug(log,"Invoked the callback");

--- a/src/main/client/batch_select.cc
+++ b/src/main/client/batch_select.cc
@@ -340,7 +340,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     as_v8_debug(log,"Invoked the callback");

--- a/src/main/client/execute.cc
+++ b/src/main/client/execute.cc
@@ -242,7 +242,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/exists.cc
+++ b/src/main/client/exists.cc
@@ -220,7 +220,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     as_v8_debug(log, "Invoked exists callback");

--- a/src/main/client/get.cc
+++ b/src/main/client/get.cc
@@ -15,12 +15,12 @@
  ******************************************************************************/
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_key.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/as_key.h>
-    #include <aerospike/as_record.h>
-    #include <aerospike/as_record_iterator.h>
+	#include <aerospike/aerospike.h>
+	#include <aerospike/aerospike_key.h>
+	#include <aerospike/as_config.h>
+	#include <aerospike/as_key.h>
+	#include <aerospike/as_record.h>
+	#include <aerospike/as_record_iterator.h>
 }
 
 #include <node.h>
@@ -46,14 +46,14 @@ using namespace v8;
  *  AsyncData — Data to be used in async calls.
  */
 typedef struct AsyncData {
-    int param_err;
-    aerospike * as;
-    as_error err;
-    as_key key;
-    as_record rec;
-    as_policy_read* policy;
-    LogInfo * log;
-    Persistent<Function> callback;
+	int param_err;
+	aerospike * as;
+	as_error err;
+	as_key key;
+	as_record rec;
+	as_policy_read* policy;
+	LogInfo * log;
+	Persistent<Function> callback;
 } AsyncData;
 
 /*******************************************************************************
@@ -70,69 +70,69 @@ static void * prepare(ResolveArgs(args))
 {
 	NanScope();
 
-    AerospikeClient * client = ObjectWrap::Unwrap<AerospikeClient>(args.This());
+	AerospikeClient * client = ObjectWrap::Unwrap<AerospikeClient>(args.This());
 
-    // Build the async data
-    AsyncData * data = new AsyncData;
-    data->as = client->as;
+	// Build the async data
+	AsyncData * data = new AsyncData;
+	data->as = client->as;
 
-    LogInfo * log = data->log = client->log;
+	LogInfo * log = data->log = client->log;
 
-    data->param_err = 0;
-    // Local variables
-    as_key *    key         = &data->key;
-    as_record * rec         = &data->rec;
+	data->param_err = 0;
+	// Local variables
+	as_key *    key         = &data->key;
+	as_record * rec         = &data->rec;
 	data->policy					= NULL;
 
 
-    int arglength = args.Length();
+	int arglength = args.Length();
 
-    if ( args[arglength-1]->IsFunction()) {
+	if ( args[arglength-1]->IsFunction()) {
 		NanAssignPersistent(data->callback, args[arglength-1].As<Function>());
-        as_v8_detail(log, "Node.js callback registered");
-    }
-    else {
-        as_v8_error(log, "No callback to register");
-        COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
-        goto Err_Return;
-    }
+		as_v8_detail(log, "Node.js callback registered");
+	}
+	else {
+		as_v8_error(log, "No callback to register");
+		COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
+		goto Err_Return;
+	}
 
-    if ( args[GET_ARG_POS_KEY]->IsObject() ) {
-        if (key_from_jsobject(key, args[GET_ARG_POS_KEY]->ToObject(), log) != AS_NODE_PARAM_OK ) {
-            as_v8_error(log, "Parsing of key (C structure) from key object failed");
-            COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
-            goto Err_Return;
-        }
-    }
-    else {
-        as_v8_error(log, "Key should be an object");
-        COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
-        goto Err_Return;
-    }
+	if ( args[GET_ARG_POS_KEY]->IsObject() ) {
+		if (key_from_jsobject(key, args[GET_ARG_POS_KEY]->ToObject(), log) != AS_NODE_PARAM_OK ) {
+			as_v8_error(log, "Parsing of key (C structure) from key object failed");
+			COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
+			goto Err_Return;
+		}
+	}
+	else {
+		as_v8_error(log, "Key should be an object");
+		COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
+		goto Err_Return;
+	}
 
-    if ( arglength > 2 ) {
-        if ( args[GET_ARG_POS_RPOLICY]->IsObject() ) {
+	if ( arglength > 2 ) {
+		if ( args[GET_ARG_POS_RPOLICY]->IsObject() ) {
 			data->policy = (as_policy_read*) cf_malloc(sizeof(as_policy_read));
-            if (readpolicy_from_jsobject( data->policy, args[GET_ARG_POS_RPOLICY]->ToObject(), log) != AS_NODE_PARAM_OK) {
-                as_v8_error(log, "Parsing of readpolicy from object failed");
-                COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
-                goto Err_Return;
-            }
-        }
-        else {
-            as_v8_error(log, "Readpolicy should be an object");
-            COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
-            goto Err_Return;
-        }
-    }
+			if (readpolicy_from_jsobject( data->policy, args[GET_ARG_POS_RPOLICY]->ToObject(), log) != AS_NODE_PARAM_OK) {
+				as_v8_error(log, "Parsing of readpolicy from object failed");
+				COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
+				goto Err_Return;
+			}
+		}
+		else {
+			as_v8_error(log, "Readpolicy should be an object");
+			COPY_ERR_MESSAGE( data->err, AEROSPIKE_ERR_PARAM );
+			goto Err_Return;
+		}
+	}
    
-    as_record_init(rec, 0);
+	as_record_init(rec, 0);
 
-    return data;
+	return data;
 
 Err_Return:
-    data->param_err = 1;
-    return data;
+	data->param_err = 1;
+	return data;
 }
 /**
  *  execute() — Function to execute inside the worker-thread.
@@ -142,32 +142,32 @@ Err_Return:
  */
 static void execute(uv_work_t * req)
 {
-    // Fetch the AsyncData structure
-    AsyncData * data = reinterpret_cast<AsyncData *>(req->data);
+	// Fetch the AsyncData structure
+	AsyncData * data = reinterpret_cast<AsyncData *>(req->data);
 
-    // Data to be used.
-    aerospike * as          = data->as;
-    as_error *  err         = &data->err;
-    as_key *    key         = &data->key;
-    as_record * rec         = &data->rec;
-    as_policy_read* policy  = data->policy;
+	// Data to be used.
+	aerospike * as          = data->as;
+	as_error *  err         = &data->err;
+	as_key *    key         = &data->key;
+	as_record * rec         = &data->rec;
+	as_policy_read* policy  = data->policy;
 
-    LogInfo * log           = data->log;
+	LogInfo * log           = data->log;
 
 
-    // Invoke the blocking call.
-    // The error is handled in the calling JS code.
-    if (as->cluster == NULL) {
-        as_v8_error(log, "Not connected to Cluster to perform the operation");
-        data->param_err = 1;
-        COPY_ERR_MESSAGE(data->err, AEROSPIKE_ERR_PARAM);
-    }
+	// Invoke the blocking call.
+	// The error is handled in the calling JS code.
+	if (as->cluster == NULL) {
+		as_v8_error(log, "Not connected to Cluster to perform the operation");
+		data->param_err = 1;
+		COPY_ERR_MESSAGE(data->err, AEROSPIKE_ERR_PARAM);
+	}
 
-    if ( data->param_err == 0 ) {
-        as_v8_debug(log, "Invoking get with ");
-        // DEBUG(log, _KEY,  key);
-        aerospike_key_get(as, err, policy, key, &rec);  
-    }
+	if ( data->param_err == 0 ) {
+		as_v8_debug(log, "Invoking get with ");
+		// DEBUG(log, _KEY,  key);
+		aerospike_key_get(as, err, policy, key, &rec);  
+	}
 
 }
 
@@ -182,64 +182,64 @@ static void execute(uv_work_t * req)
 static void respond(uv_work_t * req, int status)
 {
 	NanScope();
-    // Fetch the AsyncData structure
-    AsyncData * data        = reinterpret_cast<AsyncData *>(req->data);
+	// Fetch the AsyncData structure
+	AsyncData * data        = reinterpret_cast<AsyncData *>(req->data);
 
-    as_error *  err         = &data->err;
-    as_key *    key         = &data->key;
-    as_record * rec         = &data->rec;
-    LogInfo * log           = data->log;
-    as_v8_debug(log, "Get operations' the response is");
-    // DEBUG(log, ERROR, err);
-    
-    Handle<Value> argv[4];
-    // Build the arguments array for the callback
-    if( data->param_err == 0) {
-        argv[0] = error_to_jsobject(err, log),
-        argv[1] = recordbins_to_jsobject(rec, log ),
-        argv[2] = recordmeta_to_jsobject(rec, log),
-        argv[3] = key_to_jsobject(key, log);
-    }
-    else {
-        err->func = NULL;
-        as_v8_debug(log, "Parameter error while parsing the arguments");
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = NanNull();
-        argv[2] = NanNull();
-        argv[3] = NanNull();
-    }
+	as_error *  err         = &data->err;
+	as_key *    key         = &data->key;
+	as_record * rec         = &data->rec;
+	LogInfo * log           = data->log;
+	as_v8_debug(log, "Get operations' the response is");
+	// DEBUG(log, ERROR, err);
+	
+	Handle<Value> argv[4];
+	// Build the arguments array for the callback
+	if( data->param_err == 0) {
+		argv[0] = error_to_jsobject(err, log),
+		argv[1] = recordbins_to_jsobject(rec, log ),
+		argv[2] = recordmeta_to_jsobject(rec, log),
+		argv[3] = key_to_jsobject(key, log);
+	}
+	else {
+		err->func = NULL;
+		as_v8_debug(log, "Parameter error while parsing the arguments");
+		argv[0] = error_to_jsobject(err, log);
+		argv[1] = NanNull();
+		argv[2] = NanNull();
+		argv[3] = NanNull();
+	}
 
-    // Surround the callback in a try/catch for safety
-    TryCatch try_catch;
+	// Surround the callback in a try/catch for safety
+	TryCatch try_catch;
 
-    // Execute the callback.
+	// Execute the callback.
 	Local<Function> cb = NanNew<Function>(data->callback);
 	NanMakeCallback(NanGetCurrentContext()->Global(), cb, 4, argv);
-    as_v8_debug(log, "Invoked Get callback");
+	as_v8_debug(log, "Invoked Get callback");
 
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
-    }
+	// Process the exception, if any
+	if ( try_catch.HasCaught() ) {
+		node::FatalException(Isolate::GetCurrent(), try_catch);
+	}
 
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
+	// Dispose the Persistent handle so the callback
+	// function can be garbage-collected
 	NanDisposePersistent(data->callback);
 
-    // clean up any memory we allocated
+	// clean up any memory we allocated
 
-    if( data->param_err == 0) { 
-        as_key_destroy(key);
-        as_record_destroy(rec);
+	if( data->param_err == 0) { 
+		as_key_destroy(key);
+		as_record_destroy(rec);
 		if(data->policy != NULL)
 		{
 			cf_free(data->policy);
 		}
-        as_v8_debug(log, "Cleaned up the structures");
-    }
+		as_v8_debug(log, "Cleaned up the structures");
+	}
 
-    delete data;
-    delete req;
+	delete data;
+	delete req;
 
 
 }
@@ -253,5 +253,5 @@ static void respond(uv_work_t * req, int status)
  */
 NAN_METHOD(AerospikeClient::Get)
 {
-    V8_RETURN async_invoke(args, prepare, execute, respond);
+	V8_RETURN async_invoke(args, prepare, execute, respond);
 }

--- a/src/main/client/info.cc
+++ b/src/main/client/info.cc
@@ -353,7 +353,7 @@ static void respond(uv_work_t * req, int status)
 
         // Process the exception, if any
         if ( try_catch.HasCaught() ) {
-            node::FatalException(try_catch);
+            node::FatalException(Isolate::GetCurrent(), try_catch);
         }
     }
 
@@ -367,7 +367,7 @@ static void respond(uv_work_t * req, int status)
 
 	// Process the exception, if any
 	if ( try_catch.HasCaught() ) {
-		node::FatalException(try_catch);
+		node::FatalException(Isolate::GetCurrent(), try_catch);
 	}
 	NanDisposePersistent(data->done);
 

--- a/src/main/client/operate.cc
+++ b/src/main/client/operate.cc
@@ -266,7 +266,7 @@ static void respond(uv_work_t * req, int status)
     as_v8_debug(log, "Invoked operate callback");
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/put.cc
+++ b/src/main/client/put.cc
@@ -245,7 +245,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/query_foreach.cc
+++ b/src/main/client/query_foreach.cc
@@ -578,7 +578,7 @@ static void respond(uv_work_t * req, int status)
 
 	// Process the exception, if any
 	if ( try_catch.HasCaught() ) {
-		node::FatalException(try_catch);
+		node::FatalException(Isolate::GetCurrent(), try_catch);
 	}
 
 	// Dispose the Persistent handle so the callback

--- a/src/main/client/query_info.cc
+++ b/src/main/client/query_info.cc
@@ -183,7 +183,7 @@ static void respond(uv_work_t * req, int status)
 
 	// Process the exception, if any
 	if ( try_catch.HasCaught() ) {
-		node::FatalException(try_catch);
+		node::FatalException(Isolate::GetCurrent(), try_catch);
 	}
 
 	// Dispose the Persistent handle so the callback

--- a/src/main/client/remove.cc
+++ b/src/main/client/remove.cc
@@ -211,7 +211,7 @@ static void respond(uv_work_t * req, int status)
     as_v8_debug(log, "Invoked remove callback");
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/select.cc
+++ b/src/main/client/select.cc
@@ -248,7 +248,7 @@ static void respond(uv_work_t * req, int status)
     as_v8_debug(log, "Invoked Exists callback");
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/sindex_create.cc
+++ b/src/main/client/sindex_create.cc
@@ -277,7 +277,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/sindex_remove.cc
+++ b/src/main/client/sindex_remove.cc
@@ -210,7 +210,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/udf_register.cc
+++ b/src/main/client/udf_register.cc
@@ -321,7 +321,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback

--- a/src/main/client/udf_remove.cc
+++ b/src/main/client/udf_remove.cc
@@ -198,7 +198,7 @@ static void respond(uv_work_t * req, int status)
 
     // Process the exception, if any
     if ( try_catch.HasCaught() ) {
-        node::FatalException(try_catch);
+        node::FatalException(Isolate::GetCurrent(), try_catch);
     }
 
     // Dispose the Persistent handle so the callback


### PR DESCRIPTION
These changes include the following:

- [x] **Upgrade nan version to 1.8.x** (leads to iojs compilation working!)
- [x] **Fix "deprecated FatalException" warning** by adding an isolate to the call
- [ ] **Fix the UDF / Lua call leading to a core dump** ("cannot create a handle without a HandleScope")

I assume that `Isolate::GetCurrent()` is correct as the `isolate` parameter? Correct me if I'm wrong, I really just started getting into V8 development a few minutes ago.

I ran npm test and all tests pass, except for Lua / UDF:

```
eduard@home:~/projects/aerospike-client-nodejs$ npm test

> aerospike@1.0.40 test /home/eduard/projects/aerospike-client-nodejs
> node_modules/mocha/bin/mocha -R spec



  client.batchExists()
    ✓ should successfully find 10 records
    ✓ should fail finding 10 records
    ✓ should successfully find 1000 records (333ms)

  client.batchGet()
    ✓ should successfully read 10 records
    ✓ should fail reading 10 records
    ✓ should successfully read 1000 records (498ms)

  client.batchSelect()
    ✓ should successfully read bins from 10 records
    ✓ should fail reading bins from non-existent records
    ✓ should successfully read bins of 1000 records (689ms)

  client.Execute()
    ✓ should invoke an UDF to without any args
    ✓ should invoke an UDF with arguments
    ✓ should invoke an UDF with apply policy
    ✓ should invoke an UDF function which does not exist - expected to fail

  client.exists()
    ✓ should find the record
    ✓ should not find the record

  client.get()
    ✓ should read the record
    ✓ should not find the record
    ✓ should read the record w/ a key send policy

  client.index()
    ✓ should create an integer index
    ✓ should create an string index
    ✓ should create an integer index with info policy
    ✓ should drop an index

  client.info()
    ✓ should get "objects" from entire cluster

  client.LargeList()
Skipping LDT test cases
    ✓ should add an element of type integer to the LList 
    ✓ should add an element of type string to the LList 
    ✓ should add an element of type bytes to the LList 
    ✓ should add an element of type array to the LList 
    ✓ should add an element of type map to the LList 
    ✓ should add an array of values to LList 
    ✓ should verify that passing wrong number of arguments to add API fails gracefully
    ✓ should update an element in the LList 
    ✓ should update an array of values in the LList 
    ✓ should verify that passing wrong number of arguments to update API fails gracefully
    ✓ should verify the find API of LList -finds an existing element
    ✓ should verify the find API of LList -finds a non-existing element and fails
    ✓ should verify the range API of LList- expected to find existing elements
    ✓ should verify the range API of LList- expected to not find any elements
    ✓ should verify the size API of LList 
    ✓ should verify that size API fails gracefully when passing wrong number of arguments
    ✓ should verify the scan API of LList 
    ✓ should verify the scan API fails gracefully when wrong number of arguments are passed
    ✓ should remove an element from the LList 
    ✓ should remove an array of elements from LList 
    ✓ should verify remove API fails when invalid number of arguments are passed
    ✓ should verify removing a range of values in LList 
    ✓ should verify removeRange API fails when invalid number of arguments are passed

  client.updateLogging()
    ✓ should log the messages to test.log

  client.operate()
    ✓ should increment a bin
    ✓ should append a bin
    ✓ should prepend and read a bin
    ✓ should touch a record(refresh ttl) 
    ✓ should prepend using prepend API and verify the bin
    ✓ should prepend using prepend API and verify the bin with metadata
    ✓ should append a bin using append API and verify the bin
    ✓ should append a bin using append API and verify the bin with metadata
    ✓ should add a value to a bin and verify
    ✓ should add a value to a bin with metadata and verify
    ✓ should add a string value to a bin and expected fail
    ✓ should append a bin of type integer using append API and expected to fail
    ✓ should prepend an integer using prepend API and expect to fail

  client.put()
    ✓ should write and validate 100 records (70ms)
    ✓ should write the record w/ string key
    ✓ should write the record w/ int key
    ✓ should write the record w/ bytes key
    ✓ shoule write an array, map type of bin and read
    ✓ should write an array of map and array, map of array and map, then read
    ✓ should write, read, write, and check gen
    ✓ should write, read, remove, read, write, and check gen
    ✓ should write null for bins with empty list and map
    ✓ should write a bin of type undefined and write should not fail
    ✓ should write a set with empty string and write should pass
    ✓ should write a map with undefined entry and verify the record
    ✓ should write an object with boolean value and should fail
    ✓ should write a key with undefined value and it should fail gracefully
    ✓ should check generation and then update record only if generation is equal (CAS)

  client.query()
    ✓ should query on an integer index - filter by equality of bin value
    ✓ should query on an integer index - filter by range of bin values (74ms)
    ✓ should query on a string index - filter by equality of bin value (69ms)
    ✓ should query on an index and apply aggregation user defined function
    ✓ should scan aerospike database and apply aggregation user defined function

  client.remove()
    ✓ should remove a record w/ string key
    ✓ should remove a record w/ integer key
    ✓ should not remove a non-existent key

  client.query() - without where clause(Scan)
    ✓ should query all the records (38ms)
    ✓ should query and select no bins
    ✓ should query and select only few bins in the record
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
Aborted (core dumped)
npm ERR! Test failed.  See above for more details.
```

Argh! Well, almost. I tried checking why it happened and it seems to be related to the execution of UDF functions. The test that fails is this one:
```node
it('should do a scan background and check for the status of scan job ', function(done) {
	var args = { UDF: {module: 'scan', funcname: 'updateRecord'}}
	var scanBackground = client.query( options.namespace, options.set, args);

	var err = 0;
	var scanStream = scanBackground.execute();

	var infoCallback = function( scanJobStats, scanId) {
		done();
	}   
	scanStream.on('error', function(error) {
		err++;
	}); 
	scanStream.on('end', function(scanId) {
		scanBackground.Info(scanId, infoCallback);
	}); 
}); 
```
The error:
```
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
Aborted (core dumped)
```
I used some Google-fu and it seems we're missing a NanScope() somewhere, in general it expects a scope but there is none. **I don't know how to fix it and I am asking for help solving this problem.** Does anybody have an idea where we need to add a scope? I tried adding a NanScope() in execute() but that seems to generate more errors than it fixes.

The error is generated in the callback call it seems: `scanBackground.Info(scanId, infoCallback);` (if you comment it out you get a timeout instead of a core dump).

Compiling it with node 0.12.4 doesn't generate any errors with the new nan version and UDF tests pass:
```
  client.query() - without where clause(Scan)
    ✓ should query all the records (38ms)
    ✓ should query and select no bins
    ✓ should query and select only few bins in the record
    ✓ should do a scan background and check for the status of scan job 

  client.select()
    ✓ should read the record
    ✓ should fail - when a select is called without key 
    ✓ should not find the record
    ✓ should read the record w/ a key send policy

  client.udfRegister()
    ✓ should register an UDF file to aerospike cluster
    ✓ should register an UDF file with a LUA type to aerospike cluster
    ✓ should register an UDF file with a info policy to aerospike cluster
    ✓ should register an UDF file with a info policy and LUA type to aerospike cluster
    ✓ registering a non-existent UDF file to aerospike cluster - should fail

  client.udfRemove()
    ✓ should remove an UDF module with a info policy from aerospike cluster
    ✓ remove non-existent UDF module from aerospike cluster - should fail


  98 passing (4s)
```

Please excuse me for my inability to properly fix this by myself. But we're almost there.