### PR TITLE
connection string functionality

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,12 +47,32 @@ and sent to server in same format.  Leave empty for clusters running without res
 
 ### `hosts` attribute
 
-The `hosts` attribute should contain an Array of hosts with which the client should attempt to connect. On `client.connect()`, the client iterates through the list of hosts until it successfully connects with one.
+The `hosts` attribute should contain an Array or a connection string of hosts with which the client should attempt to connect. On `client.connect()`, the client iterates through the list of hosts until it successfully connects with one.
 
 Each entry in the list is a Object containing the following attributes:
 
 - `addr` - The IP address or domain name of the host.
 - `port` - The listening port of the host. If not specified, the default is 3000.
+
+###### using array
+```javascript
+  var config = {
+    hosts: [
+      { addr: '192.168.0.1', port: 3000 },
+      { addr: '192.168.0.2', port: 3000 }
+    ]
+  }
+```
+
+###### using connection string
+```javascript
+  var config = {
+    hosts: 'aerospike://192.168.0.1:3000,192.168.0.2'
+ // hosts: 'as://node1,node2'
+ // hosts: '192.168.0.1,node1:3030'
+ // hosts: process.env.AEROSPIKE_HOSTS || 'localhost'
+  }
+```
 
 ### `policies` attribute
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,30 +47,31 @@ and sent to server in same format.  Leave empty for clusters running without res
 
 ### `hosts` attribute
 
-The `hosts` attribute should contain an Array or a connection string of hosts with which the client should attempt to connect. On `client.connect()`, the client iterates through the list of hosts until it successfully connects with one.
+The `hosts` attribute should contain a list of hosts with which the client should attempt to connect. On `client.connect()`, the client iterates through the list of hosts until it successfully connects with one.
 
+If the hosts attribute is not specified, environment variable `AEROSPIKE_HOSTS` would be searched for string formatted hosts.
+The default value is `localhost:3000`.
+
+###### using Array
 Each entry in the list is a Object containing the following attributes:
 
 - `addr` - The IP address or domain name of the host.
 - `port` - The listening port of the host. If not specified, the default is 3000.
 
-###### using array
 ```javascript
   var config = {
     hosts: [
       { addr: '192.168.0.1', port: 3000 },
-      { addr: '192.168.0.2', port: 3000 }
+      { addr: '192.168.0.2' }
     ]
   }
 ```
 
