### PR TITLE
Capture better stacktraces

### DIFF
--- a/lib/aerospike_error.js
+++ b/lib/aerospike_error.js
@@ -49,7 +49,7 @@ const util = require('util')
  *   client.close()
  * })
  */
-function AerospikeError (code, message, func, file, line) {
+function AerospikeError (code, message, func, file, line, stack) {
   /**
    * Error name
    *
@@ -57,7 +57,7 @@ function AerospikeError (code, message, func, file, line) {
    * @type {string}
    * @readonly
    */
-  this.name = 'AerospikeError'
+  Object.defineProperty(this, 'name', {value: 'AerospikeError'})
 
   /**
    * Error message
@@ -106,11 +106,16 @@ function AerospikeError (code, message, func, file, line) {
    */
   this.line = line
 
-  Error.captureStackTrace(this, this.constructor)
+  if (stack) {
+    stack = stack.replace(/^.*$/m, util.format('%s: %s', this.name, this.message))
+    Object.defineProperty(this, 'stack', {value: stack})
+  } else {
+    Error.captureStackTrace(this, this.constructor)
+  }
 }
 
 AerospikeError.fromASError = function (err) {
-  return new AerospikeError(err.code, err.message, err.func, err.file, err.line)
+  return new AerospikeError(err.code, err.message, err.func, err.file, err.line, err.stack)
 }
 
 util.inherits(AerospikeError, Error)

--- a/lib/client.js
+++ b/lib/client.js
@@ -58,6 +58,9 @@ function Client (config) {
 
   /** @private */
   this.connected = false
+
+  /** @private */
+  this.captureStackTraces = !!process.env.AEROSPIKE_DEBUG_STACKTRACES
 }
 
 // The callback functions for the client commands take a variable number of
@@ -1387,8 +1390,17 @@ Client.prototype.sendCommand = function (cmd, args, callback) {
   // conditions; if we detect a synchronous callback we need to schedule the JS
   // callback to be called asynchronously anyway.
   var sync = true
+
+  var cmdStackTrace = null
+  if (this.captureStackTraces) {
+    cmdStackTrace = new AerospikeError().stack
+  }
+
   var self = this
   args.push(function (err, arg1, arg2, arg3) {
+    if (err && cmdStackTrace) {
+      err.stack = cmdStackTrace
+    }
     if (sync) {
       // TODO: replace with process.nextTick once we drop support for Node.js v0.12
       setImmediate(self.callbackHandler, callback, err, arg1, arg2, arg3)
@@ -1408,6 +1420,7 @@ Client.prototype.sendError = function (callback, error) {
   }
   error.code = error.code || as.status.AEROSPIKE_ERR_CLIENT
   error.message = error.message || 'Client Error'
+  Error.captureStackTrace(error)
   var self = this
   process.nextTick(function () {
     self.callbackHandler(callback, error)

--- a/test/client.js
+++ b/test/client.js
@@ -132,4 +132,18 @@ describe('Client', function () {
       })
     })
   })
+
+  describe('Client#captureStackTraces', function () {
+    it('should capture stack traces that show the command being called', function (done) {
+      var client = helper.client
+      var key = keygen.string(helper.namespace, helper.set)()
+      var orig = client.captureStackTraces
+      client.captureStackTraces = true
+      client.get(key, function (err) {
+        expect(err.stack).to.match(/Client.get/)
+        client.captureStackTraces = orig
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Resolves #189 

Adds a `captureStackTraces` setting to the client, which, when set to `true`, causes the client to capture the stack trace before any client command is being executed. If an error occurs during command execution, the stack trace will be set in the `AerospikeError` instance returned in the callback.

Capturing a stack trace for every client command is quite expensive, so this option should only be enabled temporarily for debugging purposes.

This setting can be enabled for all new client instances by setting the `AEROSPIKE_DEBUG_STACKTRACES` environment variable to any non-empty value.

Example of a typical stack trace with `captureStackTraces` _disabled_:

```
{ AerospikeError: AEROSPIKE_ERR_RECORD_NOT_FOUND
    at Function.AerospikeError.fromASError (/Users/jhecking/aerospike/aerospike-client-nodejs/lib/aerospike_error.js:118:10)
    at Client.DefaultCallbackHandler [as callbackHandler] (/Users/jhecking/aerospike/aerospike-client-nodejs/lib/client.js:74:72)
    at /Users/jhecking/aerospike/aerospike-client-nodejs/lib/client.js:1408:19
  message: 'AEROSPIKE_ERR_RECORD_NOT_FOUND',
  code: 2,
  func: 'as_event_command_parse_result',
  file: 'src/main/aerospike/as_event.c',
  line: 598 }
```

Same stack trace with `captureStackTraces` _enabled_:

```
{ AerospikeError: AEROSPIKE_ERR_RECORD_NOT_FOUND
    at Client.sendCommand (/Users/jhecking/aerospike/aerospike-client-nodejs/lib/client.js:1396:21)
    at Client.get (/Users/jhecking/aerospike/aerospike-client-nodejs/lib/client.js:791:8)
    at Context.<anonymous> (/Users/jhecking/aerospike/aerospike-client-nodejs/test/client.js:142:14)
    at callFnAsync (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runnable.js:368:21)
    at Test.Runnable.run (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runnable.js:318:7)
    at Runner.runTest (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:444:10)
    at /Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:550:12
    at next (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:361:14)
    at /Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:371:7
    at next (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:295:14)
    at Immediate.<anonymous> (/Users/jhecking/.nvm/versions/node/v7.9.0/lib/node_modules/mocha/lib/runner.js:339:5)
    at runCallback (timers.js:672:20)
    at tryOnImmediate (timers.js:645:5)
    at processImmediate [as _immediateCallback] (timers.js:617:5)
  message: 'AEROSPIKE_ERR_RECORD_NOT_FOUND',
  code: 2,
  func: 'as_event_command_parse_result',
  file: 'src/main/aerospike/as_event.c',
  line: 598 }
```