### PR TITLE
Ensure all callbacks are done asynchronously

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -163,14 +163,7 @@ Client.prototype.batchExists = function (keys, policy, callback) {
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.batchExists(keys, policy, function batchExistsCb (err, results) {
-    self.callbackHandler(callback, err, results)
-  })
+  this.sendCommand('batchExists', [keys, policy], callback)
 }
 
 /**
@@ -217,14 +210,7 @@ Client.prototype.batchGet = function (keys, policy, callback) {
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.batchGet(keys, policy, function batchGetCb (err, results) {
-    self.callbackHandler(callback, err, results)
-  })
+  this.sendCommand('batchGet', [keys, policy], callback)
 }
 
 /**
@@ -272,17 +258,8 @@ Client.prototype.batchRead = function (records, policy, callback) {
   if (typeof policy === 'function') {
     callback = policy
     policy = null
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.batchRead(records, policy, function batchReadCb (err, results) {
-    self.callbackHandler(callback, err, results)
-  })
+  this.sendCommand('batchRead', [records, policy], callback)
 }
 
 /**
@@ -331,14 +308,7 @@ Client.prototype.batchSelect = function (keys, bins, policy, callback) {
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.batchSelect(keys, bins, policy, function batchSelectCb (err, results) {
-    self.callbackHandler(callback, err, results)
-  })
+  this.sendCommand('batchSelect', [keys, bins, policy], callback)
 }
 
 /**
@@ -530,26 +500,20 @@ Client.prototype.createIndex = function (options, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  policy = policy || options.policy
-  options.type = options.type || as.indexType.DEFAULT
-  this.as_client.indexCreate(
+  var args = [
     options.ns,
     options.set,
     options.bin,
     options.index,
-    options.type,
+    options.type || as.indexType.DEFAULT,
     options.datatype,
-    policy,
-    function createIndexCb (err) {
-      var job = new IndexJob(self, options.ns, options.index)
-      self.callbackHandler(callback, err, job)
-    }
-  )
+    policy || options.policy
+  ]
+  var self = this
+  this.sendCommand('indexCreate', args, function (err) {
+    var job = new IndexJob(self, options.ns, options.index)
+    callback(err, job)
+  })
 }
 
 /**
@@ -737,13 +701,8 @@ Client.prototype.apply = function (key, udfArgs, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.applyAsync(key, udfArgs, policy, function applyCb (err, result) {
-    self.callbackHandler(callback, err, result, key)
+  this.sendCommand('applyAsync', [key, udfArgs, policy], function (err, result) {
+    callback(err, result, key)
   })
 }
 
@@ -793,13 +752,8 @@ Client.prototype.exists = function exists (key, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.existsAsync(key, policy, function existsCb (err, metadata) {
-    self.callbackHandler(callback, err, metadata, key)
+  this.sendCommand('existsAsync', [key, policy], function (err, metadata) {
+    callback(err, metadata, key)
   })
 }
 
@@ -831,13 +785,8 @@ Client.prototype.get = function (key, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.getAsync(key, policy, function getCb (err, record, metadata) {
-    self.callbackHandler(callback, err, record, metadata, key)
+  this.sendCommand('getAsync', [key, policy], function (err, record, metadata) {
+    callback(err, record, metadata, key)
   })
 }
 
@@ -894,14 +843,7 @@ Client.prototype.indexRemove = function (namespace, index, policy, callback) {
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.indexRemove(namespace, index, policy, function indexRemoveCb (err) {
-    self.callbackHandler(callback, err)
-  })
+  this.sendCommand('indexRemove', [namespace, index, policy], callback)
 }
 
 /**
@@ -1048,16 +990,7 @@ Client.prototype.infoAny = function (request, policy, callback) {
     callback = policy
     policy = null
   }
-
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-
-  var self = this
-  this.as_client.info(request, null, policy, function infoCb (err, response) {
-    self.callbackHandler(callback, err, response)
-  })
+  this.sendCommand('info', [request, null, policy], callback)
 }
 
 /**
@@ -1182,13 +1115,8 @@ Client.prototype.operate = function (key, operations, metadata, policy, callback
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.operateAsync(key, operations, metadata, policy, function operateCb (err, record, metadata) {
-    self.callbackHandler(callback, err, record, metadata, key)
+  this.sendCommand('operateAsync', [key, operations, metadata, policy], function (err, record, metadata) {
+    callback(err, record, metadata, key)
   })
 }
 
@@ -1253,14 +1181,7 @@ Client.prototype.operate = function (key, operations, metadata, policy, callback
     var ops = Object.keys(bins).map(function (bin) {
       return operations[op](bin, bins[bin])
     })
-    if (!this.isConnected(false)) {
-      this.sendError(callback, 'Not connected.')
-      return
-    }
-    var self = this
-    this.operate(key, ops, metadata, policy, function (err, record, metadata, key) {
-      self.callbackHandler(callback, err, record, metadata, key)
-    })
+    this.operate(key, ops, metadata, policy, callback)
   }
 })
 
@@ -1327,13 +1248,8 @@ Client.prototype.put = function (key, record, metadata, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.putAsync(key, record, metadata, policy, function putCb (err) {
-    self.callbackHandler(callback, err, key)
+  this.sendCommand('putAsync', [key, record, metadata, policy], function (err) {
+    callback(err, key)
   })
 }
 
@@ -1395,13 +1311,8 @@ Client.prototype.remove = function (key, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.removeAsync(key, policy, function removeCb (err) {
-    self.callbackHandler(callback, err, key)
+  this.sendCommand('removeAsync', [key, policy], function (err) {
+    callback(err, key)
   })
 }
 
@@ -1457,14 +1368,37 @@ Client.prototype.select = function (key, bins, policy, callback) {
   } else if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function')
   }
+  this.sendCommand('selectAsync', [key, bins, policy], function (err, record, metadata) {
+    callback(err, record, metadata, key)
+  })
+}
+
+/** @private */
+Client.prototype.sendCommand = function (cmd, args, callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('"callback" argument must be a function')
+  }
   if (!this.isConnected(false)) {
     this.sendError(callback, 'Not connected.')
     return
   }
