### PR TITLE
Implement cluster event callbacks

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,7 @@ Head
 * **New Features**
   * Client emits cluster state changed events [#206](https://github.com/aerospike/aerospike-client-nodejs/issues/206)
 * **Updates**
-  * Update C client library to [v4.1.7](http://www.aerospike.com/download/client/c/notes.html#4.1.7).
+  * Update C client library to [v4.1.8](http://www.aerospike.com/download/client/c/notes.html#4.1.8).
   * Update packaging to include system *.lua files in npm package [#202](https://github.com/aerospike/aerospike-client-nodejs/pull/202)
 
 v2.6.0 / 2017-05-25

--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Head
 ===================
 
+* **New Features**
+  * Client emits cluster state changed events [#206](https://github.com/aerospike/aerospike-client-nodejs/issues/206)
 * **Updates**
   * Update C client library to [v4.1.7](http://www.aerospike.com/download/client/c/notes.html#4.1.7).
   * Update packaging to include system *.lua files in npm package [#202](https://github.com/aerospike/aerospike-client-nodejs/pull/202)

--- a/aerospike-client-c.ini
+++ b/aerospike-client-c.ini
@@ -1,5 +1,5 @@
 # Version number of the Aerospike C Client package
-AEROSPIKE_C_VERSION="4.1.7"
+AEROSPIKE_C_VERSION="4.1.8"
 
 # Use the package build with libuv support
 AEROSPIKE_C_FLAVOR="libuv"

--- a/aerospike-client-c.sha256
+++ b/aerospike-client-c.sha256
@@ -1,8 +1,8 @@
-9b2b492202edf5eb8f96ad946a56d84bc07e6ca42360c4e15bf969d89b151541  aerospike-client-c-libuv-devel-4.1.7-1.el6.x86_64.rpm
-3a2684c21c93369ddddeed59e520f2652122c4671e652f3ca6e32cf3983c09da  aerospike-client-c-libuv-devel-4.1.7-1.el7.x86_64.rpm
-f358b57e34085fa77982fa558725eb68f71111934f2f434a1752d53f5873bd88  aerospike-client-c-libuv-devel-4.1.7.debian7.x86_64.deb
-afbba13e650728ff78aa47d46a9211be34baddceb97f3287f177ece12e8730e7  aerospike-client-c-libuv-devel-4.1.7.debian8.x86_64.deb
-d79f9fede7e399025fa2ff62e0e8f52ea363b07296f64860ba43b9b26d52494f  aerospike-client-c-libuv-devel-4.1.7.pkg
-d07b35d4de7d75845ed12205cf403df1a9d69718dd9fd0d860865098a3f0b5d6  aerospike-client-c-libuv-devel-4.1.7.ubuntu12.04.x86_64.deb
-0f6c8746607c809b2d679d7a5071c09e40f788061b955bffb71fd960118c16fc  aerospike-client-c-libuv-devel-4.1.7.ubuntu14.04.x86_64.deb
-275447c8d7632a14b0aa763069bb380104aca13d094db9d547fbe3e567cad730  aerospike-client-c-libuv-devel-4.1.7.ubuntu16.04.x86_64.deb
+7f5df90fc64d50ccadc60330f2d17a837444b8ede93157f0cf8d13e5422111b5  aerospike-client-c-libuv-devel-4.1.8-1.el6.x86_64.rpm
+7295aa9e5cf8915439a3bde1617e2b0477361890608ae30fae8f3f9739f3a31c  aerospike-client-c-libuv-devel-4.1.8-1.el7.x86_64.rpm
+3cdc4b6f73836a0d92b129f06f0fb0a73f77d314128521efc57499bc5022e960  aerospike-client-c-libuv-devel-4.1.8.debian7.x86_64.deb
+39055d6bc2167f8e3273512fe5263182adc7da616197bc216264b3a9083577f7  aerospike-client-c-libuv-devel-4.1.8.debian8.x86_64.deb
+371aec3157df5d23094801b558d45da5d394e37235727d8971967e0ffe8928aa  aerospike-client-c-libuv-devel-4.1.8.pkg
+a8eeb5ef8c59d2f3a718853d6f282664b7a8c373cd4a283903a6a83a93b0d5b8  aerospike-client-c-libuv-devel-4.1.8.ubuntu12.04.x86_64.deb
+5afb8b08b493932f381f27af97f1fd47d189ff2d674745d9f02596ddc31e5dd4  aerospike-client-c-libuv-devel-4.1.8.ubuntu14.04.x86_64.deb
+7072541a492b5e6b078eda76bc04ec274d146dd88c48bd6bf8af40ec9e5a69aa  aerospike-client-c-libuv-devel-4.1.8.ubuntu16.04.x86_64.deb

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,6 +26,7 @@
         'src/main/aerospike.cc',
         'src/main/client.cc',
         'src/main/config.cc',
+        'src/main/events.cc',
         'src/main/operations.cc',
         'src/main/policy.cc',
         'src/main/query.cc',

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,8 @@
 // *****************************************************************************
 
 const path = require('path')
+const util = require('util')
+const EventEmitter = require('events')
 
 const as = require('../build/Release/aerospike.node')
 const AerospikeError = require('./aerospike_error')
@@ -44,6 +46,51 @@ function Client (config) {
     throw new Error('Event loop resources have already been released! Call Client#close() with releaseEventLoop set to false to avoid this error.')
   }
 
+  EventEmitter.call(this)
+
+  // callback function for cluster events (node added/removed, etc.)
+  var eventsCb = function (event) {
+    /**
+     * @event Client#nodeAdded
+     * @type {object}
+     * @property {string} nodeName - Name of the cluster node that triggered this event.
+     * @property {string} nodeAddress - IP address & port of the cluster node that triggered this event.
+     * @since v2.7.0
+     */
+
+    /**
+     * @event Client#nodeRemoved
+     * @type {object}
+     * @property {string} nodeName - Name of the cluster node that triggered this event.
+     * @property {string} nodeAddress - IP address & port of the cluster node that triggered this event.
+     * @since v2.7.0
+     */
+
+    /**
+     * @event Client#disconnected
+     * @type {object}
+     * @since v2.7.0
+     */
+    this.emit(event.name, event)
+
+    /**
+     * @event Client#event
+     * @description Instead of adding listeners for the {@link
+     * event:Client#nodeAdded|nodeAdded}, {@link
+     * event:Client#nodeRemoved|nodeRemoved} and {@link
+     * event:Client#disconnected|disconnected} events, applications can also
+     * subscribe to the <code>event</code> event to receive callbacks for any
+     * kind of cluster event.
+     *
+     * @type {object}
+     * @property {string} name - Name of the event.
+     * @property {string} [nodeName] - Name of the cluster node that triggered this event.
+     * @property {string} [nodeAddress] - IP address & port of the cluster node that triggered this event.
+     * @since v2.7.0
+     */
+    this.emit('event', event)
+  }.bind(this)
+
   /**
    * @name Client#config
    *
@@ -54,7 +101,7 @@ function Client (config) {
   this.config = new Config(config)
 
   /** @private */
-  this.as_client = as.client(this.config)
+  this.as_client = as.client(this.config, eventsCb)
 
   /** @private */
   this.callbackHandler = Client.callbackHandler
@@ -65,6 +112,8 @@ function Client (config) {
   /** @private */
   this.captureStackTraces = !!process.env.AEROSPIKE_DEBUG_STACKTRACES
 }
+
+util.inherits(Client, EventEmitter)
 
 // The callback functions for the client commands take a variable number of
 // arguments. Since use of the arguments variable can prevent V8 from

--- a/lib/client.js
+++ b/lib/client.js
@@ -70,6 +70,21 @@ function Client (config) {
      * @event Client#disconnected
      * @type {object}
      * @since v2.7.0
+     *
+     * @example
+     *
+     * const Aerospike = require('aerospike')
+     *
+     * Aerospike.connect((error, client) => {
+     *   if (err) throw err
+     *
+     *   client.on('disconnected', (event) => {
+     *     console.warn('Client got disconnected from cluster')
+     *   })
+     *
+     *  // client is now ready to accept commands, e.g. get/put/...
+     *
+     * })
      */
     this.emit(event.name, event)
 
@@ -87,6 +102,27 @@ function Client (config) {
      * @property {string} [nodeName] - Name of the cluster node that triggered this event.
      * @property {string} [nodeAddress] - IP address & port of the cluster node that triggered this event.
      * @since v2.7.0
+     *
+     * @example
+     *
+     * const Aerospike = require('aerospike')
+     *
+     * Aerospike.connect((error, client) => {
+     *   if (err) throw err
+     *
+     *   client.on('event', (event) => {
+     *     var now = new Date().toUTCString()
+     *     console.info(now, event.name, event.nodeName)  // Example output:
+     *                  // Thu, 13 Jul 2017 06:47:35 GMT nodeAdded BB94DC07D270009
+     *                  // Thu, 13 Jul 2017 06:47:35 GMT nodeAdded C1D4DC0AD270002
+     *                  // Thu, 13 Jul 2017 06:48:52 GMT nodeRemoved C1D4DC0AD270002
+     *                  // Thu, 13 Jul 2017 06:49:08 GMT nodeRemoved BB94DC07D270009
+     *                  // Thu, 13 Jul 2017 06:49:08 GMT disconnected
+     *   })
+     *
+     *  // client is now ready to accept commands, e.g. get/put/...
+     *
+     * })
      */
     this.emit('event', event)
   }.bind(this)

--- a/src/include/client.h
+++ b/src/include/client.h
@@ -58,10 +58,11 @@ class AerospikeClient : public ObjectWrap {
 
 	public:
 		static void Init();
-		static Local<Value> NewInstance(Local<Object> args);
+		static Local<Value> NewInstance(Local<Object> config, Local<Function> eventCb);
 
 		aerospike* as;
 		LogInfo* log;
+		uv_async_t asyncEventCb;
 
 
 	/***************************************************************************

--- a/src/include/events.h
+++ b/src/include/events.h
@@ -1,0 +1,27 @@
+/***************************************************************************
+ * Copyright 2013-2017 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#pragma once
+
+#include <node.h>
+
+#include "log.h"
+
+extern "C" {
+	#include <aerospike/as_config.h>
+}
+
+void events_setup_callback(as_config *config, v8::Local<v8::Function> callback, LogInfo *log);

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -68,7 +68,8 @@ NAN_METHOD(client)
 {
 	Nan::HandleScope();
 	Local<Object> config = info[0].As<Object>();
-	info.GetReturnValue().Set(AerospikeClient::NewInstance(config));
+	Local<Function> eventCb = info[1].As<Function>();
+	info.GetReturnValue().Set(AerospikeClient::NewInstance(config, eventCb));
 }
 
 /**

--- a/src/main/events.cc
+++ b/src/main/events.cc
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright 2013-2017 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+//==========================================================
+// Includes.
+//
+
+#include "events.h"
+
+#include <node.h>
+#include <nan.h>
+#include <uv.h>
+
+#include "log.h"
+
+extern "C" {
+	#include <aerospike/as_config.h>
+	#include <citrusleaf/cf_queue.h>
+}
+
+using namespace v8;
+
+//==========================================================
+// Typedefs & constants.
+//
+
+typedef struct EventQueue {
+	public:
+		explicit EventQueue(Local<Function> cb, LogInfo *p_log) {
+			cf_queue_init(&events, sizeof(as_cluster_event), 4, true);
+			callback.SetFunction(cb);
+			log = p_log;
+		}
+
+		void push(as_cluster_event *event) {
+			cf_queue_push(&events, event);
+			as_v8_debug(log, "Cluster event %d triggered by node \"%s\" (%s)",
+					event->type, event->node_name, event->node_address);
+		}
+
+		void process() {
+			as_cluster_event event;
+			while (cf_queue_pop(&events, &event, 0) != CF_QUEUE_EMPTY) {
+				Nan::TryCatch try_catch;
+				Local<Value> argv[] = { convert(&event) };
+				callback.Call(1, argv);
+				if (try_catch.HasCaught()) {
+					Nan::FatalException(try_catch);
+				}
+			}
+		}
+
+	private:
+		cf_queue events;
+		Nan::Callback callback;
+		LogInfo *log;
+
+		Local<Value> convert(as_cluster_event *event) {
+			Nan::EscapableHandleScope scope;
+			Local<Object> jsEvent = Nan::New<Object>();
+			std::string name;
+			switch (event->type) {
+				case AS_CLUSTER_ADD_NODE:
+					name = "nodeAdded";
+					break;
+				case AS_CLUSTER_REMOVE_NODE:
+					name = "nodeRemoved";
+					break;
+				case AS_CLUSTER_DISCONNECTED:
+					name = "disconnected";
+					break;
+			}
+			jsEvent->Set(Nan::New("name").ToLocalChecked(),
+					Nan::New(name).ToLocalChecked());
+			jsEvent->Set(Nan::New("nodeName").ToLocalChecked(),
+					Nan::New(event->node_name).ToLocalChecked());
+			jsEvent->Set(Nan::New("nodeAddress").ToLocalChecked(),
+					Nan::New(event->node_address).ToLocalChecked());
+			return scope.Escape(jsEvent);
+		}
+} EventQueue;
+
+//==========================================================
+// Globals.
+//
+
+//==========================================================
+// Forward Declarations.
+//
+
+void cluster_event_callback(as_cluster_event *event);
+void cluster_event_async(uv_async_t *handle);
+
+//==========================================================
+// Inlines and Macros.
+//
+
+//==========================================================
+// Public API.
+//
+
+void
+events_setup_callback(as_config *config, Local<Function> callback, LogInfo *log)
+{
+	Nan::HandleScope scope;
+	uv_async_t *handle = (uv_async_t *) cf_malloc(sizeof(uv_async_t));
+	uv_async_init(uv_default_loop(), handle, cluster_event_async);
+	handle->data = new EventQueue(callback, log);
+	config->event_callback_udata = (void *) handle;
+	config->event_callback = cluster_event_callback;
+}
+
+//==========================================================
+// Local helpers.
+//
+
+void
+cluster_event_callback(as_cluster_event *event)
+{
+	uv_async_t *handle = (uv_async_t *) event->udata;
+	EventQueue *queue = (EventQueue *) handle->data;
+	queue->push(event);
+	uv_async_send(handle);
+}
+
+void
+cluster_event_async(uv_async_t *handle)
+{
+	Nan::HandleScope scope;
+	EventQueue *queue = (EventQueue *) handle->data;
+	queue->process();
+}


### PR DESCRIPTION
Set up a callback for AS cluster events. Client will emit the following
events:
* nodeAdded - a new cluster node was detected
* nodeRemoved - an existing node was removed from the cluster
* disconnected - the client has lost connection to all cluster nodes

Requires Aerospike C client v4.1.8.

Closes #145