### PR TITLE
Test latest stable + show travis badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 'stable'
+- 'node'
 - '4.2'
 - '0.12'
 - '0.10'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+[![Build Status](https://travis-ci.org/aerospike/aerospike-client-nodejs.svg?branch=master)](https://travis-ci.org/aerospike/aerospike-client-nodejs)
 
 # Aerospike Node.js Client
 


### PR DESCRIPTION
`stable` alias has been deprecated. 

From nvm documentation:
>  - `stable`: this alias is deprecated, and only truly applies to `node` `v0.12` and earlier. Currently, this is an alias for `node`.



