### PR TITLE
Preventing leakage to global scope + allowing LargeList instances

### DIFF
--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -25,7 +25,7 @@ RecordStream.prototype._read = function() {};
 // to node.js layer.
 // On error, emits 'error' event.
 // When all the results are consumed it emits 'end' event.
-execute = function() {
+var execute = function() {
 
 	var rs = new RecordStream();
 
@@ -76,12 +76,12 @@ execute = function() {
 };
 
 
-Info = function(scanId, callback) {
+var Info = function(scanId, callback) {
 	var self = this;
 	self.queryInfo(scanId, callback);
 };
 
-query = function(ns, set, options) {
+var query = function(ns, set, options) {
 
 
 	if (typeof(set) != "string") {
@@ -111,7 +111,7 @@ query = function(ns, set, options) {
 };
 
 
-createIntegerIndex = function(options, callback) {
+var createIntegerIndex = function(options, callback) {
 	var policy;
 	var set;
 	if (options && options.policy) {
@@ -131,7 +131,7 @@ createIntegerIndex = function(options, callback) {
 	);
 };
 
-createStringIndex = function(options, callback) {
+var createStringIndex = function(options, callback) {
 	var policy;
 	var set;
 	if (options && options.policy) {
@@ -151,7 +151,7 @@ createStringIndex = function(options, callback) {
 	);
 };
 
-createGeo2DSphereIndex = function(options, callback) {
+var createGeo2DSphereIndex = function(options, callback) {
 	var policy;
 	var set;
 	if (options && options.policy) {
@@ -171,7 +171,7 @@ createGeo2DSphereIndex = function(options, callback) {
 	);
 };
 
-parseOperateArgs = function(args) {
+var parseOperateArgs = function(args) {
 	var arglength = args.length;
 
 	var options = {};
@@ -191,7 +191,7 @@ parseOperateArgs = function(args) {
 	return options;
 };
 
-add = function(key, bins, metadata, policy, callback) {
+var add = function(key, bins, metadata, policy, callback) {
 	var options = parseOperateArgs(arguments);
 
 	// populate ops from bins argument here
@@ -204,7 +204,7 @@ add = function(key, bins, metadata, policy, callback) {
 
 };
 
-append = function(key, bins, metadata, policy, callback) {
+var append = function(key, bins, metadata, policy, callback) {
 	var options = parseOperateArgs(arguments);
 
 	// populate ops from bins argument here
@@ -216,7 +216,7 @@ append = function(key, bins, metadata, policy, callback) {
 	this.operate(key, ops, options.metadata, options.policy, options.callback);
 };
 
-prepend = function(key, bins, metadata, policy, callback) {
+var prepend = function(key, bins, metadata, policy, callback) {
 	var options = parseOperateArgs(arguments);
 
 	// populate ops from bins argument here

--- a/lib/llist.js
+++ b/lib/llist.js
@@ -68,20 +68,20 @@ var executeLDTFunction = function(ldtFunc, ldtargs, arglength, udfPosition) {
 };
 
 
-var LargeList = function(key, binName, writePolicy, createModule) {
-
-	LargeList.client = this;
-	LargeList.key = key;
-	LargeList.writePolicy = writePolicy;
-	LargeList.binName = binName;
-	LargeList.module = "llist";
-	LargeList.createModule = createModule;
-	LargeList.executeLDTFunction = executeLDTFunction;
+var LargeList = function (key, binName, writePolicy, createModule) {
+	var instance = {};
+	instance.client = this;
+	instance.key = key;
+	instance.writePolicy = writePolicy;
+	instance.binName = binName;
+	instance.module = "llist";
+	instance.createModule = createModule;
+	instance.executeLDTFunction = executeLDTFunction;
 
 	// Handle all the variations of add function.
 	// 1. val can be a single value
 	// 2. val can be an array of values
-	LargeList.add = function(val, callback) {
+	instance.add = function(val, callback) {
 		if (Array.isArray(arguments[0])) {
 			this.executeLDTFunction("add_all", arguments, 2);
 		} else {
@@ -92,7 +92,7 @@ var LargeList = function(key, binName, writePolicy, createModule) {
 
 	// Handle all the variations of update.
 	// same as add variations
-	LargeList.update = function(val, callback) {
+	instance.update = function(val, callback) {
 		if (Array.isArray(arguments[0])) {
 			this.executeLDTFunction("update_all", arguments, 2);
 		} else {
@@ -103,7 +103,7 @@ var LargeList = function(key, binName, writePolicy, createModule) {
 
 	// Handle all the variations of remove.
 	// Same as add variations and the following
-	LargeList.remove = function(val, callback) {
+	instance.remove = function(val, callback) {
 
 
 		if (Array.isArray(val)) {
@@ -114,12 +114,12 @@ var LargeList = function(key, binName, writePolicy, createModule) {
 	};
 
 	// Can pass a range to remove the values within the range (inclusive).
-	LargeList.removeRange = function(valBegin, valEnd, callback) {
+	instance.removeRange = function(valBegin, valEnd, callback) {
 
 		this.executeLDTFunction("remove_range", arguments, 3);
 	};
 
-	LargeList.find = function(val, filterArgs, callback) {
+	instance.find = function(val, filterArgs, callback) {
 		var arglength = arguments.length;
 
 		if (arglength == 2) {
@@ -133,11 +133,11 @@ var LargeList = function(key, binName, writePolicy, createModule) {
 	};
 
 	// apply filter - pass all elements through a filter and return all that qualify.
-	LargeList.filter = function(filterArgs, callback) {
+	instance.filter = function(filterArgs, callback) {
 		this.executeLDTFunction("filter", arguments, 1, 0);
 	};
 
-	LargeList.findRange = function(valBegin, valEnd, filterArgs, callback) {
+	instance.findRange = function(valBegin, valEnd, filterArgs, callback) {
 		var arglength = arguments.length;
 
 		if (arglength == 3) {
@@ -149,22 +149,23 @@ var LargeList = function(key, binName, writePolicy, createModule) {
 		}
 	};
 
-	LargeList.scan = function(callback) {
+	instance.scan = function(callback) {
 		this.executeLDTFunction("scan", arguments, 1);
 	};
 
-	LargeList.destroy = function(callback) {
+	instance.destroy = function(callback) {
 		this.executeLDTFunction("destroy", arguments, 1);
 	};
 
-	LargeList.size = function(callback) {
+	instance.size = function(callback) {
 		this.executeLDTFunction("size", arguments, 1);
 	};
 
-	LargeList.getConfig = function(callback) {
+	instance.getConfig = function(callback) {
 		this.executeLDTFunction("config", arguments, 1);
 	};
-	return LargeList;
+
+	return instance;
 };
 
 module.exports = LargeList;

--- a/lib/llist.js
+++ b/lib/llist.js
@@ -68,7 +68,7 @@ var executeLDTFunction = function(ldtFunc, ldtargs, arglength, udfPosition) {
 };
 
 
-LargeList = function(key, binName, writePolicy, createModule) {
+var LargeList = function(key, binName, writePolicy, createModule) {
 
 	LargeList.client = this;
 	LargeList.key = key;


### PR DESCRIPTION
##### Change 1:
top level explicit variable declarations are missing and strict mode is not enabled.
variables are leaking passively to global scope which can cause collision with other libraries and user modules.

strict mode should also be enabled in my opinion.

list of restrained variables: `LargeList, execute, Info,query, createIntegerIndex, createStringIndex, createGeo2DSphereIndex, parseOperateArgs, add, append, prepend ,`

##### Change 2:
Allowing instances in LargeLists.

in the current formation this is not possible:
``` javascript
var list1 = client.LargeList({ns: 'test', set: 'test', key: 'my_key1'}, 'ldt_bin');
var list2 = client.LargeList({ns: 'test', set: 'test', key: 'my_key2'}, 'ldt_bin');
```
Because LargeList stores arguments on itself (shared among all calls).
Generally speaking this is an anti pattern.
``` javascript
var LargeList = function (key, binName, writePolicy, createModule) {
    LargeList.key = key;
    return LargeList
}
```

Offered change:
``` javascript
var LargeList = function (key, binName, writePolicy, createModule) {
    var instance = {};
    instance.key = key;
    return instance
}
```
this will also encourage users to reuse object.
The structure is still wasteful because all methods are attached to each instance instead of using prototype or other method sharing techniques.