-###### using connection string
+###### using String
 ```javascript
   var config = {
-    hosts: 'aerospike://192.168.0.1:3000,192.168.0.2'
- // hosts: 'as://node1,node2'
- // hosts: '192.168.0.1,node1:3030'
- // hosts: process.env.AEROSPIKE_HOSTS || 'localhost'
+    hosts: '192.168.0.1:3000,192.168.0.2'
+ // hosts: 'node1,node2:3030'
   }
 ```
 

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -249,7 +249,11 @@ var aerospike = {
 }
 
 aerospike.client = function client (config) {
-  if (config && typeof config.hosts == 'string') {
+  config = config || {}
+  
+  config.hosts = config.hosts || process.env.AEROSPIKE_HOSTS || "localhost"
+  
+  if (typeof config.hosts == 'string') {
     config.hosts = parseHostsString(config.hosts);
   }
   
@@ -484,18 +488,17 @@ function GeoJSON (strval) {
 aerospike.GeoJSON = GeoJSON
 
 function parseHostsString(str) {
-    if (!str || !/^((aerospike|as):\/\/)?(,?[a-z0-9-_\.]+(?::\d+(?:,|\/|$))?)+\/?$/i.test(str)) {
+    if (!str || !/^([a-z0-9-_\.]+(:\d+)?,?)+$/.test(str)) {
         throw new Error("Invalid aerospike connection string: " + str);
     }
 
     return str
-            .replace(/^(aerospike|as):\/\//, '')
-            .replace(/\/$/, '')
             .split(',')
+            .filter(function (x) {return !!x})
             .map(function (server) {
                 var temp = server.split(':');
                 return {
-                    addr: temp[0] || '127.0.0.1',
+                    addr: temp[0] || 'localhost',
                     port: parseInt(temp[1]) || 3000
                 }
             });

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -249,6 +249,10 @@ var aerospike = {
 }
 
 aerospike.client = function client (config) {
+  if (config && typeof config.hosts == 'string') {
+    config.hosts = parseHostsString(config.hosts);
+  }
+  
   var client = as.client(config)
   if (client === null) {
     throw new Error('Client object creation failed - null value returned')
@@ -478,5 +482,23 @@ function GeoJSON (strval) {
   }
 }
 aerospike.GeoJSON = GeoJSON
+
+function parseHostsString(str) {
+    if (!str || !/^((aerospike|as):\/\/)?(,?[a-z0-9-_\.]+(?::\d+(?:,|\/|$))?)+\/?$/i.test(str)) {
+        throw new Error("Invalid aerospike connection string: " + str);
+    }
+
+    return str
+            .replace(/^(aerospike|as):\/\//, '')
+            .replace(/\/$/, '')
+            .split(',')
+            .map(function (server) {
+                var temp = server.split(':');
+                return {
+                    addr: temp[0] || '127.0.0.1',
+                    port: parseInt(temp[1]) || 3000
+                }
+            });
+}
 
 module.exports = aerospike

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -250,13 +250,13 @@ var aerospike = {
 
 aerospike.client = function client (config) {
   config = config || {}
-  
-  config.hosts = config.hosts || process.env.AEROSPIKE_HOSTS || "localhost"
-  
-  if (typeof config.hosts == 'string') {
-    config.hosts = parseHostsString(config.hosts);
+
+  config.hosts = config.hosts || process.env.AEROSPIKE_HOSTS || 'localhost'
+
+  if (typeof config.hosts === 'string') {
+    config.hosts = parseHostsString(config.hosts)
   }
-  
+
   var client = as.client(config)
   if (client === null) {
     throw new Error('Client object creation failed - null value returned')
@@ -487,21 +487,21 @@ function GeoJSON (strval) {
 }
 aerospike.GeoJSON = GeoJSON
 
-function parseHostsString(str) {
-    if (!str || !/^([a-z0-9-_\.]+(:\d+)?,?)+$/i.test(str)) {
-        throw new Error("Invalid aerospike connection string: " + str);
-    }
+function parseHostsString (str) {
+  if (!str || !/^([a-z0-9-_\.]+(:\d+)?,?)+$/i.test(str)) {
+    throw new Error('Invalid aerospike connection string: ' + str)
+  }
 
-    return str
-            .split(',')
-            .filter(function (x) {return !!x})
-            .map(function (host) {
-                var temp = host.split(':');
-                return {
-                    addr: temp[0] || 'localhost',
-                    port: parseInt(temp[1]) || 3000
-                }
-            });
+  return str
+      .split(',')
+      .filter(function (x) { return !!x })
+      .map(function (host) {
+        var temp = host.split(':')
+        return {
+          addr: temp[0] || 'localhost',
+          port: parseInt(temp[1], 10) || 3000
+        }
+      })
 }
 
 module.exports = aerospike

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -488,15 +488,15 @@ function GeoJSON (strval) {
 aerospike.GeoJSON = GeoJSON
 
 function parseHostsString(str) {
-    if (!str || !/^([a-z0-9-_\.]+(:\d+)?,?)+$/.test(str)) {
+    if (!str || !/^([a-z0-9-_\.]+(:\d+)?,?)+$/i.test(str)) {
         throw new Error("Invalid aerospike connection string: " + str);
     }
 
     return str
             .split(',')
             .filter(function (x) {return !!x})
-            .map(function (server) {
-                var temp = server.split(':');
+            .map(function (host) {
+                var temp = host.split(':');
                 return {
                     addr: temp[0] || 'localhost',
                     port: parseInt(temp[1]) || 3000


### PR DESCRIPTION
add support for connection string in common formats

```javascript

var config = {
    hosts: 'aerospike://192.168.0.1:3000,192.168.0.2'
 // hosts: 'as://node1,node2'
 // hosts: '192.168.0.1,node1:3030'
 // hosts: process.env.AEROSPIKE_HOSTS || 'localhost'
  }
```