### PR TITLE
Use bindings module to resolve native addon

### DIFF
--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -108,7 +108,7 @@
  * })
  */
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 
 const AerospikeError = require('./aerospike_error')
 const Client = require('./client')

--- a/lib/aerospike_error.js
+++ b/lib/aerospike_error.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const status = require('../build/Release/aerospike.node').status
+const status = require('bindings')('aerospike.node').status
 const util = require('util')
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,7 @@ const path = require('path')
 const util = require('util')
 const EventEmitter = require('events')
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const AerospikeError = require('./aerospike_error')
 const BatchCommand = require('./commands/batch_command')
 const Command = require('./commands/command')

--- a/lib/commands/command.js
+++ b/lib/commands/command.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const as = require('../../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const AerospikeError = require('../aerospike_error')
 
 class Command {

--- a/lib/commands/exists_command.js
+++ b/lib/commands/exists_command.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const as = require('../../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const Command = require('./command')
 
 class ExistsCommand extends Command {

--- a/lib/event_loop.js
+++ b/lib/event_loop.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 
 /**
  * Whether event loop resources have been released

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -63,7 +63,7 @@ function FilterPredicate (predicate, bin, dataType, indexType) {
  * @see {@link Query}
  */
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const GeoJSON = require('./geojson')
 
 const util = require('util')

--- a/lib/index_job.js
+++ b/lib/index_job.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const Info = require('./info')
 const Job = require('./job')
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -164,9 +164,8 @@ function normalizeKey (key) {
  * @private
  */
 function getSeparators (key) {
-  var name = normalizeKey(key)
-  var separators = SEPARATORS[name] || DEFAULT_SEPARATORS
-  return separators
+  let name = normalizeKey(key)
+  return separators[name] || defaultSeparators
 }
 
 /**
@@ -213,7 +212,7 @@ function splitString (str, separators) {
  *
  * @private
  */
-const SEPARATORS = {
+let separators = {
   'bins': [';:', splitBins],
   'bins-ns': [splitBins],
   'namespace': [';='],
@@ -221,10 +220,11 @@ const SEPARATORS = {
   'sindex-list': [';', ':='],
   'statistics': [';='],
   'udf-list': [';', ',='],
-  'udf-stats': [';=']
+  'udf-stats': [';='],
+  'get-dc-config': [';', ':=']
 }
 
-const DEFAULT_SEPARATORS = [smartParse]
+let defaultSeparators = [smartParse]
 
 /**********************************************************
  * Functions for dealing with specific info command results
@@ -248,5 +248,6 @@ function splitBins (str) {
 }
 
 module.exports = {
-  parse: parse
+  parse: parse,
+  separators: separators
 }

--- a/lib/job.js
+++ b/lib/job.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const Command = require('./commands/command')
 
 const DEFAULT_POLL_INTERVALL = 1000

--- a/lib/lists.js
+++ b/lib/lists.js
@@ -47,7 +47,7 @@
  * @see {@link Client#operate}
  */
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const opcodes = as.operations
 
 /**

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -94,7 +94,7 @@
  * })
  */
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const opcodes = as.operations
 const utils = require('./utils')
 

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -49,7 +49,7 @@
  * })
  */
 
-const as = require('../build/Release/aerospike.node')
+const as = require('bindings')('aerospike.node')
 const ops = as.operations
 
 /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "nan": "~2.3.0",
-    "node-bindings": "~1.3.0"
+    "bindings": "~1.3.0"
   },
   "devDependencies": {
     "expect.js": "^0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "cppcheck": "cppcheck --quiet --enable=warning,style -I src/include src/main/"
   },
   "dependencies": {
-    "nan": "~2.3.0"
+    "nan": "~2.3.0",
+    "node-bindings": "~1.3.0"
   },
   "devDependencies": {
     "expect.js": "^0.3",


### PR DESCRIPTION
Use [bindings](https://www.npmjs.com/package/bindings) to resolve native addon instead of hard-coding the path:

    require('../build/Release/aerospike.node')

Becomes:

    require('bindings')('aerospike.node')