### PR TITLE
Support Node.js v8 and Update document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - 'node'
+- '8'
 - '6'
 - '4'
 env:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An Aerospike add-on module for Node.js.
 
-This module is compatible with Node.js v4.x (LTS), v6.x (LTS) and v7.x. It
+This module is compatible with Node.js v4.x (LTS), v6.x (LTS) and v8.x (LTS). It
 supports the following operating systems: CentOS/RHEL 6/7, Debian 7/8,
 Ubuntu 12.04/14.04/16.04, as well as many Linux destributions compatible with
 one of these OS releases and macOS.
@@ -99,14 +99,14 @@ Details about the API are available in the [`docs`](docs) directory.
 <a name="Prerequisites"></a>
 ## Prerequisites
 
-The aerospike package supports Node.js v0.12.x, v4.2.x (LTS) and v5.x as well
+The aerospike package supports Node.js v4.x (LTS), v6.x (LTS) and v8.x (LTS) as well
 as io.js. To download and install the latest stable version of Node.js, visit
 [nodejs.org](http://nodejs.org/) or use the version that comes bundled with
 your operating system.
 
 The Aerospike package includes a native addon. `gcc`/`g++` v4.8 or newer or
 `clang`/`clang++` v3.4 or newer are required to build the addon with Node.js
-v4.x/v5.x.
+v4.x/v6.x/8.x.
 
 The Aerospike addon depends on the Aerospike C client library, which gets
 downloaded during package installation. Either the cURL or Wget command line tool

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "main": "lib/aerospike",
   "engines": {
-    "node": ">=0.12"
+    "node": ">= 4.x"
   },
   "os": [
     "linux",


### PR DESCRIPTION
- Add Node.js v8 to Travis CI
- Update engines of package.json based on CI result
- Update document based on CI result