### PR TITLE
Expose new consistency level in batch policy

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1640,7 +1640,8 @@ Client.prototype.updateLogging = function (logConfig) {
  * @property {number} timeout - Maximum time in milliseconds to wait for the operation to complete.
  * @property {number} key - Specifies the behavior for the key.
  * @property {number} replica - Specifies the replica to be consulted for the read.
- * @property {number} concistencyLevel - Specifies the number of replicas consulted when reading for the desired consistency guarantee.
+ * @property {number} [consistencyLevel=Aerospike.policy.consistencyLevel.ONE] - Specifies
+ * the number of replicas consulted when reading for the desired consistency guarantee.
  *
  * @see {@link module:aerospike.policy} for supported policy values.
  */
@@ -1690,6 +1691,14 @@ Client.prototype.updateLogging = function (logConfig) {
  * A policy affecting the behavior of batch operations.
  *
  * @property {number} timeout - Maximum time in milliseconds to wait for the operation to complete.
+ * @property {number} [consistencyLevel=Aerospike.policy.consistencyLevel.ONE] - Specifies
+ * the number of replicas consulted when reading for the desired consistency guarantee.
+ * @property {boolean} [allowInline=true] - Allow batch to be processed immediately in
+ * the server's receiving thread when the server deems it to be appropriate. If
+ * false, the batch will always be processed in separate transaction threads.
+ * @property {boolean} [sendSetName=false] - Send set name field to server for
+ * every key in the batch. This is only necessary when authentication is
+ * enabled and security roles are defined on a per-set basis.
  */
 
 /**
@@ -1701,7 +1710,8 @@ Client.prototype.updateLogging = function (logConfig) {
  * @property {number} key - Specifies the behavior for the key.
  * @property {number} gen - Specifies the behavior for the generation value.
  * @property {number} replica - Specifies the replica to be consulted for the read.
- * @property {number} concistencyLevel - Specifies the number of replicas consulted when reading for the desired consistency guarantee.
+ * @property {number} [consistencyLevel=Aerospike.policy.consistencyLevel.ONE] - Specifies
+ * the number of replicas consulted when reading for the desired consistency guarantee.
  * @property {number} commitLevel - Specifies the number of replicas required
  * to be committed successfully when writing before returning transaction succeeded.
  * @property {boolean} [durableDelete=false] - Specifies whether a {@link

--- a/src/main/policy.cc
+++ b/src/main/policy.cc
@@ -109,6 +109,15 @@ int batchpolicy_from_jsobject(as_policy_batch* policy, Local<Object> obj, const 
 	if ((rc = get_optional_uint32_property(&policy->timeout, NULL, obj, "timeout", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
+	if ((rc = get_optional_uint32_property((uint32_t*) &policy->consistency_level, NULL, obj, "consistencyLevel", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
+	if ((rc = get_optional_bool_property(&policy->allow_inline, NULL, obj, "allowInline", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
+	if ((rc = get_optional_bool_property(&policy->send_set_name, NULL, obj, "sendSetName", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
 	as_v8_detail(log, "Parsing batch policy: success");
 	return AS_NODE_PARAM_OK;
 }


### PR DESCRIPTION
Adds the following properties for batch policy:
* `consistencyLevel` (new in C client v4.1.6)
* `allowInline`
* `sendSetName`