+
+  // C client will call the callback function synchronously under certain error
+  // conditions; if we detect a synchronous callback we need to schedule the JS
+  // callback to be called asynchronously anyway.
+  var sync = true
   var self = this
-  this.as_client.selectAsync(key, bins, policy, function selectCb (err, record, metadata) {
-    self.callbackHandler(callback, err, record, metadata, key)
+  args.push(function (err, arg1, arg2, arg3) {
+    if (sync) {
+      // TODO: replace with process.nextTick once we drop support for Node.js v0.12
+      setImmediate(self.callbackHandler, callback, err, arg1, arg2, arg3)
+    } else {
+      return self.callbackHandler(callback, err, arg1, arg2, arg3)
+    }
   })
+
+  this.as_client[cmd].apply(this.as_client, args)
+  sync = false // if we get here before the cb was called the cb is async
 }
 
 /** @private */
@@ -1475,7 +1409,7 @@ Client.prototype.sendError = function (callback, error) {
   error.code = error.code || as.status.AEROSPIKE_ERR_CLIENT
   error.message = error.message || 'Client Error'
   var self = this
-  process.nextTick(function nextTickCb () {
+  process.nextTick(function () {
     self.callbackHandler(callback, error)
   })
 }
@@ -1512,17 +1446,8 @@ Client.prototype.truncate = function (ns, set, beforeNanos, policy, callback) {
   } else if (typeof policy === 'function') {
     callback = policy
     policy = null
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function')
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.truncate(ns, set, beforeNanos, policy, function truncateCb (err) {
-    self.callbackHandler(callback, err)
-  })
+  this.sendCommand('truncate', [ns, set, beforeNanos, policy], callback)
 }
 
 /**
@@ -1560,14 +1485,7 @@ Client.prototype.udfRegister = function (path, udfType, policy, callback) {
     policy = udfType
     udfType = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.udfRegister(path, udfType, policy, function udfRegisterCb (err) {
-    self.callbackHandler(callback, err)
-  })
+  this.sendCommand('udfRegister', [path, udfType, policy], callback)
 }
 
 /**
@@ -1618,14 +1536,7 @@ Client.prototype.udfRegisterWait = function (udfModule, pollInterval, policy, ca
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.udfRegisterWait(udfModule, pollInterval, policy, function udfRegisterWaitCb (err) {
-    self.callbackHandler(callback, err)
-  })
+  this.sendCommand('udfRegisterWait', [udfModule, pollInterval, policy], callback)
 }
 
 /**
@@ -1652,14 +1563,7 @@ Client.prototype.udfRemove = function (udfModule, policy, callback) {
     callback = policy
     policy = null
   }
-  if (!this.isConnected(false)) {
-    this.sendError(callback, 'Not connected.')
-    return
-  }
-  var self = this
-  this.as_client.udfRemove(udfModule, policy, function udfRemoveCb (err) {
-    self.callbackHandler(callback, err)
-  })
+  this.sendCommand('udfRemove', [udfModule, policy], callback)
 }
 
 Client.prototype.updateLogging = function (logConfig) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -125,10 +125,7 @@ Job.prototype.info = function (policy, callback) {
     callback = policy
     policy = null
   }
-  var client = this.client
-  client.as_client.jobInfo(this.jobID, this.module, policy, function jobInfoCb (err, info) {
-    client.callbackHandler(callback, err, info)
-  })
+  this.client.sendCommand('jobInfo', [this.jobID, this.module, policy], callback)
 }
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -14,7 +14,6 @@
 // limitations under the License.
 // *****************************************************************************
 
-const as = require('../build/Release/aerospike.node')
 const Job = require('./job')
 const Key = require('./key')
 const RecordStream = require('./record_stream')
@@ -308,10 +307,9 @@ Query.prototype.foreach = function (policy, dataCb, errorCb, endCb) {
   if (dataCb) stream.on('data', dataCb)
   if (errorCb) stream.on('error', errorCb)
   if (endCb) stream.on('end', endCb)
-  var asClient = this.client.as_client
-  var queryFn = this.udf ? asClient.queryForeach : asClient.queryAsync
-  queryFn.call(asClient, this.ns, this.set, this, policy, function (error, record, meta, key) {
-    if (error && error.code !== as.status.AEROSPIKE_OK) {
+  var cmd = this.udf ? 'queryForeach' : 'queryAsync'
+  var queryCb = function (error, record, meta, key) {
+    if (error) {
       stream.emit('error', error)
     } else if (record === null) {
       stream.emit('end')
@@ -322,7 +320,8 @@ Query.prototype.foreach = function (policy, dataCb, errorCb, endCb) {
       stream.emit('data', record, meta, key)
     }
     return !stream.aborted
-  })
+  }
+  this.client.sendCommand(cmd, [this.ns, this.set, this, policy], queryCb)
   return stream
 }
 
@@ -348,18 +347,13 @@ Query.prototype.apply = function (udfModule, udfFunction, udfArgs, policy, callb
   } else if (typeof udfArgs === 'function') {
     callback = udfArgs
     udfArgs = null
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function')
   }
   this.udf = {
     module: udfModule,
     funcname: udfFunction,
     args: udfArgs
   }
-  var client = this.client
-  client.as_client.queryApply(this.ns, this.set, this, policy, function (error, result) {
-    client.callbackHandler(callback, error, result)
-  })
+  this.client.sendCommand('queryApply', [this.ns, this.set, this, policy], callback)
 }
 
 /**
@@ -390,8 +384,6 @@ Query.prototype.background = function (udfModule, udfFunction, udfArgs, policy, 
   } else if (typeof queryID === 'function') {
     callback = queryID
     queryID = null
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function')
   }
   this.udf = {
     module: udfModule,
@@ -400,10 +392,10 @@ Query.prototype.background = function (udfModule, udfFunction, udfArgs, policy, 
   }
   queryID = queryID || Job.safeRandomJobID()
   var self = this
-  this.client.as_client.queryBackground(this.ns, this.set, this, policy, queryID, function queryBackgroundCb (err) {
+  this.client.sendCommand('queryBackground', [this.ns, this.set, this, policy, queryID], function (err) {
     var module = self.filters.length > 0 ? 'query' : 'scan'
     var job = new Job(self.client, queryID, module)
-    self.client.callbackHandler(callback, err, job)
+    callback(err, job)
   })
 }
 

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -14,7 +14,6 @@
 // limitations under the License.
 // *****************************************************************************
 
-const as = require('../build/Release/aerospike.node')
 const Job = require('./job')
 const Key = require('./key')
 const RecordStream = require('./record_stream')
@@ -216,10 +215,10 @@ Scan.prototype.background = function (udfModule, udfFunction, udfArgs, policy, s
     args: udfArgs
   }
   scanID = scanID || Job.safeRandomJobID()
-  var client = this.client
-  client.as_client.scanBackground(this.ns, this.set, this, policy, scanID, function scanBackgroundCb (err) {
-    var job = new Job(client, scanID, 'scan')
-    client.callbackHandler(callback, err, job)
+  var self = this
+  this.client.sendCommand('scanBackground', [this.ns, this.set, this, policy, scanID], function (err) {
+    var job = new Job(self.client, scanID, 'scan')
+    callback(err, job)
   })
 }
 
@@ -241,17 +240,20 @@ Scan.prototype.foreach = function (policy, dataCb, errorCb, endCb) {
   if (errorCb) stream.on('error', errorCb)
   if (endCb) stream.on('end', endCb)
   var scanID = Job.safeRandomJobID()
-  this.client.as_client.scanAsync(this.ns, this.set, this, policy, scanID, function (error, record, meta, key) {
-    if (error && error.code !== as.status.AEROSPIKE_OK) {
+  var scanCb = function (error, record, meta, key) {
+    if (error) {
       stream.emit('error', error)
     } else if (record === null) {
       stream.emit('end')
     } else {
-      key = new Key(key.ns, key.set, key.key, key.digest)
+      if (key) {
+        key = new Key(key.ns, key.set, key.key, key.digest)
+      }
       stream.emit('data', record, meta, key)
     }
     return !stream.aborted
-  })
+  }
+  this.client.sendCommand('scanAsync', [this.ns, this.set, this, policy, scanID], scanCb)
   stream.job = new Job(this.client, scanID, 'scan')
   return stream
 }


### PR DESCRIPTION
Fixes #146 

* [x] Wrap all callbacks for single-key and batch commands with `process.nextTick` if necessary to ensure cb happens asynchronously
* [x] Ensure query/scan processing starts asynchronously so that the application has a chance to register data/error/end handlers on the record stream