### PR TITLE
Refactor: Replace MakeCallback with Nan::AsyncResource

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -54,6 +54,7 @@
         'src/main/query.cc',
         'src/main/scan.cc',
         'src/main/async.cc',
+        'src/main/command.cc',
         'src/main/commands/apply_async.cc',
         'src/main/commands/batch_exists.cc',
         'src/main/commands/batch_get.cc',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1748,9 +1748,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.0",
-    "nan": "^2.8.0"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -27,12 +27,6 @@ extern "C" {
 
 #include "client.h"
 
-typedef struct CallbackData {
-	AerospikeClient * client;
-	Nan::Persistent<v8::Function> callback;
-	void* data;
-} CallbackData;
-
 class AsyncCommand : public Nan::AsyncResource {
 	public:
 		AsyncCommand(AerospikeClient* client_, v8::Local<v8::Function> callback_)
@@ -50,7 +44,7 @@ class AsyncCommand : public Nan::AsyncResource {
 
 		AerospikeClient* client;
 		Nan::Persistent<v8::Function> callback;
-		as_error* error;
+		as_error* error = NULL;
 };
 
 /**
@@ -71,8 +65,7 @@ v8::Local<v8::Value> async_invoke(
 /**
  * Asynchronously invoke callback function with the given error.
  */
-void invoke_error_callback(as_error* error, CallbackData* data);
-void invoke_error_callbackNew(as_error* error, AsyncCommand* cmd);
+void invoke_error_callback(as_error* error, AsyncCommand* cmd);
 
 // implements the as_async_record_listener interface
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop);

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -33,6 +33,26 @@ typedef struct CallbackData {
 	void* data;
 } CallbackData;
 
+class AsyncCommand : public Nan::AsyncResource {
+	public:
+		AsyncCommand(AerospikeClient* client_, v8::Local<v8::Function> callback_)
+			: AsyncResource("aerospike:AsyncCommand") {
+				client = client_;
+				callback.Reset(callback_);
+		}
+
+		~AsyncCommand() {
+			callback.Reset();
+			if (error) {
+				cf_free(error);
+			}
+		}
+
+		AerospikeClient* client;
+		Nan::Persistent<v8::Function> callback;
+		as_error* error;
+};
+
 /**
  * Creates a new as_error struct with status code set to AEROSPIKE_ERR_OK.
  */
@@ -52,6 +72,7 @@ v8::Local<v8::Value> async_invoke(
  * Asynchronously invoke callback function with the given error.
  */
 void invoke_error_callback(as_error* error, CallbackData* data);
+void invoke_error_callbackNew(as_error* error, AsyncCommand* cmd);
 
 // implements the as_async_record_listener interface
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop);

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -26,26 +26,7 @@ extern "C" {
 #include <node.h>
 
 #include "client.h"
-
-class AsyncCommand : public Nan::AsyncResource {
-	public:
-		AsyncCommand(AerospikeClient* client_, v8::Local<v8::Function> callback_)
-			: AsyncResource("aerospike:AsyncCommand") {
-				client = client_;
-				callback.Reset(callback_);
-		}
-
-		~AsyncCommand() {
-			callback.Reset();
-			if (error) {
-				cf_free(error);
-			}
-		}
-
-		AerospikeClient* client;
-		Nan::Persistent<v8::Function> callback;
-		as_error* error = NULL;
-};
+#include "command.h"
 
 /**
  * Creates a new as_error struct with status code set to AEROSPIKE_ERR_OK.
@@ -65,7 +46,7 @@ v8::Local<v8::Value> async_invoke(
 /**
  * Asynchronously invoke callback function with the given error.
  */
-void invoke_error_callback(as_error* error, AsyncCommand* cmd);
+void invoke_error_callback(AsyncCommand* cmd);
 
 // implements the as_async_record_listener interface
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop);

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -29,11 +29,6 @@ extern "C" {
 #include "command.h"
 
 /**
- * Creates a new as_error struct with status code set to AEROSPIKE_ERR_OK.
- */
-v8::Local<v8::Object> err_ok();
-
-/**
  *  Setup an asynchronous invocation of a function using libuv worker threads.
  */
 v8::Local<v8::Value> async_invoke(

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -38,11 +38,6 @@ v8::Local<v8::Value> async_invoke(
     void  (* respond)(uv_work_t* req, int status)
     );
 
-/**
- * Asynchronously invoke callback function with the given error.
- */
-void invoke_error_callback(AsyncCommand* cmd);
-
 // implements the as_async_record_listener interface
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop);
 

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -17,9 +17,9 @@
 #pragma once
 
 extern "C" {
-	#include <aerospike/aerospike.h>
-	#include <aerospike/aerospike_batch.h>
-	#include <aerospike/as_event.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_batch.h>
+#include <aerospike/as_event.h>
 }
 
 #include <nan.h>

--- a/src/include/async.h
+++ b/src/include/async.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2017 Aerospike, Inc.
+ * Copyright 2013-2018 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2018 Aerospike, Inc.
+ * Copyright 2018 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2013-2018 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include <string>
+#include "log.h"
+
+class AerospikeCommand : public Nan::AsyncResource {
+	public:
+		AerospikeCommand(std::string name, AerospikeClient* client, v8::Local<v8::Function> callback_)
+			: Nan::AsyncResource(("aerospike:" + name + "Command").c_str())
+			, cmd(name)
+			, as(client->as)
+			, log(client->log) {
+				as_error_init(&err);
+				callback.Reset(callback_);
+				as_v8_detail(log, "Initialized %s command", cmd.c_str());
+			}
+
+		~AerospikeCommand() {
+			Nan::HandleScope scope;
+			as_v8_detail(log, "Destroying %s command", cmd.c_str());
+			callback.Reset();
+		}
+
+		void SetError(as_status code, const char* fmt, ...) {
+			va_list args;
+			va_start(args, fmt);
+			as_v8_error(log, ("Error in " + cmd + " command: " + fmt).c_str(), args);
+			as_error_update(&err, code, fmt, args);
+			va_end(args);
+		}
+
+		bool IsError() {
+			return err.code != AEROSPIKE_OK;
+		}
+
+		bool CanExecute() {
+			if (IsError()) {
+				as_v8_info(log, "Cannot execute %s command because of error %d", cmd.c_str(), err.code);
+				return false;
+			}
+
+			if (as->cluster == NULL) {
+				as_v8_info(log, "Cannot execute %s command because client is invalid", cmd.c_str());
+				return false;
+			}
+
+			return true;
+		}
+
+		void Callback(const int argc, v8::Local<v8::Value> argv[]) {
+			Nan::HandleScope scope;
+			as_v8_debug(log, "Executing JS callback for %s command", cmd.c_str());
+			Nan::TryCatch try_catch;
+			v8::Local<v8::Object> target = Nan::New<v8::Object>();
+			v8::Local<v8::Function> cb = Nan::New<v8::Function>(callback);
+			runInAsyncScope(target, cb, argc, argv);
+			if (try_catch.HasCaught()) {
+				Nan::FatalException(try_catch);
+			}
+		}
+
+		std::string cmd;
+		aerospike* as;
+		as_error err;
+		LogInfo* log;
+		Nan::Persistent<v8::Function> callback;
+};

--- a/src/include/conversions.h
+++ b/src/include/conversions.h
@@ -109,3 +109,5 @@ void free_batch_records(as_batch_read_records* records);
 // Functions to set metadata of the record.
 int setTTL(v8::Local<v8::Object> obj, uint32_t* ttl, const LogInfo* log);
 int setGeneration(v8::Local<v8::Object> obj, uint16_t* generation, const LogInfo* log);
+
+size_t as_strlcpy(char *d, const char *s, size_t bufsize);

--- a/src/main/async.cc
+++ b/src/main/async.cc
@@ -111,6 +111,50 @@ void invoke_error_callback(as_error* error, CallbackData* data)
 	uv_timer_start(timer, async_error_callback, 0, 0);
 }
 
+void release_uv_timerNew(uv_handle_t* handle)
+{
+	uv_timer_t* timer = (uv_timer_t*) handle;
+	AsyncCommand* cmd = reinterpret_cast<AsyncCommand*>(timer->data);
+	cf_free(timer);
+	delete cmd;
+}
+
+void async_error_callbackNew(uv_timer_t* timer)
+{
+	Nan::HandleScope scope;
+	AsyncCommand* cmd = reinterpret_cast<AsyncCommand*>(timer->data);
+	const LogInfo* log = cmd->client->log;
+	as_error* error = cmd->error;
+
+	const int argc = 1;
+	Local<Value> argv[argc];
+	argv[0] = error_to_jsobject(error, log);
+
+	as_v8_debug(log, "Invoking JS error callback function: %d %s", error->code, error->message);
+	Nan::TryCatch try_catch;
+	Local<Object> target = Nan::New<Object>();
+	Local<Function> callback = Nan::New(cmd->callback);
+	cmd->runInAsyncScope(target, callback, argc, argv);
+	if (try_catch.HasCaught()) {
+		Nan::FatalException(try_catch);
+	}
+
+	uv_close((uv_handle_t*) timer, release_uv_timerNew);
+}
+
+void invoke_error_callbackNew(as_error* error, AsyncCommand* cmd)
+{
+	Nan::HandleScope scope;
+	as_error* err = (as_error*) cf_malloc(sizeof(as_error));
+	as_error_setall(err, error->code, error->message, error->func,
+			error->file, error->line);
+	cmd->error = err;
+	uv_timer_t* timer = (uv_timer_t*) cf_malloc(sizeof(uv_timer_t));
+	uv_timer_init(uv_default_loop(), timer);
+	timer->data = cmd;
+	uv_timer_start(timer, async_error_callbackNew, 0, 0);
+}
+
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop)
 {
 	Nan::HandleScope scope;
@@ -152,12 +196,12 @@ void async_write_listener(as_error* err, void* udata, as_event_loop* event_loop)
 {
 	Nan::HandleScope scope;
 
-	CallbackData * data = reinterpret_cast<CallbackData *>(udata);
-	if (!data) {
+	AsyncCommand* cmd = reinterpret_cast<AsyncCommand*>(udata);
+	if (!cmd) {
 		return Nan::ThrowError("Missing callback data - cannot process write callback");
 	}
 
-	const AerospikeClient * client = data->client;
+	const AerospikeClient * client = cmd->client;
 	const LogInfo * log = client->log;
 
 	const int argc = 1;
@@ -171,14 +215,14 @@ void async_write_listener(as_error* err, void* udata, as_event_loop* event_loop)
 
 	as_v8_debug(log, "Invoking JS callback function");
 	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(data->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+	Local<Object> target = Nan::New<Object>();
+	Local<Function> callback = Nan::New(cmd->callback);
+	cmd->runInAsyncScope(target, callback, argc, argv);
 	if (try_catch.HasCaught()) {
 		Nan::FatalException(try_catch);
 	}
 
-	data->callback.Reset();
-	delete data;
+	delete cmd;
 }
 
 void async_value_listener(as_error* err, as_val* value, void* udata, as_event_loop* event_loop)

--- a/src/main/async.cc
+++ b/src/main/async.cc
@@ -60,13 +60,6 @@ Local<Value> async_invoke(
 	return Nan::Undefined();
 }
 
-void invoke_error_callback(AsyncCommand* cmd)
-{
-	Nan::HandleScope scope;
-	cmd->ErrorCallback();
-	delete cmd;
-}
-
 void async_record_listener(as_error* err, as_record* record, void* udata, as_event_loop* event_loop)
 {
 	Nan::HandleScope scope;

--- a/src/main/async.cc
+++ b/src/main/async.cc
@@ -87,8 +87,7 @@ void async_write_listener(as_error* err, void* udata, as_event_loop* event_loop)
 	if (err) {
 		cmd->ErrorCallback(err);
 	} else {
-		Local<Value> argv[] = {};
-		cmd->Callback(0, argv);
+		cmd->Callback(0, {});
 	}
 
 	delete cmd;

--- a/src/main/async.cc
+++ b/src/main/async.cc
@@ -30,14 +30,6 @@ extern "C" {
 
 using namespace v8;
 
-Local<Object> err_ok()
-{
-	Nan::EscapableHandleScope scope;
-	Local<Object> err = Nan::New<Object>();
-	err->Set(Nan::New("code").ToLocalChecked(), Nan::New(AEROSPIKE_OK));
-	return scope.Escape(err);
-}
-
 /**
  *  Setup an asynchronous invocation of a function using uv worker threads.
  */

--- a/src/main/client.cc
+++ b/src/main/client.cc
@@ -16,6 +16,7 @@
 
 #include <node.h>
 #include "client.h"
+#include "command.h"
 #include "conversions.h"
 #include "config.h"
 #include "events.h"
@@ -90,28 +91,18 @@ NAN_METHOD(AerospikeClient::Connect)
 {
 	Nan::HandleScope scope;
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-
-	Local<Function> callback;
-	if (info.Length() > 0 && info[0]->IsFunction()) {
-		callback = Local<Function>::Cast(info[0]);
-	} else {
-		as_v8_error(client->log, "Callback function required");
-		return Nan::ThrowError("Callback function required");
-	}
+	Local<Function> callback = info[0].As<Function>();
+	AerospikeCommand* cmd = new AerospikeCommand("Connect", client, callback);
 
 	as_error err;
-	aerospike_connect(client->as, &err);
-	if (err.code != AEROSPIKE_OK) {
-		as_v8_error(client->log, "Connecting to Cluster Failed: %s (%d)", err.message, err.code);
+	if (aerospike_connect(client->as, &err) != AEROSPIKE_OK) {
+		cmd->ErrorCallback(&err);
 	} else {
-		as_v8_debug(client->log, "Connecting to Cluster: Success");
+		as_v8_debug(client->log, "Successfully connected to cluster: Enjoy your cake!");
+		cmd->Callback(0, {});
 	}
 
-	Nan::AsyncResource* resource = new Nan::AsyncResource("aerospike:Connect");
-	Local<Object> target = Nan::New<Object>();
-	const int argc = 1;
-	Local<Value> argv[argc] = { error_to_jsobject(&err, client->log) };
-	resource->runInAsyncScope(target, callback, argc, argv);
+	delete cmd;
 }
 
 /**

--- a/src/main/client.cc
+++ b/src/main/client.cc
@@ -107,9 +107,11 @@ NAN_METHOD(AerospikeClient::Connect)
 		as_v8_debug(client->log, "Connecting to Cluster: Success");
 	}
 
+	Nan::AsyncResource* resource = new Nan::AsyncResource("aerospike:Connect");
+	Local<Object> target = Nan::New<Object>();
 	const int argc = 1;
 	Local<Value> argv[argc] = { error_to_jsobject(&err, client->log) };
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
+	resource->runInAsyncScope(target, callback, argc, argv);
 }
 
 /**

--- a/src/main/command.cc
+++ b/src/main/command.cc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2018 Aerospike, Inc.
+ * Copyright 2018 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/command.cc
+++ b/src/main/command.cc
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright 2013-2018 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include <string>
+
+#include "command.h"
+#include "conversions.h"
+#include "log.h"
+
+extern "C" {
+#include <aerospike/as_error.h>
+}
+
+using namespace v8;
+
+AerospikeCommand*
+AerospikeCommand::SetError(as_status code, const char* fmt, ...)
+{
+	char msg[1024];
+	va_list args;
+	va_start(args, fmt);
+	vsnprintf(msg, 1024, fmt, args);
+	as_v8_error(log, "Error in %s command: %s", cmd.c_str(), msg);
+	as_error_set_message(&err, code, msg);
+	va_end(args);
+	return this;
+}
+
+bool
+AerospikeCommand::IsError()
+{
+	return err.code != AEROSPIKE_OK;
+}
+
+bool
+AerospikeCommand::CanExecute()
+{
+	if (IsError()) {
+		as_v8_info(log, "Skipping execution of %s command because an error occurred", cmd.c_str());
+		return false;
+	}
+
+	if (as->cluster == NULL) {
+		as_v8_info(log, "Skipping execution of %s command because client is invalid", cmd.c_str());
+		return false;
+	}
+
+	return true;
+}
+
+Local<Value>
+AerospikeCommand::Callback(const int argc, Local<Value> argv[])
+{
+	Nan::EscapableHandleScope scope;
+	as_v8_debug(log, "Executing JS callback for %s command", cmd.c_str());
+
+	Nan::TryCatch try_catch;
+	Local<Object> target = Nan::New<Object>();
+	Local<Function> cb = Nan::New<Function>(callback);
+	Local<Value> result = runInAsyncScope(target, cb, argc, argv)
+		.FromMaybe(Nan::Undefined().As<Value>());
+	if (try_catch.HasCaught()) {
+		Nan::FatalException(try_catch);
+	}
+
+	return scope.Escape(result);
+}
+
+Local<Value>
+AerospikeCommand::ErrorCallback()
+{
+	Nan::HandleScope scope;
+
+	as_v8_error(log, "Error in %s command: %s [%d]", cmd.c_str(), err.message, err.code);
+
+	Local<Value> args[] = { error_to_jsobject(&err, log) };
+	return Callback(1, args);
+}
+
+Local<Value>
+AerospikeCommand::ErrorCallback(as_error* error)
+{
+	Nan::HandleScope scope;
+
+	as_error_copy(&err, error);
+
+	return ErrorCallback();
+}
+
+Local<Value>
+AerospikeCommand::ErrorCallback(as_status code, const char * func, const char * file,
+		uint32_t line, const char * fmt, ...)
+{
+	Nan::HandleScope scope;
+
+	va_list args;
+	va_start(args, fmt);
+	as_error_setallv(&err, code, func, file, line, fmt, args);
+	va_end(args);
+
+	return ErrorCallback();
+}

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -45,7 +45,7 @@ class BatchExistsCommand : public AerospikeCommand {
 		as_policy_batch* policy = NULL;
 		as_batch batch;
 		as_batch_read* results = NULL;
-		uint32_t n = 0;
+		uint32_t results_len = 0;
 };
 
 bool
@@ -54,19 +54,18 @@ batch_exists_callback(const as_batch_read* results, uint32_t n, void* udata)
 	BatchExistsCommand* cmd = reinterpret_cast<BatchExistsCommand*>(udata);
 	LogInfo* log = cmd->log;
 
+	as_v8_debug(log, "BatchExists callback invoked with %d batch results", n);
+
 	if (results == NULL) {
-		as_v8_info(log, "Brigde callback for batch called with no batch results");
-		cmd->n = 0;
 		cmd->results = NULL;
+		cmd->results_len = 0;
 		return false;
 	}
 
 	// Copy the batch result to the shared data structure BatchExistsCommand,
 	// so that response can send it back to nodejs layer.
-	as_v8_debug(log, "Bridge callback invoked for a batch request of %d records", n);
-	cmd->n = n;
 	cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
-
+	cmd->results_len = n;
 	for (uint32_t i = 0; i < n; i++) {
 		cmd->results[i].result = results[i].result;
 		key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
@@ -112,10 +111,10 @@ execute(uv_work_t* req)
 		return;
 	}
 
-	as_v8_debug(log, "Submitting batch request to server with %d keys", cmd->batch.keys.size);
+	as_v8_debug(log, "Executing BatchExists command for %d keys", cmd->batch.keys.size);
 	if (aerospike_batch_exists(cmd->as, &cmd->err, cmd->policy, &cmd->batch, batch_exists_callback, cmd) != AEROSPIKE_OK) {
 		cmd->results = NULL;
-		cmd->n = 0;
+		cmd->results_len = 0;
 	}
 	as_batch_destroy(&cmd->batch);
 }
@@ -126,19 +125,13 @@ respond(uv_work_t* req, int status)
 	Nan::HandleScope scope;
 	BatchExistsCommand* cmd = reinterpret_cast<BatchExistsCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	uint32_t num_rec = cmd->n;
-	as_batch_read* batch_results = cmd->results;
 
-	const int argc = 2;
-	Local<Value> argv[argc];
-	if (cmd->IsError() || num_rec == 0 || batch_results == NULL) {
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
 	} else {
-		int rec_found = 0;
-
-		Local<Array> results = Nan::New<Array>(num_rec);
-		for (uint32_t i = 0; i< num_rec; i++) {
+		as_batch_read* batch_results = cmd->results;
+		Local<Array> results = Nan::New<Array>(cmd->results_len);
+		for (uint32_t i = 0; i< cmd->results_len; i++) {
 			as_status status = batch_results[i].result;
 			as_record * record = &batch_results[i].record;
 			const as_key * key = batch_results[i].key;
@@ -149,9 +142,8 @@ respond(uv_work_t* req, int status)
 
 			if (batch_results[i].result == AEROSPIKE_OK) {
 				result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
-				rec_found++;
 			} else {
-				as_v8_debug(log, "Record[%d] not returned by server", i);
+				as_v8_debug(log, "Record [%d] not returned by server", i);
 			}
 
 			as_key_destroy((as_key*) key);
@@ -159,12 +151,12 @@ respond(uv_work_t* req, int status)
 			results->Set(i, result);
 		}
 
-		as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = results;
+		Local<Value> argv[] = {
+			Nan::Null(),
+			results
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -89,13 +89,13 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	Local<Array> keys = Local<Array>::Cast(info[0]);
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}
 
 	if (info[1]->IsObject()) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
 		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}
 

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -172,9 +172,9 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::BatchExists)
 {
-	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsArray, "Keys must be a array");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -15,312 +15,166 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_key.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/as_key.h>
-    #include <aerospike/as_record.h>
-    #include <aerospike/aerospike_batch.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_key.h>
+#include <aerospike/as_config.h>
+#include <aerospike/as_key.h>
+#include <aerospike/as_record.h>
+#include <aerospike/aerospike_batch.h>
 }
 
 using namespace v8;
 
-/*******************************************************************************
- *      TYPES
- ******************************************************************************/
+class BatchExistsCommand : public AerospikeCommand {
+	public:
+		BatchExistsCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("BatchExists", client, callback_) { }
 
-/**
- *      BatchExistsCmd — Data to be used in async calls.
- */
-typedef struct BatchExistsCmd {
-    aerospike * as;
-    int node_err;            // To Keep track of the parameter errors from Nodejs
-    as_error err;
-    as_policy_batch* policy;
-    as_batch batch;          // Passed as input to aerospike_batch_get
-    as_batch_read  *results;// Results from a aerospike_batch_get operation
-    LogInfo * log;
-    uint32_t n;
-    Nan::Persistent<Function> callback;
-} BatchExistsCmd;
+		~BatchExistsCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (results != NULL) cf_free(results);
+		}
 
+		as_policy_batch* policy = NULL;
+		as_batch batch;
+		as_batch_read* results = NULL;
+		uint32_t n = 0;
+};
 
-
-/*******************************************************************************
- *      FUNCTIONS
- ******************************************************************************/
-
-bool batch_exists_callback(const as_batch_read * results, uint32_t n, void * udata)
+bool
+batch_exists_callback(const as_batch_read* results, uint32_t n, void* udata)
 {
-    BatchExistsCmd* cmd = reinterpret_cast<BatchExistsCmd*>(udata);
-    LogInfo* log = cmd->log;
+	BatchExistsCommand* cmd = reinterpret_cast<BatchExistsCommand*>(udata);
+	LogInfo* log = cmd->log;
 
-    //copy the batch result to the shared data structure BatchExistsCmd,
-    //so that response can send it back to nodejs layer
-    //as_batch_read* batch_result = &cmd->results;
-    if( results != NULL ) {
-        as_v8_debug(log, "Bridge callback invoked in V8 for a batch request of %d records", n);
-        cmd->n = n;
-        cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
-        for ( uint32_t i = 0; i < n; i++ ) {
-            cmd->results[i].result = results[i].result;
-            key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
-            if (results[i].result == AEROSPIKE_OK) {
-                as_record* rec = &cmd->results[i].record;
-                as_v8_debug(log, "record[%d]", i);
-                record_clone(&results[i].record, &rec, log);
-            }
-        }
-        return true;
-    }
-    else {
-        as_v8_info(log, "Brigde callback in v8 for batch called with no batch results");
-        cmd->n = 0;
-        cmd->results = NULL;
-    }
-    return false;
+	if (results == NULL) {
+		as_v8_info(log, "Brigde callback for batch called with no batch results");
+		cmd->n = 0;
+		cmd->results = NULL;
+		return false;
+	}
+
+	// Copy the batch result to the shared data structure BatchExistsCommand,
+	// so that response can send it back to nodejs layer.
+	as_v8_debug(log, "Bridge callback invoked for a batch request of %d records", n);
+	cmd->n = n;
+	cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
+
+	for (uint32_t i = 0; i < n; i++) {
+		cmd->results[i].result = results[i].result;
+		key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
+		if (results[i].result == AEROSPIKE_OK) {
+			as_record* rec = &cmd->results[i].record;
+			record_clone(&results[i].record, &rec, log);
+		}
+	}
+
+	return true;
 }
 
-/**
- *      prepare() — Function to prepare BatchExistsCmd, for use in `execute()` and `respond()`.
- *
- *      This should only keep references to V8 or V8 structures for use in
- *      `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
-    Nan::HandleScope scope;
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	BatchExistsCommand* cmd = new BatchExistsCommand(client, info[2].As<Function>());
+	LogInfo* log = client->log;
 
-    BatchExistsCmd* cmd = new BatchExistsCmd();
-    cmd->as = client->as;
-    cmd->node_err = 0;
-    cmd->n = 0;
-    cmd->results = NULL;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	Local<Array> keys = Local<Array>::Cast(info[0]);
+	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+	}
 
-    Local<Value> maybe_keys = info[0];
-    Local<Value> maybe_policy = info[1];
-    Local<Value> maybe_callback = info[2];
+	if (info[1]->IsObject()) {
+		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
+		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+		}
+	}
 
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "batch_exists callback registered");
-    } else {
-        as_v8_error(log, "Arglist must contain a callback function");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_keys->IsArray()) {
-        Local<Array> keys = Local<Array>::Cast(maybe_keys);
-        if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-            as_v8_debug(log, "parsing batch keys failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else {
-        as_v8_debug(log, "Batch key must be an array of key objects");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_policy->IsObject()) {
-        cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-        if (batchpolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "Parsing batch policy failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else if (maybe_policy->IsNull() || maybe_policy->IsUndefined()) {
-        // policy is an optional parameter - ignore if missing
-    } else {
-        as_v8_error(log, "Batch policy must be an object");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    return cmd;
-
-Err_Return:
-    cmd->node_err = 1;
-    return cmd;
+	return cmd;
 }
 
-/**
- *      execute() — Function to execute inside the worker-thread.
- *
- *      It is not safe to access V8 or V8 data structures here, so everything
- *      we need for input and output should be in the BatchExistsCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the BatchExistsCmd structure
-    BatchExistsCmd* cmd = reinterpret_cast<BatchExistsCmd *>(req->data);
+	BatchExistsCommand* cmd = reinterpret_cast<BatchExistsCommand *>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Data to be used.
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_batch* batch = &cmd->batch;
-    as_policy_batch* policy = cmd->policy;
-    LogInfo* log = cmd->log;
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if( as->cluster == NULL) {
-        as_v8_debug(log, "Cluster Object is NULL, can't perform the operation");
-        cmd->node_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-    }
-    // Invoke the blocking call.
-    // Check for no parameter errors from Nodejs
-    if (cmd->node_err == 0) {
-        as_v8_debug(log, "Submitting batch request to server with %d keys", batch->keys.size);
-        aerospike_batch_exists(as, err, policy, batch, batch_exists_callback, (void*) req->data);
-        if( err->code != AEROSPIKE_OK) {
-            cmd->results = NULL;
-            cmd->n = 0;
-        }
-        as_batch_destroy(batch);
-    }
+	as_v8_debug(log, "Submitting batch request to server with %d keys", cmd->batch.keys.size);
+	if (aerospike_batch_exists(cmd->as, &cmd->err, cmd->policy, &cmd->batch, batch_exists_callback, cmd) != AEROSPIKE_OK) {
+		cmd->results = NULL;
+		cmd->n = 0;
+	}
+	as_batch_destroy(&cmd->batch);
 }
 
-/**
- *  respond() — Function to be called after `execute()`. Used to send response
- *  to the callback.
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
-    Nan::HandleScope scope;
-    // Fetch the BatchExistsCmd structure
-    BatchExistsCmd* cmd = reinterpret_cast<BatchExistsCmd*>(req->data);
-    as_error*  err = &cmd->err;
-    uint32_t num_rec = cmd->n;
-    as_batch_read* batch_results = cmd->results;
+	Nan::HandleScope scope;
+	BatchExistsCommand* cmd = reinterpret_cast<BatchExistsCommand*>(req->data);
+	LogInfo* log = cmd->log;
+	uint32_t num_rec = cmd->n;
+	as_batch_read* batch_results = cmd->results;
 
-    LogInfo* log = cmd->log;
+	const int argc = 2;
+	Local<Value> argv[argc];
+	if (cmd->IsError() || num_rec == 0 || batch_results == NULL) {
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = Nan::Null();
+	} else {
+		int rec_found = 0;
 
-    // maintain a linked list of pointers to be freed after the nodejs callback is called
-    // Buffer object is not garbage collected by v8 gc. Have to delete explicitly
-    // to avoid memory leak.
+		Local<Array> results = Nan::New<Array>(num_rec);
+		for (uint32_t i = 0; i< num_rec; i++) {
+			as_status status = batch_results[i].result;
+			as_record * record = &batch_results[i].record;
+			const as_key * key = batch_results[i].key;
 
-    // Build the arguments array for the callback
-    Local<Value> argv[2];
+			Local<Object> result = Nan::New<Object>();
+			result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
+			result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key, log));
 
-    if (cmd->node_err == 1) {
-        // Sets the err->code and err->message in the 'err' variable
-        err->func = NULL;
-        err->line = 0;
-        err->file = NULL;
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else if ( num_rec == 0 || batch_results == NULL ) {
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else {
+			if (batch_results[i].result == AEROSPIKE_OK) {
+				result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
+				rec_found++;
+			} else {
+				as_v8_debug(log, "Record[%d] not returned by server", i);
+			}
 
-        int rec_found = 0;
+			as_key_destroy((as_key*) key);
+			as_record_destroy(record);
+			results->Set(i, result);
+		}
 
-        // the result is an array of batch results
-        Local<Array> results = Nan::New<Array>(num_rec);
+		as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = results;
+	}
 
-        for ( uint32_t i = 0; i< num_rec; i++) {
+	cmd->Callback(argc, argv);
 
-            as_status status = batch_results[i].result;
-            as_record * record = &batch_results[i].record;
-            const as_key * key = batch_results[i].key;
-
-            // a batch result object attributes:
-            //   - status
-            //   - key
-            //   - metadata
-            Local<Object> result = Nan::New<Object>();
-
-            // status attribute
-            result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
-
-            // key attribute - should always be sent
-            result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key, log));
-
-            if(batch_results[i].result == AEROSPIKE_OK) {
-
-                // metadata attribute
-                result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
-
-                rec_found++;
-            }
-            else {
-                as_v8_debug(log, "Record[%d] not returned by server ", i);
-            }
-
-            // clean up
-            as_key_destroy((as_key *) key);
-            as_record_destroy(record);
-
-            // append to the result array
-            results->Set(i, result);
-        }
-
-        as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = results;
-    }
-
-    // Surround the callback in a try/catch for safety`
-    Nan::TryCatch try_catch;
-
-    // Execute the callback.
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 2, argv);
-
-    as_v8_debug(log,"Invoked the callback");
-
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        Nan::FatalException(try_catch);
-    }
-
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-    if (cmd->node_err == 1) {
-        free(cmd->results);
-    }
-    if (batch_results != NULL) {
-        free(batch_results);
-    }
-    if (cmd->policy != NULL) {
-        cf_free(cmd->policy);
-    }
-
-    as_v8_debug(log, "Cleaned up the resources");
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *      The 'batchExists()' Operation
- */
 NAN_METHOD(AerospikeClient::BatchExists)
 {
-    async_invoke(info, prepare, execute, respond);
-}
+	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
+	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
+	async_invoke(info, prepare, execute, respond);
+}

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -87,7 +87,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	BatchExistsCommand* cmd = new BatchExistsCommand(client, info[2].As<Function>());
 	LogInfo* log = client->log;
 
-	Local<Array> keys = Local<Array>::Cast(info[0]);
+	Local<Array> keys = info[0].As<Array>();
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
 		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -91,13 +91,13 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	Local<Array> keys = Local<Array>::Cast(info[0]);
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}
 
 	if (info[1]->IsObject() ) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
 		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}
 

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -176,9 +176,9 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::BatchGet)
 {
-	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsArray, "Keys must be a array");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -45,7 +45,7 @@ class BatchGetCommand : public AerospikeCommand {
 		as_policy_batch* policy = NULL;
 		as_batch batch;
 		as_batch_read* results = NULL;
-		uint32_t n = 0;
+		uint32_t results_len = 0;
 };
 
 bool
@@ -54,21 +54,19 @@ batch_callback(const as_batch_read* results, uint32_t n, void* udata)
 	BatchGetCommand* cmd = reinterpret_cast<BatchGetCommand*>(udata);
 	LogInfo* log = cmd->log;
 
+	as_v8_debug(log, "BatchGet callback invoked with %d batch results", n);
+
 	if (results == NULL) {
-		as_v8_info(log, "Brigde callback for batch called with no batch results");
-		cmd->n = 0;
 		cmd->results = NULL;
+		cmd->results_len = 0;
 		return false;
 	}
 
-	//copy the batch result to the shared data structure BatchGetCmd,
-	//so that response can send it back to nodejs layer
-	//as_batch_read* batch_result = &cmd->results;
-	as_v8_debug(log, "Bridge callback invoked for the a batch request of %d records ", n);
-	cmd->n = n;
+	// Copy the batch result to the shared data structure BatchGetCommand, so
+	// that the response can send it back to nodejs layer.
 	cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
-
-	for ( uint32_t i = 0; i < n; i++ ) {
+	cmd->results_len = n;
+	for (uint32_t i = 0; i < n; i++) {
 		cmd->results[i].result = results[i].result;
 		key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
 		if (results[i].result == AEROSPIKE_OK) {
@@ -114,10 +112,10 @@ execute(uv_work_t * req)
 		return;
 	}
 
-	as_v8_debug(log, "Submitting batch request to server with %d keys", cmd->batch.keys.size);
+	as_v8_debug(log, "Executing BatchGet command for %d keys", cmd->batch.keys.size);
 	if (aerospike_batch_get(cmd->as, &cmd->err, cmd->policy, &cmd->batch, batch_callback, cmd) != AEROSPIKE_OK) {
 		cmd->results = NULL;
-		cmd->n = 0;
+		cmd->results_len = 0;
 	}
 	as_batch_destroy(&cmd->batch);
 }
@@ -128,22 +126,16 @@ respond(uv_work_t* req, int status)
 	Nan::HandleScope scope;
 	BatchGetCommand* cmd = reinterpret_cast<BatchGetCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	uint32_t num_rec = cmd->n;
-	as_batch_read* batch_results = cmd->results;
 
-	const int argc = 2;
-	Local<Value> argv[2];
-	if (cmd->IsError() || num_rec == 0 || batch_results == NULL) {
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
 	} else {
-		int rec_found = 0;
-
-		Local<Array> results = Nan::New<Array>(num_rec);
-		for (uint32_t i = 0; i< num_rec; i++) {
+		as_batch_read* batch_results = cmd->results;
+		Local<Array> results = Nan::New<Array>(cmd->results_len);
+		for (uint32_t i = 0; i< cmd->results_len; i++) {
 			as_status status = batch_results[i].result;
-			as_record * record = &batch_results[i].record;
-			const as_key * key = batch_results[i].key;
+			as_record* record = &batch_results[i].record;
+			const as_key* key = batch_results[i].key;
 
 			Local<Object> result = Nan::New<Object>();
 			result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
@@ -152,9 +144,8 @@ respond(uv_work_t* req, int status)
 			if (batch_results[i].result == AEROSPIKE_OK) {
 				result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
 				result->Set(Nan::New("bins").ToLocalChecked(), recordbins_to_jsobject(record, log));
-				rec_found++;
 			} else {
-				as_v8_debug(log, "Record[%d] not returned by server", i);
+				as_v8_debug(log, "Record [%d] not returned by server", i);
 			}
 
 			as_key_destroy((as_key*) key);
@@ -163,12 +154,12 @@ respond(uv_work_t* req, int status)
 			results->Set(i, result);
 		}
 
-		as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = (results);
+		Local<Value> argv[] = {
+			Nan::Null(),
+			results
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -89,7 +89,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	BatchGetCommand* cmd = new BatchGetCommand(client, info[2].As<Function>());
 	LogInfo* log = client->log;
 
-	Local<Array> keys = Local<Array>::Cast(info[0]);
+	Local<Array> keys = info[0].As<Array>();
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
 		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -15,318 +15,170 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_key.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/as_key.h>
-    #include <aerospike/as_record.h>
-    #include <aerospike/aerospike_batch.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_key.h>
+#include <aerospike/as_config.h>
+#include <aerospike/as_key.h>
+#include <aerospike/as_record.h>
+#include <aerospike/aerospike_batch.h>
 }
 
 using namespace v8;
 
-/*******************************************************************************
- *      TYPES
- ******************************************************************************/
+class BatchGetCommand : public AerospikeCommand {
+	public:
+		BatchGetCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("BatchGet", client, callback_) { }
 
-/**
- *      BatchGetCmd — Data to be used in async calls.
- */
-typedef struct BatchGetCmd {
-    aerospike * as;
-    int node_err;            // To Keep track of the parameter errors from Nodejs
-    as_error err;
-    as_policy_batch* policy;
-    as_batch batch;          // Passed as input to aerospike_batch_get
-    as_batch_read  *results; // Results from a aerospike_batch_get operation
-    uint32_t n;
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} BatchGetCmd;
+		~BatchGetCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (results != NULL) cf_free(results);
+		}
 
+		as_policy_batch* policy = NULL;
+		as_batch batch;
+		as_batch_read* results = NULL;
+		uint32_t n = 0;
+};
 
-
-/*******************************************************************************
- *      FUNCTIONS
- ******************************************************************************/
-
-bool batch_callback(const as_batch_read * results, uint32_t n, void * udata)
+bool
+batch_callback(const as_batch_read* results, uint32_t n, void* udata)
 {
-    // Fetch the BatchGetCmd structure
-    BatchGetCmd* cmd = reinterpret_cast<BatchGetCmd*>(udata);
-    LogInfo* log = cmd->log;
-    //copy the batch result to the shared data structure BatchGetCmd,
-    //so that response can send it back to nodejs layer
-    //as_batch_read* batch_result = &cmd->results;
-    if( results != NULL ) {
-        as_v8_debug(log, "Bridge callback invoked in V8 for the batch request of %d records ", n);
-        cmd->n = n;
-        cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
-        for ( uint32_t i = 0; i < n; i++ ) {
-            cmd->results[i].result = results[i].result;
-            as_v8_debug(log, "batch result for the key");
-            key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
-            if (results[i].result == AEROSPIKE_OK) {
-                as_record* rec = &cmd->results[i].record;
+	BatchGetCommand* cmd = reinterpret_cast<BatchGetCommand*>(udata);
+	LogInfo* log = cmd->log;
 
-                as_v8_detail(log, "Record[%d]", i);
+	if (results == NULL) {
+		as_v8_info(log, "Brigde callback for batch called with no batch results");
+		cmd->n = 0;
+		cmd->results = NULL;
+		return false;
+	}
 
-                as_record_init(rec, results[i].record.bins.size);
-                record_clone(&results[i].record, &rec, log);
-            }
-        }
-        return true;
-    }
-    else {
-        as_v8_info(log, "Brigde callback in v8 for batch called with no batch results");
-        cmd->n = 0;
-        cmd->results = NULL;
-    }
-    return false;
+	//copy the batch result to the shared data structure BatchGetCmd,
+	//so that response can send it back to nodejs layer
+	//as_batch_read* batch_result = &cmd->results;
+	as_v8_debug(log, "Bridge callback invoked for the a batch request of %d records ", n);
+	cmd->n = n;
+	cmd->results = (as_batch_read*) calloc(n, sizeof(as_batch_read));
+
+	for ( uint32_t i = 0; i < n; i++ ) {
+		cmd->results[i].result = results[i].result;
+		key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
+		if (results[i].result == AEROSPIKE_OK) {
+			as_record* rec = &cmd->results[i].record;
+			as_record_init(rec, results[i].record.bins.size);
+			record_clone(&results[i].record, &rec, log);
+		}
+	}
+
+	return true;
 }
 
-/**
- *      prepare() — Function to prepare BatchGetCmd, for use in `execute()` and `respond()`.
- *
- *      This should only keep references to V8 or V8 structures for use in
- *      `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 {
-    Nan::HandleScope scope;
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	BatchGetCommand* cmd = new BatchGetCommand(client, info[2].As<Function>());
+	LogInfo* log = client->log;
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	Local<Array> keys = Local<Array>::Cast(info[0]);
+	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+	}
 
-    // Build the async data
-    BatchGetCmd* cmd = new BatchGetCmd();
-    cmd->as = client->as;
-    cmd->node_err = 0;
-    cmd->n = 0;
-    cmd->results = NULL;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	if (info[1]->IsObject() ) {
+		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
+		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+		}
+	}
 
-    Local<Value> maybe_keys = info[0];
-    Local<Value> maybe_policy = info[1];
-    Local<Value> maybe_callback = info[2];
-
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "batch_get callback registered");
-    } else {
-        as_v8_error(log, "Arglist must contain a callback function");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_keys->IsArray() ) {
-        Local<Array> keys = Local<Array>::Cast(maybe_keys);
-        if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "parsing batch keys failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else {
-        as_v8_error(log, "Batch key must be an array of key objects");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_policy->IsObject() ) {
-        cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-        if (batchpolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "Parsing batch policy failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else if (maybe_policy->IsNull() || maybe_policy->IsUndefined()) {
-        // policy is an optional parameter - ignore if missing
-    } else {
-        as_v8_error(log, "Batch policy must be an object");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    return cmd;
-
-Err_Return:
-    cmd->node_err = 1;
-    return cmd;
+	return cmd;
 }
 
-/**
- *      execute() — Function to execute inside the worker-thread.
- *
- *      It is not safe to access V8 or V8 data structures here, so everything
- *      we need for input and output should be in the BatchGetCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t * req)
 {
-    // Fetch the BatchGetCmd structure
-    BatchGetCmd* cmd = reinterpret_cast<BatchGetCmd*>(req->data);
+	BatchGetCommand* cmd = reinterpret_cast<BatchGetCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Data to be used.
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_batch* batch = &cmd->batch;
-    as_policy_batch* policy= cmd->policy;
-    LogInfo* log = cmd->log;
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if( as->cluster == NULL) {
-        as_v8_error(log, "Cluster Object is NULL, can't perform the operation");
-        cmd->node_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-    }
-
-    // Invoke the blocking call.
-    // Check for no parameter errors from Nodejs
-    if (cmd->node_err == 0) {
-        as_v8_debug(log, "Submitting batch request to server with %d keys", batch->keys.size);
-        aerospike_batch_get(as, err, policy, batch, batch_callback, (void*) req->data);
-        if( err->code != AEROSPIKE_OK) {
-            cmd->results = NULL;
-            cmd->n = 0;
-        }
-        as_batch_destroy(batch);
-    }
+	as_v8_debug(log, "Submitting batch request to server with %d keys", cmd->batch.keys.size);
+	if (aerospike_batch_get(cmd->as, &cmd->err, cmd->policy, &cmd->batch, batch_callback, cmd) != AEROSPIKE_OK) {
+		cmd->results = NULL;
+		cmd->n = 0;
+	}
+	as_batch_destroy(&cmd->batch);
 }
 
-/**
- *  respond() — Function to be called after `execute()`. Used to send response
- *  to the callback.
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
-    Nan::HandleScope scope;
-    // Fetch the BatchGetCmd structure
-    BatchGetCmd* cmd = reinterpret_cast<BatchGetCmd*>(req->data);
-    as_error* err = &cmd->err;
-    uint32_t num_rec = cmd->n;
-    as_batch_read* batch_results = cmd->results;
+	Nan::HandleScope scope;
+	BatchGetCommand* cmd = reinterpret_cast<BatchGetCommand*>(req->data);
+	LogInfo* log = cmd->log;
+	uint32_t num_rec = cmd->n;
+	as_batch_read* batch_results = cmd->results;
 
-    LogInfo* log = cmd->log;
+	const int argc = 2;
+	Local<Value> argv[2];
+	if (cmd->IsError() || num_rec == 0 || batch_results == NULL) {
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = Nan::Null();
+	} else {
+		int rec_found = 0;
 
-    // Build the arguments array for the callback
-    Local<Value> argv[2];
+		Local<Array> results = Nan::New<Array>(num_rec);
+		for (uint32_t i = 0; i< num_rec; i++) {
+			as_status status = batch_results[i].result;
+			as_record * record = &batch_results[i].record;
+			const as_key * key = batch_results[i].key;
 
-    if (cmd->node_err == 1) {
-        // Sets the err->code and err->message in the 'err' variable
-        err->func = NULL;
-        err->line = 0;
-        err->file = NULL;
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else if ( num_rec == 0 || batch_results == NULL ) {
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else {
+			Local<Object> result = Nan::New<Object>();
+			result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
+			result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key ? key : &record->key, log));
 
-        int rec_found = 0;
+			if (batch_results[i].result == AEROSPIKE_OK) {
+				result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
+				result->Set(Nan::New("bins").ToLocalChecked(), recordbins_to_jsobject(record, log));
+				rec_found++;
+			} else {
+				as_v8_debug(log, "Record[%d] not returned by server", i);
+			}
 
-        // the result is an array of batch results
-        Local<Array> results = Nan::New<Array>(num_rec);
+			as_key_destroy((as_key*) key);
+			as_record_destroy(record);
 
-        for ( uint32_t i = 0; i< num_rec; i++) {
+			results->Set(i, result);
+		}
 
-            as_status status = batch_results[i].result;
-            as_record * record = &batch_results[i].record;
-            const as_key * key = batch_results[i].key;
+		as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = (results);
+	}
 
-            // a batch result object attributes:
-            //   - status
-            //   - key
-            //   - metadata
-            //   - record
-            Local<Object> result = Nan::New<Object>();
+	cmd->Callback(argc, argv);
 
-            // status attribute
-            result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
-
-            // key attribute - should always be sent
-            result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key ? key : &record->key, log));
-
-            if( batch_results[i].result == AEROSPIKE_OK ) {
-
-                // metadata attribute
-                result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
-
-                // record attribute
-                result->Set(Nan::New("bins").ToLocalChecked(), recordbins_to_jsobject(record, log));
-
-                rec_found++;
-            }
-            else {
-                as_v8_debug(log, "Record[%d] not returned by server ", i);
-            }
-
-            // clean up
-            as_key_destroy((as_key *) key);
-            as_record_destroy(record);
-
-            // append to the result array
-            results->Set(i, result);
-        }
-
-        as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = (results);
-    }
-
-    // Surround the callback in a try/catch for safety`
-    Nan::TryCatch try_catch;
-
-    // Execute the callback.
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 2, argv);
-
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        Nan::FatalException(try_catch);
-    }
-
-    as_v8_debug(log,"Invoked the callback");
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-    if (cmd->node_err == 1) {
-        free(cmd->results);
-    }
-    if (batch_results != NULL) {
-        free(batch_results);
-    }
-
-    if (cmd->policy != NULL) {
-        cf_free(cmd->policy);
-    }
-    as_v8_debug(log, "Cleaned up the resources");
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *      The 'batchGet()' Operation
- */
 NAN_METHOD(AerospikeClient::BatchGet)
 {
-    async_invoke(info, prepare, execute, respond);
-}
+	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
+	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
+	async_invoke(info, prepare, execute, respond);
+}

--- a/src/main/commands/batch_read_async.cc
+++ b/src/main/commands/batch_read_async.cc
@@ -38,7 +38,7 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	as_policy_batch* p_policy = NULL;
 	as_status status;
 
-	if (batch_read_records_from_jsarray(&records, Local<Array>::Cast(info[0]), log) != AS_NODE_PARAM_OK) {
+	if (batch_read_records_from_jsarray(&records, info[0].As<Array>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Records array invalid");
 		return;
 	}

--- a/src/main/commands/batch_read_async.cc
+++ b/src/main/commands/batch_read_async.cc
@@ -29,11 +29,8 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	AsyncCommand* cmd = new AsyncCommand(client, info[2].As<Function>());
 	LogInfo* log = client->log;
-
-	CallbackData* data = new CallbackData();
-	data->client = client;
-	data->callback.Reset(info[2].As<Function>());
 
 	as_batch_read_records* records = NULL;
 	as_policy_batch policy;
@@ -43,14 +40,14 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 
 	if (batch_read_records_from_jsarray(&records, Local<Array>::Cast(info[0]), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Records array invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 		return;
 	}
 
 	if (info[1]->IsObject()) {
 		if (batchpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, data);
+			invoke_error_callback(&err, cmd);
 			free_batch_records(records);
 			return;
 		}
@@ -58,9 +55,9 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	}
 
 	as_v8_debug(log, "Sending async batch read command\n");
-	status = aerospike_batch_read_async(client->as, &err, p_policy, records, async_batch_listener, data, NULL);
+	status = aerospike_batch_read_async(client->as, &err, p_policy, records, async_batch_listener, cmd, NULL);
 	if (status != AEROSPIKE_OK) {
 		free_batch_records(records);
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 	}
 }

--- a/src/main/commands/batch_read_async.cc
+++ b/src/main/commands/batch_read_async.cc
@@ -16,6 +16,7 @@
 
 #include "client.h"
 #include "async.h"
+#include "command.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
@@ -24,9 +25,9 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::BatchReadAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsArray, "records must be an array of objects");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsArray, "Records must be an array of objects");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("BatchRead", client, info[2].As<Function>());
@@ -38,15 +39,13 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	as_status status;
 
 	if (batch_read_records_from_jsarray(&records, Local<Array>::Cast(info[0]), log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Records array invalid");
-		invoke_error_callback(cmd);
+		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Records array invalid");
 		return;
 	}
 
 	if (info[1]->IsObject()) {
 		if (batchpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			free_batch_records(records);
 			return;
 		}
@@ -54,9 +53,10 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	}
 
 	as_v8_debug(log, "Sending async batch read command\n");
-	status = aerospike_batch_read_async(client->as, &cmd->err, p_policy, records, async_batch_listener, cmd, NULL);
+	status = aerospike_batch_read_async(client->as, &cmd->err, p_policy,
+			records, async_batch_listener, cmd, NULL);
 	if (status != AEROSPIKE_OK) {
 		free_batch_records(records);
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 }

--- a/src/main/commands/batch_select.cc
+++ b/src/main/commands/batch_select.cc
@@ -94,12 +94,12 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	BatchSelectCommand* cmd = new BatchSelectCommand(client, info[3].As<Function>());
 	LogInfo* log = client->log;
 
-	Local<Array> keys = Local<Array>::Cast(info[0]);
+	Local<Array> keys = info[0].As<Array>();
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
 		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}
 
-	Local<Array> bins = Local<Array>::Cast(info[1]);
+	Local<Array> bins = info[1].As<Array>();
 	if (bins_from_jsarray(&cmd->bins, &cmd->numbins, bins, log) != AS_NODE_PARAM_OK) {
 		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch bins parameter invalid");
 	}

--- a/src/main/commands/batch_select.cc
+++ b/src/main/commands/batch_select.cc
@@ -15,343 +15,180 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_key.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/as_key.h>
-    #include <aerospike/as_record.h>
-    #include <aerospike/aerospike_batch.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_key.h>
+#include <aerospike/as_config.h>
+#include <aerospike/as_key.h>
+#include <aerospike/as_record.h>
+#include <aerospike/aerospike_batch.h>
 }
 
 using namespace v8;
 
-/*******************************************************************************
- *      TYPES
- ******************************************************************************/
+class BatchSelectCommand : public AerospikeCommand {
+	public:
+		BatchSelectCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("BatchSelect", client, callback_) { }
 
-/**
- *      BatchSelectCmd — Data to be used in async calls.
- */
-typedef struct BatchSelectCmd {
-    aerospike * as;
-    int node_err;            // To Keep track of the parameter errors from Nodejs
-    as_error err;
-    as_policy_batch* policy;
-    as_batch batch;          // Passed as input to aerospike_batch_get
-    as_batch_read  *results; // Results from a aerospike_batch_get operation
-    uint32_t n;
-    uint32_t numbins;
-    char** bins;
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} BatchSelectCmd;
+		~BatchSelectCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (results != NULL) cf_free(results);
+			for (uint32_t i = 0; i < numbins; i++) {
+				cf_free(bins[i]);
+			}
+			cf_free(bins);
+		}
 
-/*******************************************************************************
- *      FUNCTIONS
- ******************************************************************************/
+	as_policy_batch* policy = NULL;
+	as_batch batch;
+	as_batch_read* results = NULL;
+	uint32_t n = 0;
+	uint32_t numbins = 0;
+	char** bins = NULL;
+};
 
-bool batch_select_callback(const as_batch_read * results, uint32_t n, void * udata)
+bool
+batch_select_callback(const as_batch_read* results, uint32_t n, void* udata)
 {
-    // Fetch the BatchSelectCmd structure
-    BatchSelectCmd* cmd = reinterpret_cast<BatchSelectCmd*>(udata);
-    LogInfo* log = cmd->log;
-    //copy the batch result to the shared data structure BatchSelectCmd,
-    //so that response can send it back to nodejs layer
-    if( results != NULL ) {
-        as_v8_debug(log, "Bridge callback invoked in V8 for the batch request of %d records ", n);
-        cmd->n = n;
-        cmd->results = (as_batch_read*) cf_calloc(n, sizeof(as_batch_read));
-        for ( uint32_t i = 0; i < n; i++ ) {
-            cmd->results[i].result = results[i].result;
-            as_v8_debug(log, "batch result for the key");
-            key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
-            if (results[i].result == AEROSPIKE_OK) {
-                as_record* rec = &cmd->results[i].record;
+	BatchSelectCommand* cmd = reinterpret_cast<BatchSelectCommand*>(udata);
+	LogInfo* log = cmd->log;
 
-                as_v8_detail(log, "Record[%d]", i);
+	if (results == NULL) {
+		as_v8_info(log, "Brigde callback for batch called with no batch results");
+		cmd->n = 0;
+		cmd->results = NULL;
+		return false;
+	}
 
-                as_record_init(rec, results[i].record.bins.size);
-                record_clone(&results[i].record, &rec, log);
-            }
-        }
-        return true;
-    }
-    else {
-        as_v8_info(log, "Brigde callback in v8 for batch called with no batch results");
-        cmd->n = 0;
-        cmd->results = NULL;
-    }
-    return false;
+	// Copy the batch result to the shared data structure BatchSelectCommand,
+	// so that response can send it back to nodejs layer.
+	as_v8_debug(log, "Bridge callback invoked for the batch request of %d records ", n);
+	cmd->n = n;
+	cmd->results = (as_batch_read*) cf_calloc(n, sizeof(as_batch_read));
+
+	for (uint32_t i = 0; i < n; i++) {
+		cmd->results[i].result = results[i].result;
+		key_clone(results[i].key, (as_key**) &cmd->results[i].key, log);
+		if (results[i].result == AEROSPIKE_OK) {
+			as_record* rec = &cmd->results[i].record;
+			as_record_init(rec, results[i].record.bins.size);
+			record_clone(&results[i].record, &rec, log);
+		}
+	}
+
+	return true;
 }
 
-/**
- *      prepare() — Function to prepare BatchSelectCmd, for use in `execute()` and `respond()`.
- *
- *      This should only keep references to V8 or V8 structures for use in
- *      `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 {
-    Nan::HandleScope scope;
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	BatchSelectCommand* cmd = new BatchSelectCommand(client, info[3].As<Function>());
+	LogInfo* log = client->log;
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	Local<Array> keys = Local<Array>::Cast(info[0]);
+	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+	}
 
-    // Build the async data
-    BatchSelectCmd* cmd = new BatchSelectCmd();
-    cmd->as = client->as;
-    cmd->node_err = 0;
-    cmd->n = 0;
-    cmd->results = NULL;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	Local<Array> bins = Local<Array>::Cast(info[1]);
+	if (bins_from_jsarray(&cmd->bins, &cmd->numbins, bins, log) != AS_NODE_PARAM_OK) {
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch bins parameter invalid");
+	}
 
-    Local<Value> maybe_keys = info[0];
-    Local<Value> maybe_bins = info[1];
-    Local<Value> maybe_policy = info[2];
-    Local<Value> maybe_callback = info[3];
+	if (info[2]->IsObject() ) {
+		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
+		if (batchpolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+		}
+	}
 
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "batch_get callback registered");
-    } else {
-        as_v8_error(log, "Arglist must contain a callback function");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_keys->IsArray()) {
-        Local<Array> keys = Local<Array>::Cast(maybe_keys);
-        if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "parsing batch keys failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else {
-        as_v8_error(log, "Batch key must be an array of key objects");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    if (maybe_bins->IsArray() ) {
-        Local<Array> bins = Local<Array>::Cast(maybe_bins);
-        int res = bins_from_jsarray(&cmd->bins, &cmd->numbins, bins, log);
-        if (res != AS_NODE_PARAM_OK) {
-            as_v8_error(log,"Parsing bins failed in select ");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else {
-        as_v8_error(log, "Bin names should be an array of string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-
-    }
-
-    if (maybe_policy->IsObject() ) {
-        cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-        if (batchpolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "Parsing batch policy failed");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            goto Err_Return;
-        }
-    } else if (maybe_policy->IsNull() || maybe_policy->IsUndefined()) {
-        // policy is an optional parameter - ignore if missing
-    } else {
-        as_v8_error(log, "Batch policy must be an object");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        goto Err_Return;
-    }
-
-    return cmd;
-
-Err_Return:
-    cmd->node_err = 1;
-    return cmd;
+	return cmd;
 }
 
-/**
- *      execute() — Function to execute inside the worker-thread.
- *
- *      It is not safe to access V8 or V8 data structures here, so everything
- *      we need for input and output should be in the BatchSelectCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the BatchSelectCmd structure
-    BatchSelectCmd* cmd = reinterpret_cast<BatchSelectCmd*>(req->data);
+	BatchSelectCommand* cmd = reinterpret_cast<BatchSelectCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Data to be used.
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_batch* batch = &cmd->batch;
-    as_policy_batch* policy= cmd->policy;
-    LogInfo* log = cmd->log;
-    const char** bins = (const char**) cmd->bins;
-    uint32_t numbins = cmd->numbins;
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if( as->cluster == NULL) {
-        as_v8_error(log, "Cluster Object is NULL, can't perform the operation");
-        cmd->node_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-    }
-
-    // Invoke the blocking call.
-    // Check for no parameter errors from Nodejs
-    if (cmd->node_err == 0) {
-        as_v8_debug(log, "Submitting batch request to server with %d keys", batch->keys.size);
-        aerospike_batch_get_bins(as, err, policy, batch, bins, numbins, batch_select_callback, (void*) req->data);
-        if( err->code != AEROSPIKE_OK) {
-            cmd->results = NULL;
-            cmd->n = 0;
-        }
-        as_batch_destroy(batch);
-    }
-
+	as_v8_debug(log, "Submitting batch request to server with %d keys", cmd->batch.keys.size);
+	if (aerospike_batch_get_bins(cmd->as, &cmd->err, cmd->policy, &cmd->batch, (const char**) cmd->bins, cmd->numbins, batch_select_callback, cmd) != AEROSPIKE_OK) {
+		cmd->results = NULL;
+		cmd->n = 0;
+	}
+	as_batch_destroy(&cmd->batch);
 }
 
-
-/**
- *  respond() — Function to be called after `execute()`. Used to send response
- *  to the callback.
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
-    Nan::HandleScope scope;
-    // Fetch the BatchSelectCmd structure
-    BatchSelectCmd* cmd = reinterpret_cast<BatchSelectCmd*>(req->data);
-    as_error* err = &cmd->err;
-    uint32_t num_rec = cmd->n;
-    as_batch_read* batch_results = cmd->results;
+	Nan::HandleScope scope;
+	BatchSelectCommand* cmd = reinterpret_cast<BatchSelectCommand*>(req->data);
+	LogInfo* log = cmd->log;
+	uint32_t num_rec = cmd->n;
+	as_batch_read* batch_results = cmd->results;
 
-    LogInfo* log = cmd->log;
+	const int argc = 2;
+	Local<Value> argv[2];
+	if (cmd->IsError() || num_rec == 0 || batch_results == NULL) {
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = Nan::Null();
+	} else {
+		int rec_found = 0;
 
-    // Build the arguments array for the callback
-    Local<Value> argv[2];
+		Local<Array> results = Nan::New<Array>(num_rec);
+		for (uint32_t i = 0; i< num_rec; i++) {
+			as_status status = batch_results[i].result;
+			as_record * record = &batch_results[i].record;
+			const as_key * key = batch_results[i].key;
 
-    if (cmd->node_err == 1) {
-        // Sets the err->code and err->message in the 'err' variable
-        err->func = NULL;
-        err->line = 0;
-        err->file = NULL;
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else if ( num_rec == 0 || batch_results == NULL ) {
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = Nan::Null();
-    }
-    else {
+			Local<Object> result = Nan::New<Object>();
+			result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
+			result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key ? key : &record->key, log));
 
-        int rec_found = 0;
+			if (batch_results[i].result == AEROSPIKE_OK) {
+				result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
+				result->Set(Nan::New("bins").ToLocalChecked(), recordbins_to_jsobject(record, log));
+				rec_found++;
+			} else {
+				as_v8_debug(log, "Record[%d] not returned by server ", i);
+			}
 
-        // the result is an array of batch results
-        Local<Array> results = Nan::New<Array>(num_rec);
+			as_key_destroy((as_key*) key);
+			as_record_destroy(record);
+			results->Set(i, result);
+		}
 
-        for ( uint32_t i = 0; i< num_rec; i++) {
+		as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
+		argv[0] = error_to_jsobject(&cmd->err, log);
+		argv[1] = (results);
+	}
 
-            as_status status = batch_results[i].result;
-            as_record * record = &batch_results[i].record;
-            const as_key * key = batch_results[i].key;
+	cmd->Callback(argc, argv);
 
-            // a batch result object attributes:
-            //   - status
-            //   - key
-            //   - metadata
-            //   - record
-            Local<Object> result = Nan::New<Object>();
-
-            // status attribute
-            result->Set(Nan::New("status").ToLocalChecked(), Nan::New(status));
-
-            // key attribute - should always be sent
-            result->Set(Nan::New("key").ToLocalChecked(), key_to_jsobject(key ? key : &record->key, log));
-
-            if( batch_results[i].result == AEROSPIKE_OK ) {
-
-                // metadata attribute
-                result->Set(Nan::New("meta").ToLocalChecked(), recordmeta_to_jsobject(record, log));
-
-                // record attribute
-                result->Set(Nan::New("bins").ToLocalChecked(), recordbins_to_jsobject(record, log));
-
-                rec_found++;
-            }
-            else {
-                as_v8_debug(log, "Record[%d] not returned by server ", i);
-            }
-
-            // clean up
-            as_key_destroy((as_key *) key);
-            as_record_destroy(record);
-
-            // append to the result array
-            results->Set(i, result);
-        }
-
-        as_v8_debug(log, "%d record objects are present in the batch array",  rec_found);
-        argv[0] = error_to_jsobject(err, log);
-        argv[1] = (results);
-    }
-
-    // Surround the callback in a try/catch for safety`
-    Nan::TryCatch try_catch;
-
-    // Execute the callback.
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 2, argv);
-
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        Nan::FatalException(try_catch);
-    }
-
-    as_v8_debug(log,"Invoked the callback");
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-     for (uint32_t i = 0; i < cmd->numbins; i++) {
-         cf_free(cmd->bins[i]);
-     }
-     cf_free(cmd->bins);
-
-    if (cmd->node_err == 1) {
-        cf_free(cmd->results);
-    }
-    if (batch_results != NULL) {
-        cf_free(batch_results);
-    }
-    if (cmd->policy != NULL) {
-        cf_free(cmd->policy);
-    }
-
-    as_v8_debug(log, "Cleaned up the resources");
-
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *      The 'batchGet()' Operation
- */
 NAN_METHOD(AerospikeClient::BatchSelect)
 {
-    async_invoke(info, prepare, execute, respond);
-}
+	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
+	TYPE_CHECK_REQ(info[1], IsArray, "bins must be a array");
+	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
 
+	async_invoke(info, prepare, execute, respond);
+}

--- a/src/main/commands/batch_select.cc
+++ b/src/main/commands/batch_select.cc
@@ -96,18 +96,18 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	Local<Array> keys = Local<Array>::Cast(info[0]);
 	if (batch_from_jsarray(&cmd->batch, keys, log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch keys parameter invalid");
 	}
 
 	Local<Array> bins = Local<Array>::Cast(info[1]);
 	if (bins_from_jsarray(&cmd->bins, &cmd->numbins, bins, log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch bins parameter invalid");
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch bins parameter invalid");
 	}
 
 	if (info[2]->IsObject() ) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
 		if (batchpolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}
 

--- a/src/main/commands/batch_select.cc
+++ b/src/main/commands/batch_select.cc
@@ -185,10 +185,10 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::BatchSelect)
 {
-	TYPE_CHECK_REQ(info[0], IsArray, "keys must be a array");
-	TYPE_CHECK_REQ(info[1], IsArray, "bins must be a array");
-	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsArray, "Keys must be a array");
+	TYPE_CHECK_REQ(info[1], IsArray, "Bins must be a array");
+	TYPE_CHECK_OPT(info[2], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/exists_async.cc
+++ b/src/main/commands/exists_async.cc
@@ -25,9 +25,9 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::ExistsAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsObject, "key must be an object");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsObject, "Key must be an object");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("Exists", client, info[2].As<Function>());
@@ -40,16 +40,14 @@ NAN_METHOD(AerospikeClient::ExistsAsync)
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(cmd);
+		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
 		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -58,7 +56,7 @@ NAN_METHOD(AerospikeClient::ExistsAsync)
 	as_v8_debug(log, "Sending async exists command\n");
 	status = aerospike_key_exists_async(client->as, &cmd->err, p_policy, &key, async_record_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 
 Cleanup:

--- a/src/main/commands/get_async.cc
+++ b/src/main/commands/get_async.cc
@@ -29,11 +29,8 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	AsyncCommand* cmd = new AsyncCommand(client, info[2].As<Function>());
 	LogInfo* log = client->log;
-
-	CallbackData* data = new CallbackData();
-	data->client = client;
-	data->callback.Reset(info[2].As<Function>());
 
 	as_key key;
 	bool key_initalized = false;
@@ -44,7 +41,7 @@ NAN_METHOD(AerospikeClient::GetAsync)
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
@@ -52,16 +49,16 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	if (info[1]->IsObject()) {
 		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, data);
+			invoke_error_callback(&err, cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async get command\n");
-	status = aerospike_key_get_async(client->as, &err, p_policy, &key, async_record_listener, data, NULL, NULL);
+	status = aerospike_key_get_async(client->as, &err, p_policy, &key, async_record_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/get_async.cc
+++ b/src/main/commands/get_async.cc
@@ -40,16 +40,14 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(cmd);
+		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
 		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -58,7 +56,7 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	as_v8_debug(log, "Sending async get command\n");
 	status = aerospike_key_get_async(client->as, &cmd->err, p_policy, &key, async_record_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 
 Cleanup:

--- a/src/main/commands/get_async.cc
+++ b/src/main/commands/get_async.cc
@@ -16,6 +16,7 @@
 
 #include "client.h"
 #include "async.h"
+#include "command.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
@@ -29,36 +30,35 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-	AsyncCommand* cmd = new AsyncCommand(client, info[2].As<Function>());
+	AsyncCommand* cmd = new AsyncCommand("Get", client, info[2].As<Function>());
 	LogInfo* log = client->log;
 
 	as_key key;
 	bool key_initalized = false;
 	as_policy_read policy;
 	as_policy_read* p_policy = NULL;
-	as_error err;
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, cmd);
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
+		invoke_error_callback(cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
 		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, cmd);
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
+			invoke_error_callback(cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async get command\n");
-	status = aerospike_key_get_async(client->as, &err, p_policy, &key, async_record_listener, cmd, NULL, NULL);
+	status = aerospike_key_get_async(client->as, &cmd->err, p_policy, &key, async_record_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, cmd);
+		invoke_error_callback(cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/get_async.cc
+++ b/src/main/commands/get_async.cc
@@ -25,9 +25,9 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::GetAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsObject, "key must be an object");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsObject, "Key must be an object");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("Get", client, info[2].As<Function>());

--- a/src/main/commands/index_create.cc
+++ b/src/main/commands/index_create.cc
@@ -106,13 +106,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	IndexCreateCommand* cmd = reinterpret_cast<IndexCreateCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[argc];
-	argv[0] = error_to_jsobject(&cmd->err, log);
-
-	cmd->Callback(argc, argv);
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
+	} else {
+		cmd->Callback(0, {});
+	}
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/index_create.cc
+++ b/src/main/commands/index_create.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -57,11 +58,11 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	IndexCreateCommand* cmd = new IndexCreateCommand(client, info[7].As<Function>());
 	LogInfo* log = client->log;
 
-	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
 	if (info[1]->IsString()) {
-		strncpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
+		strlcpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
 	}
-	strncpy(cmd->bin, *String::Utf8Value(info[2]->ToString()), AS_BIN_NAME_MAX_LEN);
+	strlcpy(cmd->bin, *String::Utf8Value(info[2]->ToString()), AS_BIN_NAME_MAX_LEN);
 	cmd->index = strdup(*String::Utf8Value(info[3]->ToString()));
 	cmd->itype = (as_index_type) info[4]->ToInteger()->Value();
 	cmd->dtype = (as_index_datatype) info[5]->ToInteger()->Value();

--- a/src/main/commands/index_create.cc
+++ b/src/main/commands/index_create.cc
@@ -15,255 +15,110 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/aerospike_index.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/as_config.h>
+#include <aerospike/aerospike_index.h>
 }
 
 using namespace v8;
 
-/*******************************************************************************
- *  TYPES
- ******************************************************************************/
+class IndexCreateCommand : public AerospikeCommand {
+	public:
+		IndexCreateCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("IndexCreate", client, callback_) { }
 
-/**
- *  IndexCreateCmd — Data to be used in async calls.
- *
- *  libuv allows us to pass around a pointer to an arbitraty object when
- *  running asynchronous functions. We create a data structure to hold the
- *  data we need during and after async work.
- */
-typedef struct IndexCreateCmd {
-    aerospike * as;
-    int param_err;
-    as_error err;
-    as_index_task task;
-    as_policy_info* policy;
-    as_namespace ns;
-    as_set set;
-    as_bin_name bin;
-    char * index;
-	as_index_type itype;
-    as_index_datatype dtype;
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} IndexCreateCmd;
+		~IndexCreateCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (index != NULL) free(index);
+		}
 
+		as_index_task task;
+		as_policy_info* policy = NULL;
+		as_namespace ns;
+		as_set set;
+		as_bin_name bin;
+		char* index = NULL;
+		as_index_type itype;
+		as_index_datatype dtype;
+};
 
-/*******************************************************************************
- *  FUNCTIONS
- ******************************************************************************/
-
-/**
- *  prepare() — Function to prepare IndexCreateCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
-    Nan::HandleScope scope;
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	IndexCreateCommand* cmd = new IndexCreateCommand(client, info[7].As<Function>());
+	LogInfo* log = client->log;
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	if (info[1]->IsString()) {
+		strncpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
+	}
+	strncpy(cmd->bin, *String::Utf8Value(info[2]->ToString()), AS_BIN_NAME_MAX_LEN);
+	cmd->index = strdup(*String::Utf8Value(info[3]->ToString()));
+	cmd->itype = (as_index_type) info[4]->ToInteger()->Value();
+	cmd->dtype = (as_index_datatype) info[5]->ToInteger()->Value();
 
-    IndexCreateCmd* cmd = new IndexCreateCmd();
-    cmd->as = client->as;
-    cmd->param_err = 0;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	if (info[6]->IsObject()) {
+		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
+		if (infopolicy_from_jsobject(cmd->policy, info[6]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+		}
+	}
 
-    Local<Value> maybe_ns = info[0];
-    Local<Value> maybe_set = info[1];
-    Local<Value> maybe_bin = info[2];
-    Local<Value> maybe_index_name = info[3];
-    Local<Value> maybe_index_type = info[4];
-    Local<Value> maybe_index_datatype = info[5];
-    Local<Value> maybe_policy = info[6];
-    Local<Value> maybe_callback = info[7];
-
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "Node.js Callback Registered");
-    } else {
-        as_v8_error(log, "No callback to register");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_ns->IsString()) {
-        strncpy(cmd->ns, *String::Utf8Value(maybe_ns->ToString()), AS_NAMESPACE_MAX_SIZE);
-        as_v8_detail(log, "The index creation on namespace %s", cmd->ns);
-    } else {
-        as_v8_error(log, "namespace should be string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_set->IsString()) {
-        strncpy(cmd->set, *String::Utf8Value(maybe_set->ToString()), AS_SET_MAX_SIZE);
-        as_v8_detail(log, "The index creation on set %s", cmd->set);
-    }
-
-    if (maybe_bin->IsString()) {
-        strncpy(cmd->bin, *String::Utf8Value(maybe_bin->ToString()), AS_BIN_NAME_MAX_LEN);
-        as_v8_detail(log, "The index creation on bin %s", cmd->bin);
-    } else {
-        as_v8_error(log, "bin name should be passed as a string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_index_name->IsString()) {
-        cmd->index = strdup(*String::Utf8Value(maybe_index_name->ToString()));
-        as_v8_detail(log, "The index to be created %s", cmd->index);
-    } else {
-        as_v8_error(log, "index name should be passed as a string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_index_type->IsNumber()) {
-        cmd->itype = (as_index_type) maybe_index_type->ToInteger()->Value();
-        as_v8_detail(log, "The type of the index %d", cmd->itype);
-    } else {
-        as_v8_error(log, "index type should be an integer enumerator");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_index_datatype->IsNumber()) {
-        cmd->dtype = (as_index_datatype) maybe_index_datatype->ToInteger()->Value();
-        as_v8_detail(log, "The data type of the index %d", cmd->dtype);
-    } else {
-        as_v8_error(log, "index data type should be an integer enumerator");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_policy->IsObject()) {
-        cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-        if (infopolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "infopolicy shoule be an object");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            cmd->param_err = 1;
-            return cmd;
-        }
-    }
-
-    return cmd;
+	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the IndexCreateCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the IndexCreateCmd structure
-    IndexCreateCmd* cmd = reinterpret_cast<IndexCreateCmd*>(req->data);
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_policy_info* policy = cmd->policy;
-    LogInfo* log = cmd->log;
-    // Invoke the blocking call.
-    // The error is handled in the calling JS code.
-    if (as->cluster == NULL) {
-        cmd->param_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        as_v8_error(log, "Not connected to cluster to put record");
-    }
+	IndexCreateCommand* cmd = reinterpret_cast<IndexCreateCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    if (cmd->param_err == 0) {
-        as_v8_debug(log, "Invoking aerospike index create");
-        aerospike_index_create_complex(as, err, &cmd->task, policy, cmd->ns,
-                cmd->set, cmd->bin, cmd->index, cmd->itype, cmd->dtype);
-    }
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
+	as_v8_debug(log, "Executing IndexCreate command: ns=%s, set=%s, bin=%s, index=%s, type=%d, datatype=%d",
+			cmd->ns, cmd->set, cmd->bin, cmd->index, cmd->itype, cmd->dtype);
+	aerospike_index_create_complex(cmd->as, &cmd->err, &cmd->task, cmd->policy, cmd->ns,
+			cmd->set, cmd->bin, cmd->index, cmd->itype, cmd->dtype);
 }
 
-/**
- *  AfterWork — Function to execute when the Work is complete
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
+	Nan::HandleScope scope;
+	IndexCreateCommand* cmd = reinterpret_cast<IndexCreateCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    Nan::HandleScope scope;
-    // Fetch the IndexCreateCmd structure
-    IndexCreateCmd* cmd = reinterpret_cast<IndexCreateCmd*>(req->data);
-    as_error* err = &cmd->err;
-    LogInfo* log = cmd->log;
-    as_v8_debug(log, "SINDEX creation : response is");
+	const int argc = 1;
+	Local<Value> argv[argc];
+	argv[0] = error_to_jsobject(&cmd->err, log);
 
-    Local<Value> argv[1];
-    // Build the arguments array for the callback
-    if (cmd->param_err == 0) {
-        argv[0] = error_to_jsobject(err, log);
-    }
-    else {
-        err->func = NULL;
-        as_v8_debug(log, "Parameter error for put operation");
-        argv[0] = error_to_jsobject(err, log);
-    }
+	cmd->Callback(argc, argv);
 
-    // Surround the callback in a try/catch for safety
-    Nan::TryCatch try_catch;
-
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-    // Execute the callback.
-    if ( !cb->IsNull() ) {
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 1, argv);
-        as_v8_debug(log, "Invoked Put callback");
-    }
-
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        Nan::FatalException(try_catch);
-    }
-
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-
-    if ( cmd->param_err == 0) {
-        if( cmd->policy != NULL)
-        {
-            cf_free(cmd->policy);
-        }
-        as_v8_debug(log, "Cleaned up all the structures");
-    }
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *  The 'put()' Operation
- */
 NAN_METHOD(AerospikeClient::IndexCreate)
 {
-    async_invoke(info, prepare, execute, respond);
+	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
+	TYPE_CHECK_REQ(info[2], IsString, "bin must be a string");
+	TYPE_CHECK_REQ(info[3], IsString, "index_name must be a string");
+	TYPE_CHECK_REQ(info[4], IsNumber, "index_type must be an integer");
+	TYPE_CHECK_REQ(info[5], IsNumber, "index_datatype must be an integer");
+	TYPE_CHECK_OPT(info[6], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[7], IsFunction, "callback must be a function");
+
+	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/index_create.cc
+++ b/src/main/commands/index_create.cc
@@ -120,14 +120,14 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::IndexCreate)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_REQ(info[2], IsString, "bin must be a string");
-	TYPE_CHECK_REQ(info[3], IsString, "index_name must be a string");
-	TYPE_CHECK_OPT(info[4], IsNumber, "index_type must be an integer");
-	TYPE_CHECK_REQ(info[5], IsNumber, "index_datatype must be an integer");
-	TYPE_CHECK_OPT(info[6], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[7], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_REQ(info[2], IsString, "Bin must be a string");
+	TYPE_CHECK_REQ(info[3], IsString, "Index name must be a string");
+	TYPE_CHECK_OPT(info[4], IsNumber, "Index type must be an integer");
+	TYPE_CHECK_REQ(info[5], IsNumber, "Index datatype must be an integer");
+	TYPE_CHECK_OPT(info[6], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[7], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -53,13 +53,16 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	IndexRemoveCommand* cmd = new IndexRemoveCommand(client, info[3].As<Function>());
 	LogInfo* log = cmd->log = client->log;
 
-	strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	if (as_strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
+	}
+
 	cmd->index = strdup(*String::Utf8Value(info[1]->ToString()));
 
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*)cf_malloc(sizeof(as_policy_info));
 		if(infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -89,13 +89,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	IndexRemoveCommand* cmd = reinterpret_cast<IndexRemoveCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[1];
-	argv[0] = error_to_jsobject(&cmd->err, log);
-
-	cmd->Callback(argc, argv);
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
+	} else {
+		cmd->Callback(0, {});
+	}
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -52,7 +53,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	IndexRemoveCommand* cmd = new IndexRemoveCommand(client, info[3].As<Function>());
 	LogInfo* log = cmd->log = client->log;
 
-	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
 	cmd->index = strdup(*String::Utf8Value(info[1]->ToString()));
 
 	if (info[2]->IsObject()) {

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -15,211 +15,94 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/aerospike_index.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/as_config.h>
+#include <aerospike/aerospike_index.h>
 }
 
 using namespace v8;
 
-/*******************************************************************************
- *  TYPES
- ******************************************************************************/
+class IndexRemoveCommand : public AerospikeCommand {
+	public:
+		IndexRemoveCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("IndexRemove", client, callback_) { }
 
-/**
- *  IndexRemoveCmd — Data to be used in async calls.
- *
- *  libuv allows us to pass around a pointer to an arbitraty object when
- *  running asynchronous functions. We create a data structure to hold the
- *  data we need during and after async work.
- */
-typedef struct IndexRemoveCmd {
-    aerospike * as;
-    int param_err;
-    as_error err;
-    as_policy_info* policy;
-    as_namespace ns;
-    char * index;
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} IndexRemoveCmd;
+		~IndexRemoveCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (index != NULL) cf_free(index);
+		}
 
+		as_policy_info* policy = NULL;
+		as_namespace ns;
+		char* index = NULL;
+};
 
-/*******************************************************************************
- *  FUNCTIONS
- ******************************************************************************/
-
-/**
- *  prepare() — Function to prepare IndexRemoveCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
-    Nan::HandleScope scope;
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	IndexRemoveCommand* cmd = new IndexRemoveCommand(client, info[3].As<Function>());
+	LogInfo* log = cmd->log = client->log;
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	cmd->index = strdup(*String::Utf8Value(info[1]->ToString()));
 
-    IndexRemoveCmd* cmd = new IndexRemoveCmd();
-    cmd->as = client->as;
-    cmd->param_err = 0;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	if (info[2]->IsObject()) {
+		cmd->policy = (as_policy_info*)cf_malloc(sizeof(as_policy_info));
+		if(infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+		}
+	}
 
-    Local<Value> maybe_ns = info[0];
-    Local<Value> maybe_index_name = info[1];
-    Local<Value> maybe_policy = info[2];
-    Local<Value> maybe_callback = info[3];
-
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "Node.js Callback Registered");
-    } else {
-        as_v8_error(log, "No callback to register");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_ns->IsString()) {
-        strncpy(cmd->ns, *String::Utf8Value(maybe_ns->ToString()), AS_NAMESPACE_MAX_SIZE);
-        as_v8_detail(log, "The index creation on namespace %s", cmd->ns);
-    } else {
-        as_v8_error(log, "namespace should be string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_index_name->IsString()) {
-        cmd->index = strdup(*String::Utf8Value(maybe_index_name->ToString()));
-        as_v8_detail(log, "The index to be created %s", cmd->index);
-    } else {
-        as_v8_error(log, "index name should be passed as a string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_policy->IsObject()) {
-        cmd->policy = (as_policy_info*)cf_malloc(sizeof(as_policy_info));
-        if(infopolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "infopolicy shoule be an object");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            cmd->param_err = 1;
-            return cmd;
-        }
-    }
-
-    return cmd;
+	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the IndexRemoveCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the IndexRemoveCmd structure
-    IndexRemoveCmd* cmd = reinterpret_cast<IndexRemoveCmd*>(req->data);
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_policy_info* policy = cmd->policy;
-    LogInfo* log = cmd->log;
+	IndexRemoveCommand* cmd = reinterpret_cast<IndexRemoveCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Invoke the blocking call.
-    // The error is handled in the calling JS code.
-    if (as->cluster == NULL) {
-        cmd->param_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        as_v8_error(log, "Not connected to cluster ");
-    }
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if (cmd->param_err == 0) {
-        as_v8_debug(log, "Invoking aerospike index remove");
-        aerospike_index_remove(as, err, policy, cmd->ns, cmd->index);
-    }
-
+	as_v8_debug(log, "Executing IndexRemove command: ns=%s, index=%s",
+			cmd->ns, cmd->index);
+	aerospike_index_remove(cmd->as, &cmd->err, cmd->policy, cmd->ns, cmd->index);
 }
 
-/**
- *  AfterWork — Function to execute when the Work is complete
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
+	Nan::HandleScope scope;
+	IndexRemoveCommand* cmd = reinterpret_cast<IndexRemoveCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    Nan::HandleScope scope;
-    // Fetch the IndexRemoveCmd structure
-    IndexRemoveCmd* cmd = reinterpret_cast<IndexRemoveCmd*>(req->data);
-    as_error* err = &cmd->err;
-    LogInfo* log = cmd->log;
-    as_v8_debug(log, "SINDEX remove : response is");
+	const int argc = 1;
+	Local<Value> argv[1];
+	argv[0] = error_to_jsobject(&cmd->err, log);
 
-    Local<Value> argv[1];
-    // Build the arguments array for the callback
-    if (cmd->param_err == 0) {
-        argv[0] = error_to_jsobject(err, log);
-    }
-    else {
-        err->func = NULL;
-        as_v8_debug(log, "Parameter error for sindex remove");
-        argv[0] = error_to_jsobject(err, log);
-    }
+	cmd->Callback(argc, argv);
 
-    // Surround the callback in a try/catch for safety
-    Nan::TryCatch try_catch;
-
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-    // Execute the callback.
-    if ( !cb->IsNull() ) {
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 1, argv);
-        as_v8_debug(log, "Invoked sindex remove callback");
-    }
-
-    // Process the exception, if any
-    if ( try_catch.HasCaught() ) {
-        Nan::FatalException(try_catch);
-    }
-
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-
-    if (cmd->param_err == 0) {
-        if (cmd->policy != NULL)
-        {
-            cf_free(cmd->policy);
-        }
-        as_v8_debug(log, "Cleaned up all the structures");
-    }
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *  The 'put()' Operation
- */
 NAN_METHOD(AerospikeClient::IndexRemove)
 {
-    async_invoke(info, prepare, execute, respond);
+	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
+	TYPE_CHECK_REQ(info[1], IsString, "index_name must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+
+	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -103,10 +103,10 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::IndexRemove)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_REQ(info[1], IsString, "index_name must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_REQ(info[1], IsString, "Index name must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -130,10 +130,10 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::Info)
 {
-	TYPE_CHECK_OPT(info[0], IsString, "request must be a string");
-	TYPE_CHECK_OPT(info[1], IsObject, "host must be an object");
-	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+	TYPE_CHECK_OPT(info[0], IsString, "Request must be a string");
+	TYPE_CHECK_OPT(info[1], IsObject, "Host must be an object");
+	TYPE_CHECK_OPT(info[2], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -60,9 +61,9 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	if (info[0]->IsString()) {
 		cmd->request = (char*) cf_malloc(INFO_REQUEST_LEN);
 		String::Utf8Value request(info[0]->ToString());
-		strncpy(cmd->request, *request, INFO_REQUEST_LEN);
+		strlcpy(cmd->request, *request, INFO_REQUEST_LEN);
 	} else {
-		cmd->req = (char*) "";
+		cmd->request = (char*) "";
 	}
 
 	if (info[1]->IsObject()) {

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -15,151 +15,102 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-	#include <aerospike/aerospike.h>
-	#include <aerospike/aerospike_info.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_info.h>
 }
 
 #define INFO_REQUEST_LEN  50
 
 using namespace v8;
 
-/*******************************************************************************
- *  TYPES
- ******************************************************************************/
-
-/**
- *  InfoCmd — Data to be used in async calls.
- *
- *  libuv allows us to pass around a pointer to an arbitraty object when
- *  running asynchronous functions. We create a data structure to hold the
- *  data we need during and after async work.
- */
-class InfoCommand : public Nan::AsyncResource {
+class InfoCommand : public AerospikeCommand {
 	public:
 		InfoCommand(AerospikeClient* client, Local<Function> callback_)
-			: Nan::AsyncResource("aerospike:InfoCommand")
-			, as(client->as)
-			, log(client->log) {
-				callback.Reset(callback_);
-			}
+			: AerospikeCommand("Info", client, callback_) {}
 
 		~InfoCommand() {
-			callback.Reset();
+			if (policy != NULL) cf_free(policy);
+			if (request != NULL) cf_free(request);
+			if (response != NULL) cf_free(response);
+			if (addr != NULL) cf_free(addr);
 		}
 
-		aerospike* as;
-		bool param_err = false;
-		as_error err;
-		as_policy_info policy;
-		as_policy_info* p_policy = NULL;
-		char* req = NULL;
-		char* res = NULL;
+		as_policy_info* policy = NULL;
+		char* request = NULL;
+		char* response = NULL;
 		char* addr = NULL;
 		uint16_t port = 0;
-		LogInfo* log;
-		Nan::Persistent<Function> callback;
 };
 
-
-/*******************************************************************************
- *  FUNCTIONS
- ******************************************************************************/
-
-/**
- *  prepare() — Function to prepare InfoCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 {
 	Nan::HandleScope scope;
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	InfoCommand* cmd = new InfoCommand(client, info[3].As<Function>());
 	LogInfo* log = client->log;
 
-	Local<Value> maybe_request = info[0];
-	Local<Value> maybe_host = info[1];
-	Local<Value> maybe_policy = info[2];
-
-	if (maybe_request->IsString()) {
-		cmd->req = (char*) cf_malloc(INFO_REQUEST_LEN);
-		String::Utf8Value request(maybe_request->ToString());
-		strncpy(cmd->req, *request, INFO_REQUEST_LEN);
+	if (info[0]->IsString()) {
+		cmd->request = (char*) cf_malloc(INFO_REQUEST_LEN);
+		String::Utf8Value request(info[0]->ToString());
+		strncpy(cmd->request, *request, INFO_REQUEST_LEN);
 	} else {
 		cmd->req = (char*) "";
 	}
 
-	if (maybe_host->IsObject()) {
-		if (host_from_jsobject(maybe_host->ToObject(), &cmd->addr, &cmd->port, log) != AS_NODE_PARAM_OK) {
-			as_v8_debug(log, "host parameter is invalid");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+	if (info[1]->IsObject()) {
+		if (host_from_jsobject(info[1]->ToObject(), &cmd->addr, &cmd->port, log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Host parameter is invalid");
 		}
 	}
 
-	if (maybe_policy->IsObject()) {
-		if (infopolicy_from_jsobject(&cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK ) {
-			as_v8_debug(log, "policy parameter is invalid");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+	if (info[2]->IsObject()) {
+		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
+		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK ) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
 
-Return:
 	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the InfoCmd structure.
- */
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
 	InfoCommand* cmd = reinterpret_cast<InfoCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in info command");
+	if (!cmd->CanExecute()) {
+		return;
+	}
+
+	if (cmd->addr == NULL) {
+		as_v8_debug(log, "Sending info command \"%s\" to random cluster host", cmd->request);
+		aerospike_info_any(cmd->as, &cmd->err, cmd->policy, cmd->request, &cmd->response);
 	} else {
-		if (cmd->addr == NULL) {
-			as_v8_debug(log, "Sending info command \"%s\" to random cluster host", cmd->req);
-			aerospike_info_any(cmd->as, &cmd->err, cmd->p_policy, cmd->req, &cmd->res);
-		} else {
-			as_v8_debug(log, "Sending info command \"%s\" to cluster host %s:%d", cmd->req, cmd->addr, cmd->port);
-			aerospike_info_host(cmd->as, &cmd->err, cmd->p_policy, cmd->addr, cmd->port, cmd->req, &cmd->res);
-		}
+		as_v8_debug(log, "Sending info command \"%s\" to cluster host %s:%d", cmd->request, cmd->addr, cmd->port);
+		aerospike_info_host(cmd->as, &cmd->err, cmd->policy, cmd->addr, cmd->port, cmd->request, &cmd->response);
 	}
 }
 
-/**
- *  AfterWork — Function to execute when the Work is complete
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	InfoCommand* cmd = reinterpret_cast<InfoCommand*>(req->data);
-	char* response = cmd->res;
 	LogInfo* log = cmd->log;
+	char* response = cmd->response;
 
 	const int argc = 2;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
+	if (cmd->IsError()) {
 		argv[0] = error_to_jsobject(&cmd->err, log);
 		argv[1] = Nan::Null();
 	} else {
@@ -167,31 +118,17 @@ static void respond(uv_work_t * req, int status)
 		if (response != NULL && strlen(response) > 0) {
 			as_v8_debug(log, "Response is %s", response);
 			argv[1] = Nan::New(response).ToLocalChecked();
-			cf_free((void*)response);
 		} else {
 			argv[1] = Nan::Null();
 		}
 	}
 
-	Nan::TryCatch try_catch;
-	Local<Object> target = Nan::New<Object>();
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	cmd->runInAsyncScope(target, cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *  The 'info()' Operation
- */
 NAN_METHOD(AerospikeClient::Info)
 {
 	TYPE_CHECK_OPT(info[0], IsString, "request must be a string");

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -38,7 +38,7 @@ class InfoCommand : public AerospikeCommand {
 
 		~InfoCommand() {
 			if (policy != NULL) cf_free(policy);
-			if (request != NULL) cf_free(request);
+			if (request != NULL && strlen(request) > 0) cf_free(request);
 			if (response != NULL) cf_free(response);
 			if (addr != NULL) cf_free(addr);
 		}

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -107,25 +107,22 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	InfoCommand* cmd = reinterpret_cast<InfoCommand*>(req->data);
-	LogInfo* log = cmd->log;
-	char* response = cmd->response;
 
-	const int argc = 2;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
-		if (response != NULL && strlen(response) > 0) {
-			as_v8_debug(log, "Response is %s", response);
-			argv[1] = Nan::New(response).ToLocalChecked();
+		Local<Value> response;
+		if (cmd->response != NULL && strlen(cmd->response) > 0) {
+			response = Nan::New(cmd->response).ToLocalChecked();
 		} else {
-			argv[1] = Nan::Null();
+			response = Nan::Null();
 		}
+		Local<Value> argv[] = {
+			Nan::Null(),
+			response
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/info_foreach.cc
+++ b/src/main/commands/info_foreach.cc
@@ -176,9 +176,9 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::InfoForeach)
 {
-	TYPE_CHECK_OPT(info[0], IsString, "request must be a string");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_OPT(info[0], IsString, "Request must be a string");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/info_foreach.cc
+++ b/src/main/commands/info_foreach.cc
@@ -133,11 +133,8 @@ respond(uv_work_t* req, int status)
 	InfoForeachCommand* cmd = reinterpret_cast<InfoForeachCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
-	const int argc = 2;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+		cmd->ErrorCallback();
 	} else {
 		as_vector* results = cmd->results;
 		Local<Array> v8Results = Nan::New<Array>(results->size);
@@ -166,11 +163,12 @@ respond(uv_work_t* req, int status)
 			v8Results->Set(i, v8Result);
 		}
 
-		argv[0] = err_ok();
-		argv[1] = v8Results;
+		Local<Value> argv[] = {
+			Nan::Null(),
+			v8Results
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/info_foreach.cc
+++ b/src/main/commands/info_foreach.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -63,7 +64,7 @@ aerospike_info_callback(const as_error* error, const as_node* node, const char* 
 
 	if (strlen(node->name) > 0) {
 		as_v8_debug(log, "Response from node %s", node->name);
-		strncpy(result.node, node->name, AS_NODE_NAME_SIZE);
+		strlcpy(result.node, node->name, AS_NODE_NAME_SIZE);
 	} else {
 		result.node[0] = '\0';
 		as_v8_debug(log, "No host name from cluster");
@@ -71,8 +72,7 @@ aerospike_info_callback(const as_error* error, const as_node* node, const char* 
 
 	if (response != NULL) {
 		as_v8_debug(log, "Response is %s", response);
-		result.info = (char*) cf_malloc(strlen(response) + 1);
-		strncpy(result.info, response, strlen(response) + 1);
+		result.info = strdup(response);
 	} else {
 		result.info = NULL;
 		as_v8_debug(log, "No response from cluster");
@@ -94,7 +94,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[0]->IsString()) {
 		cmd->request = (char*) malloc(INFO_REQUEST_LEN);
 		String::Utf8Value request(info[0]->ToString());
-		strncpy(cmd->request, *request, INFO_REQUEST_LEN);
+		strlcpy(cmd->request, *request, INFO_REQUEST_LEN);
 	} else {
 		cmd->request = (char*) "";
 	}

--- a/src/main/commands/info_foreach.cc
+++ b/src/main/commands/info_foreach.cc
@@ -46,7 +46,7 @@ class InfoForeachCommand : public AerospikeCommand {
 
 		~InfoForeachCommand() {
 			if (policy != NULL) cf_free(policy);
-			if (request != NULL) cf_free(request);
+			if (request != NULL && strlen(request) > 0) cf_free(request);
 			as_vector_destroy(results);
 		}
 

--- a/src/main/commands/job_info.cc
+++ b/src/main/commands/job_info.cc
@@ -87,17 +87,15 @@ respond(uv_work_t* req, int status)
 	JobInfoCommand* cmd = reinterpret_cast<JobInfoCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
-	const int argc = 2;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
-		argv[1] = jobinfo_to_jsobject(&cmd->job_info, log);
+		Local<Value> argv[] = {
+			Nan::Null(),
+			jobinfo_to_jsobject(&cmd->job_info, log)
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/job_info.cc
+++ b/src/main/commands/job_info.cc
@@ -59,7 +59,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
 		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/job_info.cc
+++ b/src/main/commands/job_info.cc
@@ -103,10 +103,10 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::JobInfo)
 {
-	TYPE_CHECK_REQ(info[0], IsNumber, "job_id must be a number");
-	TYPE_CHECK_REQ(info[1], IsString, "module must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsNumber, "Job ID must be a number");
+	TYPE_CHECK_REQ(info[1], IsString, "Module must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/operate_async.cc
+++ b/src/main/commands/operate_async.cc
@@ -50,7 +50,7 @@ NAN_METHOD(AerospikeClient::OperateAsync)
 	}
 	key_initalized = true;
 
-	if (operations_from_jsarray(&operations, Local<Array>::Cast(info[1]), log) != AS_NODE_PARAM_OK) {
+	if (operations_from_jsarray(&operations, info[1].As<Array>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Operations array invalid");
 		goto Cleanup;
 	}

--- a/src/main/commands/put_async.cc
+++ b/src/main/commands/put_async.cc
@@ -33,9 +33,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	LogInfo* log = client->log;
 
-	CallbackData* data = new CallbackData();
-	data->client = client;
-	data->callback.Reset(info[4].As<Function>());
+	AsyncCommand* cmd = new AsyncCommand(client, info[4].As<Function>());
 
 	as_key key;
 	bool key_initalized= false;
@@ -48,14 +46,14 @@ NAN_METHOD(AerospikeClient::PutAsync)
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callbackNew(&err, cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (recordbins_from_jsobject(&record, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Record object invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callbackNew(&err, cmd);
 		goto Cleanup;
 	}
 	record_initalized = true;
@@ -63,7 +61,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	if (info[2]->IsObject()) {
 		if (recordmeta_from_jsobject(&record, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Meta object invalid");
-			invoke_error_callback(&err, data);
+			invoke_error_callbackNew(&err, cmd);
 			goto Cleanup;
 		}
 	}
@@ -71,16 +69,16 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	if (info[3]->IsObject()) {
 		if (writepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, data);
+			invoke_error_callbackNew(&err, cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async put command");
-	status = aerospike_key_put_async(client->as, &err, p_policy, &key, &record, async_write_listener, data, NULL, NULL);
+	status = aerospike_key_put_async(client->as, &err, p_policy, &key, &record, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, data);
+		invoke_error_callbackNew(&err, cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/put_async.cc
+++ b/src/main/commands/put_async.cc
@@ -25,11 +25,11 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::PutAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsObject, "key must be an object");
-	TYPE_CHECK_REQ(info[1], IsObject, "record must be an object");
-	TYPE_CHECK_OPT(info[2], IsObject, "metadata must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsObject, "Key must be an object");
+	TYPE_CHECK_REQ(info[1], IsObject, "Record must be an object");
+	TYPE_CHECK_OPT(info[2], IsObject, "Metadata must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[4], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("Put", client, info[4].As<Function>());
@@ -44,31 +44,27 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(cmd);
+		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (recordbins_from_jsobject(&record, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		cmd->SetError(AEROSPIKE_ERR_PARAM, "Record object invalid");
-		invoke_error_callback(cmd);
+		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Record object invalid");
 		goto Cleanup;
 	}
 	record_initalized = true;
 
 	if (info[2]->IsObject()) {
 		if (recordmeta_from_jsobject(&record, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Meta object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Meta object invalid");
 			goto Cleanup;
 		}
 	}
 
 	if (info[3]->IsObject()) {
 		if (writepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -77,7 +73,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	as_v8_debug(log, "Sending async put command");
 	status = aerospike_key_put_async(client->as, &cmd->err, p_policy, &key, &record, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 
 Cleanup:

--- a/src/main/commands/put_async.cc
+++ b/src/main/commands/put_async.cc
@@ -31,9 +31,8 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-	LogInfo* log = client->log;
-
 	AsyncCommand* cmd = new AsyncCommand(client, info[4].As<Function>());
+	LogInfo* log = client->log;
 
 	as_key key;
 	bool key_initalized= false;
@@ -46,14 +45,14 @@ NAN_METHOD(AerospikeClient::PutAsync)
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callbackNew(&err, cmd);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (recordbins_from_jsobject(&record, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Record object invalid");
-		invoke_error_callbackNew(&err, cmd);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 	record_initalized = true;
@@ -61,7 +60,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	if (info[2]->IsObject()) {
 		if (recordmeta_from_jsobject(&record, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Meta object invalid");
-			invoke_error_callbackNew(&err, cmd);
+			invoke_error_callback(&err, cmd);
 			goto Cleanup;
 		}
 	}
@@ -69,7 +68,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	if (info[3]->IsObject()) {
 		if (writepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callbackNew(&err, cmd);
+			invoke_error_callback(&err, cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -78,7 +77,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	as_v8_debug(log, "Sending async put command");
 	status = aerospike_key_put_async(client->as, &err, p_policy, &key, &record, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callbackNew(&err, cmd);
+		invoke_error_callback(&err, cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/put_async.cc
+++ b/src/main/commands/put_async.cc
@@ -16,6 +16,7 @@
 
 #include "client.h"
 #include "async.h"
+#include "command.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
@@ -31,7 +32,7 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-	AsyncCommand* cmd = new AsyncCommand(client, info[4].As<Function>());
+	AsyncCommand* cmd = new AsyncCommand("Put", client, info[4].As<Function>());
 	LogInfo* log = client->log;
 
 	as_key key;
@@ -40,44 +41,43 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	bool record_initalized = false;
 	as_policy_write policy;
 	as_policy_write* p_policy = NULL;
-	as_error err;
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, cmd);
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
+		invoke_error_callback(cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (recordbins_from_jsobject(&record, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Record object invalid");
-		invoke_error_callback(&err, cmd);
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Record object invalid");
+		invoke_error_callback(cmd);
 		goto Cleanup;
 	}
 	record_initalized = true;
 
 	if (info[2]->IsObject()) {
 		if (recordmeta_from_jsobject(&record, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Meta object invalid");
-			invoke_error_callback(&err, cmd);
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Meta object invalid");
+			invoke_error_callback(cmd);
 			goto Cleanup;
 		}
 	}
 
 	if (info[3]->IsObject()) {
 		if (writepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, cmd);
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
+			invoke_error_callback(cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async put command");
-	status = aerospike_key_put_async(client->as, &err, p_policy, &key, &record, async_write_listener, cmd, NULL, NULL);
+	status = aerospike_key_put_async(client->as, &cmd->err, p_policy, &key, &record, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, cmd);
+		invoke_error_callback(cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -70,7 +70,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
 		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -113,11 +113,11 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::QueryApply)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[4], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -96,20 +96,16 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	QueryApplyCommand* cmd = reinterpret_cast<QueryApplyCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 2;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		as_v8_info(log, "QueryApply command failed: %d %s\n", cmd->err.code, cmd->err.message);
-		argv[0] = error_to_jsobject(&cmd->err, log);
-		argv[1] = Nan::Null();
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
-		argv[1] = val_to_jsvalue(cmd->val, log);
+		Local<Value> argv[] = {
+			Nan::Null(),
+			val_to_jsvalue(cmd->val, cmd->log)
+		};
+		cmd->Callback(2, argv);
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
@@ -22,85 +23,85 @@
 #include "query.h"
 
 extern "C" {
-	#include <aerospike/aerospike_query.h>
-	#include <aerospike/as_error.h>
-	#include <aerospike/as_policy.h>
-	#include <aerospike/as_query.h>
-	#include <aerospike/as_status.h>
+#include <aerospike/aerospike_query.h>
+#include <aerospike/as_error.h>
+#include <aerospike/as_policy.h>
+#include <aerospike/as_query.h>
+#include <aerospike/as_status.h>
 }
 
 using namespace v8;
 
-typedef struct QueryApplyCmd {
-	bool param_err;
-	aerospike* as;
-	as_error err;
-	as_policy_query policy;
-	as_policy_query* p_policy;
-	as_query query;
-	as_val* val;
-	LogInfo* log;
-	Nan::Persistent<Function> callback;
-} QueryApplyCmd;
+class QueryApplyCommand : public AerospikeCommand {
+	public:
+		QueryApplyCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("QueryApply", client, callback_) {}
 
-static bool query_foreach_callback(const as_val* val, void* udata) {
+		~QueryApplyCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (val != NULL) cf_free(val);
+			as_query_destroy(&query);
+		}
+
+		as_policy_query* policy = NULL;
+		as_query query;
+		as_val* val = NULL;
+};
+
+static bool
+query_foreach_callback(const as_val* val, void* udata) {
 	if (val) {
-		QueryApplyCmd* cmd = reinterpret_cast<QueryApplyCmd*>(udata);
+		QueryApplyCommand* cmd = reinterpret_cast<QueryApplyCommand*>(udata);
 		cmd->val = asval_clone(val, cmd->log);
 	}
 	return false;
 }
 
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 {
+	Nan::HandleScope scope;
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	QueryApplyCommand* cmd = new QueryApplyCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
-
-	QueryApplyCmd* cmd = new QueryApplyCmd();
-	cmd->param_err = false;
-	cmd->as = client->as;
-	cmd->log = client->log;
-	cmd->callback.Reset(info[4].As<Function>());
 
 	setup_query(&cmd->query, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (querypolicy_from_jsobject(&cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_v8_error(log, "Parsing of query policy from object failed");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
+		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
 
-Return:
 	return cmd;
 }
 
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
-	QueryApplyCmd* cmd = reinterpret_cast<QueryApplyCmd*>(req->data);
+	QueryApplyCommand* cmd = reinterpret_cast<QueryApplyCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in the query options");
-	} else {
-		as_v8_debug(log, "Sending query command with stream UDF");
-		aerospike_query_foreach(cmd->as, &cmd->err, cmd->p_policy, &cmd->query, query_foreach_callback, (void*) cmd);
+
+	if (!cmd->CanExecute()) {
+		return;
 	}
-	as_query_destroy(&cmd->query);
+
+	as_v8_debug(log, "Sending query command with stream UDF");
+	aerospike_query_foreach(cmd->as, &cmd->err, cmd->policy, &cmd->query, query_foreach_callback, cmd);
 }
 
-static void respond(uv_work_t* req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
-	QueryApplyCmd* cmd = reinterpret_cast<QueryApplyCmd*>(req->data);
+	QueryApplyCommand* cmd = reinterpret_cast<QueryApplyCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
 	const int argc = 2;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
-		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
+	if (cmd->IsError()) {
+		as_v8_info(log, "QueryApply command failed: %d %s\n", cmd->err.code, cmd->err.message);
 		argv[0] = error_to_jsobject(&cmd->err, log);
 		argv[1] = Nan::Null();
 	} else {
@@ -108,15 +109,8 @@ static void respond(uv_work_t* req, int status)
 		argv[1] = val_to_jsvalue(cmd->val, log);
 	}
 
-	as_v8_detail(log, "Invoking JS callback for query_apply");
-	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
-	cmd->callback.Reset();
 	delete cmd;
 	delete req;
 }

--- a/src/main/commands/query_async.cc
+++ b/src/main/commands/query_async.cc
@@ -34,11 +34,11 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::QueryAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[4], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("Query", client, info[4].As<Function>());
@@ -53,8 +53,7 @@ NAN_METHOD(AerospikeClient::QueryAsync)
 
 	if (info[3]->IsObject()) {
 		if (querypolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -63,7 +62,7 @@ NAN_METHOD(AerospikeClient::QueryAsync)
 	as_v8_debug(log, "Sending async query command");
 	status = aerospike_query_async(client->as, &cmd->err, p_policy, &query, async_scan_listener, cmd, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 
 Cleanup:

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -103,12 +103,12 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::QueryBackground)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_OPT(info[4], IsNumber, "query_id must be a number");
-	TYPE_CHECK_REQ(info[5], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_OPT(info[4], IsNumber, "Query ID must be a number");
+	TYPE_CHECK_REQ(info[5], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -59,7 +59,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_write*) cf_malloc(sizeof(as_policy_write));
 		if (writepolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
@@ -22,49 +23,44 @@
 #include "query.h"
 
 extern "C" {
-	#include <aerospike/aerospike_query.h>
-	#include <aerospike/as_error.h>
-	#include <aerospike/as_policy.h>
-	#include <aerospike/as_query.h>
-	#include <aerospike/as_status.h>
+#include <aerospike/aerospike_query.h>
+#include <aerospike/as_error.h>
+#include <aerospike/as_policy.h>
+#include <aerospike/as_query.h>
+#include <aerospike/as_status.h>
 }
 
 using namespace v8;
 
-typedef struct QueryBackgroundCmd {
-    bool param_err;
-    aerospike* as;
-    as_error err;
-    as_policy_write policy;
-    as_policy_write* p_policy;
-    uint64_t query_id;
-    as_query query;
-    LogInfo* log;
-    Nan::Persistent<Function> callback;
-} QueryBackgroundCmd;
+class QueryBackgroundCommand : public AerospikeCommand {
+	public:
+		QueryBackgroundCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("QueryBackground", client, callback_) {}
 
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+		~QueryBackgroundCommand() {
+			if (policy != NULL) cf_free(policy);
+			as_query_destroy(&query);
+		}
+
+		as_policy_write* policy = NULL;
+		uint64_t query_id = 0;
+		as_query query;
+};
+
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	QueryBackgroundCommand* cmd = new QueryBackgroundCommand(client, info[5].As<Function>());
 	LogInfo* log = client->log;
-
-	QueryBackgroundCmd* cmd = new QueryBackgroundCmd();
-	cmd->param_err = false;
-	cmd->as = client->as;
-	cmd->log = client->log;
-	cmd->query_id = 0;
-	cmd->callback.Reset(info[5].As<Function>());
 
 	setup_query(&cmd->query, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (writepolicy_from_jsobject(&cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_v8_error(log, "Parsing of query policy from object failed");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+		cmd->policy = (as_policy_write*) cf_malloc(sizeof(as_policy_write));
+		if (writepolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
 
 	if (info[4]->IsNumber()) {
@@ -72,47 +68,41 @@ static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 		as_v8_info(log, "Using query ID %lli for background query.", cmd->query_id);
 	}
 
-Return:
 	return cmd;
 }
 
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
-	QueryBackgroundCmd* cmd = reinterpret_cast<QueryBackgroundCmd*>(req->data);
+	QueryBackgroundCommand* cmd = reinterpret_cast<QueryBackgroundCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in the query options");
-	} else {
-		as_v8_debug(log, "Sending query background command");
-		aerospike_query_background(cmd->as, &cmd->err, cmd->p_policy, &cmd->query, &cmd->query_id);
+
+	if (!cmd->CanExecute()) {
+		return;
 	}
-	as_query_destroy(&cmd->query);
+
+	as_v8_debug(log, "Sending query background command");
+	aerospike_query_background(cmd->as, &cmd->err, cmd->policy, &cmd->query, &cmd->query_id);
 }
 
-static void respond(uv_work_t* req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
-	QueryBackgroundCmd* cmd = reinterpret_cast<QueryBackgroundCmd*>(req->data);
+	QueryBackgroundCommand* cmd = reinterpret_cast<QueryBackgroundCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
 	const int argc = 1;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
+	if (cmd->IsError()) {
 		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
 		argv[0] = error_to_jsobject(&cmd->err, log);
 	} else {
 		argv[0] = err_ok();
 	}
 
-	as_v8_detail(log, "Invoking JS callback for query_background");
-	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
-	cmd->callback.Reset();
 	delete cmd;
 	delete req;
 }

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -90,18 +90,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	QueryBackgroundCommand* cmd = reinterpret_cast<QueryBackgroundCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
-		argv[0] = error_to_jsobject(&cmd->err, log);
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
+		cmd->Callback(0, {});
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
@@ -22,33 +23,43 @@
 #include "query.h"
 
 extern "C" {
-	#include <aerospike/aerospike_query.h>
-	#include <aerospike/as_error.h>
-	#include <aerospike/as_policy.h>
-	#include <aerospike/as_query.h>
-	#include <aerospike/as_sleep.h>
-	#include <aerospike/as_status.h>
-	#include <aerospike/as_queue_mt.h>
+#include <aerospike/aerospike_query.h>
+#include <aerospike/as_error.h>
+#include <aerospike/as_policy.h>
+#include <aerospike/as_query.h>
+#include <aerospike/as_sleep.h>
+#include <aerospike/as_status.h>
+#include <aerospike/as_queue_mt.h>
 }
 
 using namespace v8;
 
 #define QUEUE_SZ 100000
 
-typedef struct QueryForeachCmd {
-	bool param_err;
-	aerospike* as;
-	as_error err;
-	as_policy_query policy;
-	as_policy_query* p_policy;
-	as_query query;
-	as_queue_mt* result_q;
-	uint32_t max_q_size;
-	uint32_t signal_interval;
-	uv_async_t async_handle;
-	LogInfo* log;
-	Nan::Persistent<Function> callback;
-} QueryForeachCmd;
+class QueryForeachCommand : public AerospikeCommand {
+	public:
+		QueryForeachCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("QueryForeach", client, callback_) {
+				max_q_size = QUEUE_SZ; // TODO: make this configurable
+				results = as_queue_mt_create(sizeof(as_val*), max_q_size);
+			}
+
+		~QueryForeachCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (results != NULL) {
+				as_queue_mt_destroy(results);
+				results = NULL;
+			}
+			as_query_destroy(&query);
+		}
+
+		as_policy_query* policy = NULL;
+		as_query query;
+		as_queue_mt* results;
+		uint32_t max_q_size;
+		uint32_t signal_interval = 0;
+		uv_async_t async_handle;
+};
 
 // Push the record from the server to a queue.
 // The record cannot be passed directly from query callback to v8 thread
@@ -56,9 +67,10 @@ typedef struct QueryForeachCmd {
 // callback is in C client thread, which is not aware of the v8 context. So
 // store this records in a temporary queue. When the queue reaches a certain
 // size, signal v8 thread to process the queue.
-static bool async_queue_populate(const as_val* val, QueryForeachCmd* cmd)
+static bool
+async_queue_populate(const as_val* val, QueryForeachCommand* cmd)
 {
-	if (cmd->result_q == NULL) {
+	if (cmd->results == NULL) {
 		// Result queue is not initialized - this should never happen!
 		as_v8_error(cmd->log, "Internal Error: Queue not initialized");
 		return false;
@@ -67,10 +79,10 @@ static bool async_queue_populate(const as_val* val, QueryForeachCmd* cmd)
 	// Clone the value as as_val is freed up after the callback.
 	as_val* clone = asval_clone((as_val*) val, cmd->log);
 	if (clone != NULL) {
-		if (as_queue_mt_size(cmd->result_q) >= cmd->max_q_size) {
+		if (as_queue_mt_size(cmd->results) >= cmd->max_q_size) {
 			as_sleep(1000);
 		}
-		as_queue_mt_push(cmd->result_q, &clone);
+		as_queue_mt_push(cmd->results, &clone);
 		cmd->signal_interval++;
 		if (cmd->signal_interval % (cmd->max_q_size / 20) == 0) {
 			cmd->signal_interval = 0;
@@ -82,166 +94,124 @@ static bool async_queue_populate(const as_val* val, QueryForeachCmd* cmd)
 }
 
 // Pop each record from the queue and invoke the node callback with this record.
-static void async_queue_process(QueryForeachCmd* cmd)
+static void
+async_queue_process(QueryForeachCommand* cmd)
 {
 	Nan::HandleScope scope;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
+	Local<Function> callback = Nan::New<Function>(cmd->callback);
+	Local<Object> target = Nan::New<Object>();
+
+	const int argc = 2;
 	as_val* val = NULL;
-	while (cmd->result_q && !as_queue_mt_empty(cmd->result_q)) {
-		if (as_queue_mt_pop(cmd->result_q, &val, AS_QUEUE_FOREVER)) {
-			const int argc = 2;
+	while (cmd->results && !as_queue_mt_empty(cmd->results)) {
+		if (as_queue_mt_pop(cmd->results, &val, AS_QUEUE_FOREVER)) {
 			Local<Value> argv[argc];
 			argv[0] = err_ok();
 			argv[1] = val_to_jsvalue(val, cmd->log);
-			Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
+			cmd->runInAsyncScope(target, callback, argc, argv);
 			as_val_destroy(val);
 		}
 	}
 }
 
-static void async_callback(uv_async_t* handle)
+static void
+async_callback(uv_async_t* handle)
 {
-	QueryForeachCmd* cmd = reinterpret_cast<QueryForeachCmd*>(handle->data);
-	if (cmd->result_q == NULL) {
-		as_v8_error(cmd->log, "Internal error: data or result q is not initialized");
+	QueryForeachCommand* cmd = reinterpret_cast<QueryForeachCommand*>(handle->data);
+	if (cmd->results == NULL) {
+		as_v8_error(cmd->log, "Internal error: result queue is not initialized");
 		return;
 	}
 	async_queue_process(cmd);
 }
 
-static bool query_foreach_callback(const as_val* val, void* udata)
+static bool
+query_foreach_callback(const as_val* val, void* udata)
 {
-	QueryForeachCmd* cmd = reinterpret_cast<QueryForeachCmd*>(udata);
+	QueryForeachCommand* cmd = reinterpret_cast<QueryForeachCommand*>(udata);
 	if (val == NULL) {
-		as_v8_debug(cmd->log, "value returned by query callback is NULL");
+		as_v8_debug(cmd->log, "Value returned by query callback is NULL");
 		return false;
 	}
 	return async_queue_populate(val, cmd);
 }
 
-static void release_handle(uv_handle_t* async_handle)
+static void
+release_handle(uv_handle_t* async_handle)
 {
-    QueryForeachCmd* cmd = reinterpret_cast<QueryForeachCmd*>(async_handle->data);
+	Nan::HandleScope scope;
+    QueryForeachCommand* cmd = reinterpret_cast<QueryForeachCommand*>(async_handle->data);
     delete cmd;
 }
 
-/**
- *  prepare() — Function to prepare QueryForeachCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
 	Nan::HandleScope scope;
-
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	QueryForeachCommand* cmd = new QueryForeachCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
-
-	QueryForeachCmd* cmd = new QueryForeachCmd();
-	cmd->param_err = false;
-	cmd->as = client->as;
-	cmd->log = client->log;
-	cmd->callback.Reset(info[4].As<Function>());
 
 	setup_query(&cmd->query, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (querypolicy_from_jsobject(&cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_v8_error(log, "Parsing of query policy from object failed");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
+		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
-
-	cmd->signal_interval   = 0;
-	cmd->result_q          = as_queue_mt_create(sizeof(as_val*), QUEUE_SZ);
-	cmd->max_q_size        = QUEUE_SZ; // TODO: make this configurable
 
 	uv_async_init(uv_default_loop(), &cmd->async_handle, async_callback);
 	cmd->async_handle.data = (void*) cmd;
 
-Return:
 	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the QueryForeachCmd structure.
- */
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
-	QueryForeachCmd* cmd = reinterpret_cast<QueryForeachCmd*>(req->data);
+	QueryForeachCommand* cmd = reinterpret_cast<QueryForeachCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in the query options");
-	} else {
-		as_v8_debug(log, "Sending query command with UDF aggregation");
-		aerospike_query_foreach(cmd->as, &cmd->err, cmd->p_policy, &cmd->query, query_foreach_callback, (void*) cmd);
-
-		// send an async signal here. If at all there's any residual records left in the result_q,
-		// this signal's callback will send it to node layer.
-		uv_async_send(&cmd->async_handle);
+	if (!cmd->CanExecute()) {
+		return;
 	}
 
-	as_query_destroy(&cmd->query);
+	as_v8_debug(log, "Sending query command with UDF aggregation");
+	aerospike_query_foreach(cmd->as, &cmd->err, cmd->policy, &cmd->query, query_foreach_callback, (void*) cmd);
+
+	// Send an async signal here. If at all there's any residual records left in the results,
+	// this signal's callback will send it to node layer.
+	uv_async_send(&cmd->async_handle);
 }
 
-/**
- *  respond() — Function to be called after `execute()`. Used to send response
- *  to the callback.
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t* req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
-	QueryForeachCmd* cmd = reinterpret_cast<QueryForeachCmd*>(req->data);
+	QueryForeachCommand* cmd = reinterpret_cast<QueryForeachCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
 	const int argc = 2;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
+	if (cmd->IsError()) {
 		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
 		argv[0] = error_to_jsobject(&cmd->err, log);
 	} else {
 		argv[0] = err_ok();
-		if (cmd->result_q && !as_queue_mt_empty(cmd->result_q)) {
+		if (cmd->results && !as_queue_mt_empty(cmd->results)) {
 			async_queue_process(cmd);
 		}
 	}
 	argv[1] = Nan::Null();
 
-	as_v8_detail(log, "Invoking JS callback for query_apply");
-	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
-	cmd->callback.Reset();
-	if (cmd->result_q != NULL) {
-		as_queue_mt_destroy(cmd->result_q);
-		cmd->result_q = NULL;
-	}
 	uv_close((uv_handle_t*) &cmd->async_handle, release_handle);
-
-	as_query_destroy(&cmd->query);
 
 	delete req;
 }
 
-/**
- *  The 'query.foreach()' Operation
- */
 NAN_METHOD(AerospikeClient::QueryForeach)
 {
 	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -45,7 +45,6 @@ class QueryForeachCommand : public AerospikeCommand {
 			}
 
 		~QueryForeachCommand() {
-			fprintf(stderr, "-> ~QueryForeachCommand()\n");
 			if (policy != NULL) cf_free(policy);
 			if (results != NULL) {
 				as_queue_mt_destroy(results);

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -206,11 +206,11 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::QueryForeach)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[4], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -98,8 +98,6 @@ static void
 async_queue_process(QueryForeachCommand* cmd)
 {
 	Nan::HandleScope scope;
-	Local<Function> callback = Nan::New<Function>(cmd->callback);
-	Local<Object> target = Nan::New<Object>();
 
 	const int argc = 2;
 	as_val* val = NULL;
@@ -108,7 +106,7 @@ async_queue_process(QueryForeachCommand* cmd)
 			Local<Value> argv[argc];
 			argv[0] = err_ok();
 			argv[1] = val_to_jsvalue(val, cmd->log);
-			cmd->runInAsyncScope(target, callback, argc, argv);
+			cmd->Callback(argc, argv);
 			as_val_destroy(val);
 		}
 	}

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -45,6 +45,7 @@ class QueryForeachCommand : public AerospikeCommand {
 			}
 
 		~QueryForeachCommand() {
+			fprintf(stderr, "-> ~QueryForeachCommand()\n");
 			if (policy != NULL) cf_free(policy);
 			if (results != NULL) {
 				as_queue_mt_destroy(results);
@@ -157,7 +158,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
 		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/remove_async.cc
+++ b/src/main/commands/remove_async.cc
@@ -29,9 +29,8 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-	LogInfo* log = client->log;
-
 	AsyncCommand* cmd = new AsyncCommand(client, info[2].As<Function>());
+	LogInfo* log = client->log;
 
 	as_key key;
 	bool key_initalized = false;
@@ -42,7 +41,7 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callbackNew(&err, cmd);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
@@ -50,7 +49,7 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 	if (info[1]->IsObject()) {
 		if (removepolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callbackNew(&err, cmd);
+			invoke_error_callback(&err, cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -59,7 +58,7 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 	as_v8_debug(log, "Sending async remove command");
 	status = aerospike_key_remove_async(client->as, &err, p_policy, &key, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callbackNew(&err, cmd);
+		invoke_error_callback(&err, cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/remove_async.cc
+++ b/src/main/commands/remove_async.cc
@@ -16,6 +16,7 @@
 
 #include "client.h"
 #include "async.h"
+#include "command.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
@@ -29,36 +30,35 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
-	AsyncCommand* cmd = new AsyncCommand(client, info[2].As<Function>());
+	AsyncCommand* cmd = new AsyncCommand("Remove", client, info[2].As<Function>());
 	LogInfo* log = client->log;
 
 	as_key key;
 	bool key_initalized = false;
 	as_policy_remove policy;
 	as_policy_remove* p_policy = NULL;
-	as_error err;
 	as_status status;
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
-		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, cmd);
+		cmd->SetError(AEROSPIKE_ERR_PARAM, "Key object invalid");
+		invoke_error_callback(cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
 		if (removepolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, cmd);
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
+			invoke_error_callback(cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async remove command");
-	status = aerospike_key_remove_async(client->as, &err, p_policy, &key, async_write_listener, cmd, NULL, NULL);
+	status = aerospike_key_remove_async(client->as, &cmd->err, p_policy, &key, async_write_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, cmd);
+		invoke_error_callback(cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/scan_async.cc
+++ b/src/main/commands/scan_async.cc
@@ -34,12 +34,12 @@ using namespace v8;
 
 NAN_METHOD(AerospikeClient::ScanAsync)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_OPT(info[4], IsNumber, "scan_id must be a number");
-	TYPE_CHECK_REQ(info[5], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_OPT(info[4], IsNumber, "Scan_id must be a number");
+	TYPE_CHECK_REQ(info[5], IsFunction, "Callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
 	AsyncCommand* cmd = new AsyncCommand("Scan", client, info[5].As<Function>());
@@ -55,8 +55,7 @@ NAN_METHOD(AerospikeClient::ScanAsync)
 
 	if (info[3]->IsObject()) {
 		if (scanpolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(cmd);
+			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
 		p_policy = &policy;
@@ -70,7 +69,7 @@ NAN_METHOD(AerospikeClient::ScanAsync)
 	as_v8_debug(log, "Sending async scan command");
 	status = aerospike_scan_async(client->as, &cmd->err, p_policy, &scan, &scan_id, async_scan_listener, cmd, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(cmd);
+		cmd->ErrorCallback();
 	}
 
 Cleanup:

--- a/src/main/commands/scan_background.cc
+++ b/src/main/commands/scan_background.cc
@@ -103,12 +103,12 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::ScanBackground)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_OPT(info[2], IsObject, "options must be an object");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_OPT(info[4], IsNumber, "scan_id must be a number");
-	TYPE_CHECK_REQ(info[5], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_OPT(info[2], IsObject, "Options must be an object");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_OPT(info[4], IsNumber, "Scan ID must be a number");
+	TYPE_CHECK_REQ(info[5], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/scan_background.cc
+++ b/src/main/commands/scan_background.cc
@@ -90,18 +90,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	ScanBackgroundCommand* cmd = reinterpret_cast<ScanBackgroundCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
-		argv[0] = error_to_jsobject(&cmd->err, log);
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
+		cmd->Callback(0, {});
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/scan_background.cc
+++ b/src/main/commands/scan_background.cc
@@ -59,7 +59,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_scan*) cf_malloc(sizeof(as_policy_scan));
 		if (scanpolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/scan_background.cc
+++ b/src/main/commands/scan_background.cc
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
@@ -22,49 +23,44 @@
 #include "scan.h"
 
 extern "C" {
-	#include <aerospike/aerospike_scan.h>
-	#include <aerospike/as_error.h>
-	#include <aerospike/as_policy.h>
-	#include <aerospike/as_scan.h>
-	#include <aerospike/as_status.h>
+#include <aerospike/aerospike_scan.h>
+#include <aerospike/as_error.h>
+#include <aerospike/as_policy.h>
+#include <aerospike/as_scan.h>
+#include <aerospike/as_status.h>
 }
 
 using namespace v8;
 
-typedef struct ScanBackgroundCmd {
-    bool param_err;
-    aerospike* as;
-    as_error err;
-    as_policy_scan policy;
-    as_policy_scan* p_policy;
-    uint64_t scan_id;
-    as_scan scan;
-    LogInfo* log;
-    Nan::Persistent<Function> callback;
-} ScanBackgroundCmd;
+class ScanBackgroundCommand : public AerospikeCommand {
+	public:
+		ScanBackgroundCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("ScanBackground", client, callback_) {}
 
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+		~ScanBackgroundCommand() {
+			if (policy != NULL) cf_free(policy);
+			as_scan_destroy(&scan);
+		}
+
+		as_policy_scan* policy = NULL;
+		uint64_t scan_id = 0;
+		as_scan scan;
+};
+
+static void*
+prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 {
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	ScanBackgroundCommand* cmd = new ScanBackgroundCommand(client, info[5].As<Function>());
 	LogInfo* log = client->log;
-
-	ScanBackgroundCmd* cmd = new ScanBackgroundCmd();
-	cmd->param_err = false;
-	cmd->as = client->as;
-	cmd->log = client->log;
-	cmd->scan_id = 0;
-	cmd->callback.Reset(info[5].As<Function>());
 
 	setup_scan(&cmd->scan, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (scanpolicy_from_jsobject(&cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_v8_error(log, "Parsing of scan policy from object failed");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+		cmd->policy = (as_policy_scan*) cf_malloc(sizeof(as_policy_scan));
+		if (scanpolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
 
 	if (info[4]->IsNumber()) {
@@ -72,47 +68,41 @@ static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 		as_v8_info(log, "Using scan ID %lli for background scan.", cmd->scan_id);
 	}
 
-Return:
 	return cmd;
 }
 
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
-	ScanBackgroundCmd* cmd = reinterpret_cast<ScanBackgroundCmd*>(req->data);
+	ScanBackgroundCommand* cmd = reinterpret_cast<ScanBackgroundCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in the scan options");
-	} else {
-		as_v8_debug(log, "Sending scan_background command");
-		aerospike_scan_background(cmd->as, &cmd->err, cmd->p_policy, &cmd->scan, &cmd->scan_id);
+
+	if (!cmd->CanExecute()) {
+		return;
 	}
-	as_scan_destroy(&cmd->scan);
+
+	as_v8_debug(log, "Sending scan_background command");
+	aerospike_scan_background(cmd->as, &cmd->err, cmd->policy, &cmd->scan, &cmd->scan_id);
 }
 
-static void respond(uv_work_t* req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
-	ScanBackgroundCmd* cmd = reinterpret_cast<ScanBackgroundCmd*>(req->data);
+	ScanBackgroundCommand* cmd = reinterpret_cast<ScanBackgroundCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
 	const int argc = 1;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
+	if (cmd->IsError()) {
 		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
 		argv[0] = error_to_jsobject(&cmd->err, log);
 	} else {
 		argv[0] = err_ok();
 	}
 
-	as_v8_detail(log, "Invoking JS callback for scan_background");
-	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
-	cmd->callback.Reset();
 	delete cmd;
 	delete req;
 }

--- a/src/main/commands/select_async.cc
+++ b/src/main/commands/select_async.cc
@@ -48,7 +48,7 @@ NAN_METHOD(AerospikeClient::SelectAsync)
 	}
 	key_initalized = true;
 
-	if (bins_from_jsarray(&bins, &num_bins, Local<Array>::Cast(info[1]), log) != AS_NODE_PARAM_OK) {
+	if (bins_from_jsarray(&bins, &num_bins, info[1].As<Array>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Bins array invalid");
 		goto Cleanup;
 	}

--- a/src/main/commands/select_async.cc
+++ b/src/main/commands/select_async.cc
@@ -30,11 +30,8 @@ NAN_METHOD(AerospikeClient::SelectAsync)
 	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
 
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	AsyncCommand* cmd = new AsyncCommand(client, info[3].As<Function>());
 	LogInfo* log = client->log;
-
-	CallbackData* data = new CallbackData();
-	data->client = client;
-	data->callback.Reset(info[3].As<Function>());
 
 	as_key key;
 	bool key_initalized = false;
@@ -47,30 +44,30 @@ NAN_METHOD(AerospikeClient::SelectAsync)
 
 	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Key object invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (bins_from_jsarray(&bins, &num_bins, Local<Array>::Cast(info[1]), log) != AS_NODE_PARAM_OK) {
 		as_error_update(&err, AEROSPIKE_ERR_PARAM, "Bins array invalid");
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 		goto Cleanup;
 	}
 
 	if (info[2]->IsObject()) {
 		if (readpolicy_from_jsobject(&policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
 			as_error_update(&err, AEROSPIKE_ERR_PARAM, "Policy object invalid");
-			invoke_error_callback(&err, data);
+			invoke_error_callback(&err, cmd);
 			goto Cleanup;
 		}
 		p_policy = &policy;
 	}
 
 	as_v8_debug(log, "Sending async select command\n");
-	status = aerospike_key_select_async(client->as, &err, p_policy, &key, (const char**)bins, async_record_listener, data, NULL, NULL);
+	status = aerospike_key_select_async(client->as, &err, p_policy, &key, (const char**)bins, async_record_listener, cmd, NULL, NULL);
 	if (status != AEROSPIKE_OK) {
-		invoke_error_callback(&err, data);
+		invoke_error_callback(&err, cmd);
 	}
 
 Cleanup:

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -106,11 +106,11 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::Truncate)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "namespace must be a string");
-	TYPE_CHECK_OPT(info[1], IsString, "set must be a string");
-	TYPE_CHECK_REQ(info[2], IsNumber, "before_nanos must be a number");
-	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Namespace must be a string");
+	TYPE_CHECK_OPT(info[1], IsString, "Set must be a string");
+	TYPE_CHECK_REQ(info[2], IsNumber, "Before nanos must be a number");
+	TYPE_CHECK_OPT(info[3], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[4], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -15,41 +15,40 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-	#include <aerospike/aerospike.h>
+#include <aerospike/aerospike.h>
 }
 
 using namespace v8;
 
-typedef struct TruncateCmd {
-	bool param_err;
-	aerospike* as;
-	as_error err;
-	as_policy_info policy;
-	as_policy_info* p_policy;
+class TruncateCommand : public AerospikeCommand {
+	public:
+		TruncateCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("Truncate", client, callback_) {}
+
+		~TruncateCommand() {
+			if (policy != NULL) cf_free(policy);
+		}
+
+	as_policy_info* policy = NULL;
 	as_namespace ns;
 	as_set set;
-	uint64_t before_nanos;
-	LogInfo* log;
-	Nan::Persistent<Function> callback;
-} TruncateCmd;
+	uint64_t before_nanos = 0;
+};
 
-
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	TruncateCommand* cmd = new TruncateCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
 
-	TruncateCmd* cmd = new TruncateCmd();
-	cmd->param_err = false;
-	cmd->as = client->as;
-	cmd->log = client->log;
-	cmd->callback.Reset(info[4].As<Function>());
 	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
 
 	if (info[1]->IsString()) {
@@ -61,55 +60,47 @@ static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	}
 
 	if (info[3]->IsObject()) {
-		if (infopolicy_from_jsobject(&cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			as_v8_error(log, "Parsing of info policy from object failed");
-			COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-			cmd->param_err = true;
-			goto Return;
+		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
+		if (infopolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
-		cmd->p_policy = &cmd->policy;
 	}
 
-Return:
 	return cmd;
 }
 
-static void execute(uv_work_t* req)
+static void
+execute(uv_work_t* req)
 {
-	TruncateCmd* cmd = reinterpret_cast<TruncateCmd*>(req->data);
+	TruncateCommand* cmd = reinterpret_cast<TruncateCommand*>(req->data);
 	LogInfo* log = cmd->log;
-	if (cmd->param_err) {
-		as_v8_debug(log, "Parameter error in the truncate options");
-	} else {
-		as_v8_debug(log, "Invoking aerospike truncate");
-		aerospike_truncate(cmd->as, &cmd->err, cmd->p_policy, cmd->ns, cmd->set, cmd->before_nanos);
+
+	if (!cmd->CanExecute()) {
+		return;
 	}
+
+	as_v8_debug(log, "Executing Truncate command: ns=%s, set=%s, before_nanos=%d", cmd->ns, cmd->set, cmd->before_nanos);
+	aerospike_truncate(cmd->as, &cmd->err, cmd->policy, cmd->ns, cmd->set, cmd->before_nanos);
 }
 
-static void respond(uv_work_t* req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
-	TruncateCmd* cmd = reinterpret_cast<TruncateCmd*>(req->data);
+	TruncateCommand* cmd = reinterpret_cast<TruncateCommand*>(req->data);
 	LogInfo* log = cmd->log;
 
 	const int argc = 1;
 	Local<Value> argv[argc];
-	if (cmd->err.code != AEROSPIKE_OK) {
+	if (cmd->IsError()) {
 		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
 		argv[0] = error_to_jsobject(&cmd->err, log);
 	} else {
 		argv[0] = err_ok();
 	}
 
-	as_v8_detail(log, "Invoking JS callback for truncate");
-	Nan::TryCatch try_catch;
-	Local<Function> cb = Nan::New<Function>(cmd->callback);
-	Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, argc, argv);
-	if (try_catch.HasCaught()) {
-		Nan::FatalException(try_catch);
-	}
+	cmd->Callback(argc, argv);
 
-	cmd->callback.Reset();
 	delete cmd;
 	delete req;
 }
@@ -121,5 +112,6 @@ NAN_METHOD(AerospikeClient::Truncate)
 	TYPE_CHECK_REQ(info[2], IsNumber, "before_nanos must be a number");
 	TYPE_CHECK_OPT(info[3], IsObject, "policy must be an object");
 	TYPE_CHECK_REQ(info[4], IsFunction, "callback must be a function");
+
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -50,10 +50,14 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	TruncateCommand* cmd = new TruncateCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
 
-	strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	if (as_strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+		return cmd->SetError(AEROSPIKE_ERR_PARAM, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
+	}
 
 	if (info[1]->IsString()) {
-		strlcpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
+		if (as_strlcpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Set exceeds max. length (%d)", AS_SET_MAX_SIZE);
+		}
 	}
 
 	if (info[2]->IsNumber()) {
@@ -63,7 +67,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
 		if (infopolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -93,18 +93,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	TruncateCommand* cmd = reinterpret_cast<TruncateCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[argc];
 	if (cmd->IsError()) {
-		as_v8_info(log, "Command failed: %d %s\n", cmd->err.code, cmd->err.message);
-		argv[0] = error_to_jsobject(&cmd->err, log);
+		cmd->ErrorCallback();
 	} else {
-		argv[0] = err_ok();
+		cmd->Callback(0, {});
 	}
-
-	cmd->Callback(argc, argv);
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -49,10 +50,10 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	TruncateCommand* cmd = new TruncateCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
 
-	strncpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
+	strlcpy(cmd->ns, *String::Utf8Value(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE);
 
 	if (info[1]->IsString()) {
-		strncpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
+		strlcpy(cmd->set, *String::Utf8Value(info[1]->ToString()), AS_SET_MAX_SIZE);
 	}
 
 	if (info[2]->IsNumber()) {

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -45,7 +45,7 @@ class UdfRegisterCommand : public AerospikeCommand {
 		}
 
 	as_policy_info* policy = NULL;
-	char filename[MAX_FILENAME_LEN] = "";
+	char filename[MAX_FILENAME_LEN] = { '\0' };
 	as_bytes content;
 	as_udf_type type;
 };

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -159,13 +159,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	UdfRegisterCommand* cmd = reinterpret_cast<UdfRegisterCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[1];
-	argv[0] = error_to_jsobject(&cmd->err, log);
-
-	cmd->Callback(argc, argv);
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
+	} else {
+		cmd->Callback(0, {});
+	}
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -173,10 +173,10 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::Register)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "filename must be a string");
-	TYPE_CHECK_OPT(info[1], IsNumber, "type must be an integer");
-	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Filename must be a string");
+	TYPE_CHECK_OPT(info[1], IsNumber, "Type must be an integer");
+	TYPE_CHECK_OPT(info[2], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -15,312 +15,171 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_udf.h>
-    #include <aerospike/as_udf.h>
-    #include <aerospike/as_config.h>
-    #include <aerospike/as_string.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_udf.h>
+#include <aerospike/as_udf.h>
+#include <aerospike/as_config.h>
+#include <aerospike/as_string.h>
 }
 
-#define FILESIZE 255
+#define MAX_FILENAME_LEN 255
 
 using namespace v8;
 
-/*******************************************************************************
- *  TYPES
- ******************************************************************************/
+class UdfRegisterCommand : public AerospikeCommand {
+	public:
+		UdfRegisterCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("UdfRegister", client, callback_) {}
 
-/**
- *  UdfRegisterCmd — Data to be used in async calls.
- *
- *  libuv allows us to pass around a pointer to an arbitraty object when
- *  running asynchronous functions. We create a data structure to hold the
- *  data we need during and after async work.
- */
-typedef struct UdfRegisterCmd {
-    aerospike * as;
-    int param_err;
-    as_error err;
-    as_policy_info* policy;
-    char filename[FILESIZE];
-    as_bytes content;
-    as_udf_type type;
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} UdfRegisterCmd;
+		~UdfRegisterCommand() {
+			if (policy != NULL) cf_free(policy);
+			as_bytes_destroy(&content);
+		}
+
+	as_policy_info* policy = NULL;
+	char filename[MAX_FILENAME_LEN] = "";
+	as_bytes content;
+	as_udf_type type;
+};
 
 
-/*******************************************************************************
- *  FUNCTIONS
- ******************************************************************************/
-
-/**
- *  prepare() — Function to prepare UdfRegisterCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	UdfRegisterCommand* cmd = new UdfRegisterCommand(client, info[3].As<Function>());
+	LogInfo* log = client->log;
 
-    Nan::HandleScope scope;
+	memset(cmd->filename, 0, MAX_FILENAME_LEN);
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	char* filepath = strdup(*String::Utf8Value(info[0]->ToString()));
+	FILE * file = fopen(filepath, "r");
+	if (!file) {
+		cmd->SetError(AEROSPIKE_ERR, "Cannot open file: %s", filepath);
+		if (filepath != NULL) cf_free(filepath);
+		return cmd;
+	}
 
-    UdfRegisterCmd* cmd = new UdfRegisterCmd();
-    cmd->as = client->as;
-    cmd->param_err = 0;
-    cmd->policy = NULL;
-    LogInfo* log = cmd->log = client->log;
+	// Determine the file size.
+	int rv = fseek(file, 0, SEEK_END);
+	if (rv != 0) {
+		cmd->SetError(AEROSPIKE_ERR_CLIENT, "Cannot determine file size: fseek returned %d", rv);
+		if (filepath != NULL) cf_free(filepath);
+		fclose(file);
+		return cmd;
+	}
 
-    memset(cmd->filename, 0, FILESIZE);
+	int file_size = ftell(file);
+	if (file_size < 0) {
+		cmd->SetError(AEROSPIKE_ERR, "Cannot determine file size: ftell returned %d", file_size);
+		if (filepath != NULL) cf_free(filepath);
+		fclose(file);
+		return cmd;
+	}
 
-    char* filepath              = NULL;
+	//Read the file's content into local buffer.
+	rewind(file);
+	uint8_t* file_content = (uint8_t*) cf_malloc(sizeof(uint8_t) * file_size);
+	if (file_content == NULL) {
+		cmd->SetError(AEROSPIKE_ERR, "Memory allocation for UDF buffer failed");
+		fclose(file);
+		return cmd;
+	}
 
-    Local<Value> maybe_filename = info[0];
-    Local<Value> maybe_type = info[1];
-    Local<Value> maybe_policy = info[2];
-    Local<Value> maybe_callback = info[3];
+	uint8_t* p_write = file_content;
+	int read = fread(p_write, 1, 512, file);
+	int size = 0;
 
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "Node.js Callback Registered");
-    } else {
-        as_v8_error(log, "No callback to register");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
+	while (read) {
+		size += read;
+		p_write += read;
+		read = fread(p_write, 1, 512, file);
+	}
+	fclose(file);
 
-    if (maybe_filename->IsString()) {
-        int length = maybe_filename->ToString()->Length() + 1;
-        filepath = (char*) cf_malloc( sizeof(char) * length);
-        strcpy(filepath, *String::Utf8Value(maybe_filename->ToString()));
-        filepath[length-1] = '\0';
-    } else {
-        as_v8_error(log, "UDF file name should be string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
+	as_string filename;
+	as_basename(&filename, filepath);
+	size_t filesize = as_string_len(&filename);
+	if (as_string_get(&filename) == NULL) {
+		cmd->SetError(AEROSPIKE_ERR, "Cannot determine UDF file basename");
+		if (filepath != NULL) cf_free(filepath);
+		return cmd;
+	} else if (filesize > MAX_FILENAME_LEN) {
+		cmd->SetError(AEROSPIKE_ERR, "UDF filename is too long (> %d)", MAX_FILENAME_LEN);
+		if (filepath != NULL) cf_free(filepath);
+		return cmd;
+	}
 
-    FILE * file = fopen(filepath, "r");
-    if (!file) {
-        as_v8_debug(log, "Cannot open file %s", filepath);
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR);
-        cmd->param_err = 1;
-        if (filepath != NULL) {
-            cf_free(filepath);
-        }
-        return cmd;
-    }
+	strncpy(cmd->filename, as_string_get(&filename), filesize);
+	cmd->filename[filesize+1] = '\0';
+	//Wrap the local buffer as an as_bytes object.
+	as_bytes_init_wrap(&cmd->content, file_content, size, true);
 
-    // Determine the file size.
-    int rv = fseek(file, 0, SEEK_END);
-    if (rv != 0) {
-        as_v8_error(log, "file-seek operation failed with error : %d", rv);
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR);
-        cmd->param_err = 1;
-        if (filepath != NULL) {
-            cf_free(filepath);
-        }
-        fclose(file);
-        return cmd;
-    }
+	if (info[1]->IsNumber()) {
+		cmd->type = (as_udf_type) info[1]->IntegerValue();
+	} else {
+		cmd->type = AS_UDF_TYPE_LUA;
+	}
 
-    int file_size = ftell(file);
-    if (file_size == -1L) {
-        as_v8_error(log, "ftell operation failed with error %d ",file_size);
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR);
-        cmd->param_err = 1;
-        if(filepath != NULL) {
-            cf_free(filepath);
-        }
-        fclose(file);
-        return cmd;
-    }
+	if (info[2]->IsObject()) {
+		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
+		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			if (filepath != NULL) cf_free(filepath);
+			return cmd;
+		}
+	}
 
-    //Read the file's content into local buffer.
-    rewind(file);
-    uint8_t * file_content = (uint8_t*)cf_malloc(sizeof(uint8_t) * file_size);
-    if (file_content == NULL) {
-        as_v8_error(log, "UDF buffer - memory allocation failed ");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR);
-        cmd->param_err = 1;
-        fclose(file);
-        return cmd;
-    }
+	if (filepath != NULL) cf_free(filepath);
 
-    uint8_t* p_write = file_content;
-    int read = fread(p_write, 1, 512, file);
-    int size = 0;
-
-    while (read) {
-        size += read;
-        p_write += read;
-        read = fread( p_write, 1, 512, file);
-    }
-    fclose(file);
-
-    as_string filename;
-    as_basename(&filename, filepath);
-    size_t filesize = as_string_len(&filename);
-    if (as_string_get(&filename) == NULL) {
-        as_v8_error(log, "Filename could not be parsed from path");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        if(filepath != NULL) {
-            cf_free(filepath);
-        }
-        return cmd;
-    } else if (filesize > FILESIZE) {
-        as_v8_error(log, "Filename length is greater than allowed size(255)");
-        COPY_ERR_MESSAGE( cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        if (filepath != NULL) {
-            cf_free(filepath);
-        }
-        return cmd;
-    }
-
-    strncpy(cmd->filename, as_string_get(&filename), filesize);
-    cmd->filename[filesize+1] = '\0';
-    //Wrap the local buffer as an as_bytes object.
-    as_bytes_init_wrap(&cmd->content, file_content, size, true);
-
-    if (maybe_type->IsNumber()) {
-        cmd->type = (as_udf_type) maybe_type->IntegerValue();
-    } else {
-        cmd->type = AS_UDF_TYPE_LUA;
-        as_v8_detail(log, "UDF type not an argument using default value(LUA)");
-    }
-
-    if (maybe_policy->IsObject()) {
-        cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-        if (infopolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "infopolicy shoule be an object");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            cmd->param_err = 1;
-            if (filepath != NULL) {
-                cf_free(filepath);
-            }
-            return cmd;
-        }
-    }
-
-    if (filepath != NULL) {
-        cf_free(filepath);
-    }
-
-    return cmd;
+	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the UdfRegisterCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the UdfRegisterCmd structure
-    UdfRegisterCmd* cmd = reinterpret_cast<UdfRegisterCmd*>(req->data);
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_policy_info* policy = cmd->policy;
-    LogInfo* log = cmd->log;
+	UdfRegisterCommand* cmd = reinterpret_cast<UdfRegisterCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Invoke the blocking call.
-    // The error is handled in the calling JS code.
-    if (as->cluster == NULL) {
-        cmd->param_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        as_v8_error(log, "Not connected to cluster to put record");
-    }
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if (cmd->param_err == 0) {
-        as_v8_debug(log, "Invoking aerospike udf register ");
-        aerospike_udf_put(as, err, policy, cmd->filename, cmd->type, &cmd->content);
-    } else {
-        return;
-    }
+	as_v8_debug(log, "Executing UdfRegister command: %s", cmd->filename);
+	aerospike_udf_put(cmd->as, &cmd->err, cmd->policy, cmd->filename, cmd->type, &cmd->content);
 }
 
-/**
- *  AfterWork — Function to execute when the Work is complete
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
+	Nan::HandleScope scope;
+	UdfRegisterCommand* cmd = reinterpret_cast<UdfRegisterCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    Nan::HandleScope scope;
-    // Fetch the UdfRegisterCmd structure
-    UdfRegisterCmd* cmd = reinterpret_cast<UdfRegisterCmd*>(req->data);
-    as_error* err = &cmd->err;
-    LogInfo* log = cmd->log;
-    as_v8_debug(log, "UDF register operation : response is");
+	const int argc = 1;
+	Local<Value> argv[1];
+	argv[0] = error_to_jsobject(&cmd->err, log);
 
-    Local<Value> argv[1];
-    // Build the arguments array for the callback
-    if (cmd->param_err == 0) {
-        argv[0] = error_to_jsobject(err, log);
-    } else {
-        err->func = NULL;
-        as_v8_debug(log, "Parameter error for put operation");
-        argv[0] = error_to_jsobject(err, log);
-    }
+	cmd->Callback(argc, argv);
 
-    // Surround the callback in a try/catch for safety
-    Nan::TryCatch try_catch;
-
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-
-    // Execute the callback.
-    if (!cb->IsNull()) {
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 1, argv);
-        as_v8_debug(log, "Invoked Put callback");
-    }
-
-    // Process the exception, if any
-    if (try_catch.HasCaught()) {
-        Nan::FatalException(try_catch);
-    }
-
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-
-    if (cmd->param_err == 0) {
-        as_bytes_destroy( &cmd->content);
-        if(cmd->policy != NULL) {
-            cf_free(cmd->policy);
-        }
-        as_v8_debug(log, "Cleaned up all the structures");
-    }
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *  The 'put()' Operation
- */
 NAN_METHOD(AerospikeClient::Register)
 {
-    async_invoke(info, prepare, execute, respond);
+	TYPE_CHECK_REQ(info[0], IsString, "filename must be a string");
+	TYPE_CHECK_OPT(info[1], IsNumber, "type must be an integer");
+	TYPE_CHECK_OPT(info[2], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[3], IsFunction, "callback must be a function");
+
+	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -20,6 +20,7 @@
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/aerospike.h>
@@ -36,7 +37,7 @@ using namespace v8;
 class UdfRegisterCommand : public AerospikeCommand {
 	public:
 		UdfRegisterCommand(AerospikeClient* client, Local<Function> callback_)
-			: AerospikeCommand("UdfRegister", client, callback_) {}
+			: AerospikeCommand("UdfRegister", client, callback_) { }
 
 		~UdfRegisterCommand() {
 			if (policy != NULL) cf_free(policy);
@@ -118,8 +119,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 		return cmd;
 	}
 
-	strncpy(cmd->filename, as_string_get(&filename), filesize);
-	cmd->filename[filesize+1] = '\0';
+	strlcpy(cmd->filename, as_string_get(&filename), filesize + 1);
 	//Wrap the local buffer as an as_bytes object.
 	as_bytes_init_wrap(&cmd->content, file_content, size, true);
 

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -15,201 +15,91 @@
  ******************************************************************************/
 
 #include "client.h"
+#include "command.h"
 #include "async.h"
 #include "conversions.h"
 #include "policy.h"
 #include "log.h"
 
 extern "C" {
-    #include <aerospike/aerospike.h>
-    #include <aerospike/aerospike_udf.h>
-    #include <aerospike/as_udf.h>
-    #include <aerospike/as_config.h>
+#include <aerospike/aerospike.h>
+#include <aerospike/aerospike_udf.h>
+#include <aerospike/as_udf.h>
+#include <aerospike/as_config.h>
 }
-
-#define FILESIZE 255
 
 using namespace v8;
 
-/*******************************************************************************
- *  TYPES
- ******************************************************************************/
+class UdfRemoveCommand : public AerospikeCommand {
+	public:
+		UdfRemoveCommand(AerospikeClient* client, Local<Function> callback_)
+			: AerospikeCommand("UdfRemove", client, callback_) {}
 
-/**
- *  UdfRemoveCmd — Data to be used in async calls.
- *
- *  libuv allows us to pass around a pointer to an arbitraty object when
- *  running asynchronous functions. We create a data structure to hold the
- *  data we need during and after async work.
- */
+		~UdfRemoveCommand() {
+			if (policy != NULL) cf_free(policy);
+			if (module != NULL) free(module);
+		}
 
-typedef struct UdfRemoveCmd {
-    aerospike * as;
-    int param_err;
-    as_error err;
-    as_policy_info* policy;
-    char filename[FILESIZE];
-    LogInfo * log;
-    Nan::Persistent<Function> callback;
-} UdfRemoveCmd;
+		as_policy_info* policy = NULL;
+		char* module = NULL;
+};
 
-
-/*******************************************************************************
- *  FUNCTIONS
- ******************************************************************************/
-
-/**
- *  prepare() — Function to prepare UdfRemoveCmd, for use in `execute()` and `respond()`.
- *
- *  This should only keep references to V8 or V8 structures for use in
- *  `respond()`, because it is unsafe for use in `execute()`.
- */
-static void* prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
+static void*
+prepare(const Nan::FunctionCallbackInfo<Value> &info)
 {
-    Nan::HandleScope scope;
+	Nan::HandleScope scope;
+	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	UdfRemoveCommand* cmd = new UdfRemoveCommand(client, info[2].As<Function>());
+	LogInfo* log = client->log;
 
-    AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.This());
+	cmd->module = strdup(*String::Utf8Value(info[0]->ToString()));
 
-    UdfRemoveCmd* cmd = new UdfRemoveCmd();
-    cmd->as = client->as;
-    cmd->policy = NULL;
-    cmd->param_err = 0;
-    LogInfo* log = cmd->log = client->log;
+	if (info[1]->IsObject()) {
+		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
+		if (infopolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+		}
+	}
 
-    Local<Value> maybe_filename = info[0];
-    Local<Value> maybe_policy = info[1];
-    Local<Value> maybe_callback = info[2];
-
-    if (maybe_callback->IsFunction()) {
-        cmd->callback.Reset(maybe_callback.As<Function>());
-        as_v8_detail(log, "Node.js Callback Registered");
-    } else {
-        as_v8_error(log, "No callback to register");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_filename->IsString()) {
-        strcpy(cmd->filename, *String::Utf8Value(maybe_filename->ToString()));
-        as_v8_detail(log, "The udf remove module name %s", cmd->filename);
-    } else {
-        as_v8_error(log, "UDF file name should be string");
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        cmd->param_err = 1;
-        return cmd;
-    }
-
-    if (maybe_policy->IsObject()) {
-        cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-        if (infopolicy_from_jsobject(cmd->policy, maybe_policy->ToObject(), log) != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "infopolicy shoule be an object");
-            COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-            cmd->param_err = 1;
-            return cmd;
-        }
-    }
-
-    return cmd;
+	return cmd;
 }
 
-/**
- *  execute() — Function to execute inside the worker-thread.
- *
- *  It is not safe to access V8 or V8 data structures here, so everything
- *  we need for input and output should be in the UdfRemoveCmd structure.
- */
-static void execute(uv_work_t * req)
+static void
+execute(uv_work_t* req)
 {
-    // Fetch the UdfRemoveCmd structure
-    UdfRemoveCmd* cmd = reinterpret_cast<UdfRemoveCmd*>(req->data);
-    aerospike* as = cmd->as;
-    as_error* err = &cmd->err;
-    as_policy_info* policy = cmd->policy;
-    LogInfo* log = cmd->log;
+	UdfRemoveCommand* cmd = reinterpret_cast<UdfRemoveCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    // Invoke the blocking call.
-    // The error is handled in the calling JS code.
-    if (as->cluster == NULL) {
-        cmd->param_err = 1;
-        COPY_ERR_MESSAGE(cmd->err, AEROSPIKE_ERR_PARAM);
-        as_v8_error(log, "Not connected to cluster to put record");
-    }
+	if (!cmd->CanExecute()) {
+		return;
+	}
 
-    if (cmd->param_err == 0) {
-        as_v8_debug(log, "Invoking aerospike udf register ");
-        aerospike_udf_remove(as, err, policy, cmd->filename);
-    }
-
+	as_v8_debug(log, "Executing UdfRemove command: module=%s", cmd->module);
+	aerospike_udf_remove(cmd->as, &cmd->err, cmd->policy, cmd->module);
 }
 
-/**
- *  AfterWork — Function to execute when the Work is complete
- *
- *  This function will be run inside the main event loop so it is safe to use
- *  V8 again. This is where you will convert the results into V8 types, and
- *  call the callback function with those results.
- */
-static void respond(uv_work_t * req, int status)
+static void
+respond(uv_work_t* req, int status)
 {
+	Nan::HandleScope scope;
+	UdfRemoveCommand* cmd = reinterpret_cast<UdfRemoveCommand*>(req->data);
+	LogInfo* log = cmd->log;
 
-    Nan::HandleScope scope;
-    // Fetch the UdfRemoveCmd structure
-    UdfRemoveCmd* cmd = reinterpret_cast<UdfRemoveCmd*>(req->data);
-    as_error* err = &cmd->err;
-    LogInfo* log = cmd->log;
-    as_v8_debug(log, "UDF register operation : response is");
+	const int argc = 1;
+	Local<Value> argv[argc];
+	argv[0] = error_to_jsobject(&cmd->err, log);
 
-    Local<Value> argv[1];
-    // Build the arguments array for the callback
-    if (cmd->param_err == 0) {
-        argv[0] = error_to_jsobject(err, log);
-    } else {
-        err->func = NULL;
-        as_v8_debug(log, "Parameter error for put operation");
-        argv[0] = error_to_jsobject(err, log);
-    }
+	cmd->Callback(argc, argv);
 
-    // Surround the callback in a try/catch for safety
-    Nan::TryCatch try_catch;
-
-    Local<Function> cb = Nan::New<Function>(cmd->callback);
-    // Execute the callback.
-    if (!cb->IsNull()) {
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), cb, 1, argv);
-        as_v8_debug(log, "Invoked Put callback");
-    }
-
-    // Process the exception, if any
-    if (try_catch.HasCaught()) {
-        Nan::FatalException(try_catch);
-    }
-
-    // Dispose the Persistent handle so the callback
-    // function can be garbage-collected
-    cmd->callback.Reset();
-
-    // clean up any memory we allocated
-
-    if (cmd->param_err == 0) {
-        if (cmd->policy != NULL) {
-            cf_free(cmd->policy);
-        }
-        as_v8_debug(log, "Cleaned up all the structures");
-    }
-
-    delete cmd;
-    delete req;
+	delete cmd;
+	delete req;
 }
 
-/*******************************************************************************
- *  OPERATION
- ******************************************************************************/
-
-/**
- *  The 'put()' Operation
- */
 NAN_METHOD(AerospikeClient::UDFRemove)
 {
-    async_invoke(info, prepare, execute, respond);
+	TYPE_CHECK_REQ(info[0], IsString, "module must be a string");
+	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+
+	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -97,9 +97,9 @@ respond(uv_work_t* req, int status)
 
 NAN_METHOD(AerospikeClient::UDFRemove)
 {
-	TYPE_CHECK_REQ(info[0], IsString, "module must be a string");
-	TYPE_CHECK_OPT(info[1], IsObject, "policy must be an object");
-	TYPE_CHECK_REQ(info[2], IsFunction, "callback must be a function");
+	TYPE_CHECK_REQ(info[0], IsString, "Module must be a string");
+	TYPE_CHECK_OPT(info[1], IsObject, "Policy must be an object");
+	TYPE_CHECK_REQ(info[2], IsFunction, "Callback must be a function");
 
 	async_invoke(info, prepare, execute, respond);
 }

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -83,13 +83,12 @@ respond(uv_work_t* req, int status)
 {
 	Nan::HandleScope scope;
 	UdfRemoveCommand* cmd = reinterpret_cast<UdfRemoveCommand*>(req->data);
-	LogInfo* log = cmd->log;
 
-	const int argc = 1;
-	Local<Value> argv[argc];
-	argv[0] = error_to_jsobject(&cmd->err, log);
-
-	cmd->Callback(argc, argv);
+	if (cmd->IsError()) {
+		cmd->ErrorCallback();
+	} else {
+		cmd->Callback(0, {});
+	}
 
 	delete cmd;
 	delete req;

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -57,7 +57,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	if (info[1]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
 		if (infopolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
-			cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
+			return cmd->SetError(AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -33,7 +33,7 @@ using namespace v8;
 class UdfRemoveCommand : public AerospikeCommand {
 	public:
 		UdfRemoveCommand(AerospikeClient* client, Local<Function> callback_)
-			: AerospikeCommand("UdfRemove", client, callback_) {}
+			: AerospikeCommand("UdfRemove", client, callback_) { }
 
 		~UdfRemoveCommand() {
 			if (policy != NULL) cf_free(policy);

--- a/src/main/events.cc
+++ b/src/main/events.cc
@@ -37,11 +37,12 @@ using namespace v8;
 // Typedefs & constants.
 //
 
-typedef struct EventQueue {
+class EventQueue : public Nan::AsyncResource {
 	public:
-		explicit EventQueue(Local<Function> cb, LogInfo *p_log) {
+		EventQueue(Local<Function> cb, LogInfo *p_log)
+			: Nan::AsyncResource("aerospike:EventQueue") {
 			as_queue_mt_init(&events, sizeof(as_cluster_event), 4);
-			callback.SetFunction(cb);
+			callback.Reset(cb);
 			log = p_log;
 		}
 
@@ -56,7 +57,9 @@ typedef struct EventQueue {
 			while (as_queue_mt_pop(&events, &event, 0)) {
 				Nan::TryCatch try_catch;
 				Local<Value> argv[] = { convert(&event) };
-				callback.Call(1, argv);
+				Local<Function> cb = Nan::New<Function>(callback);
+				Local<Object> target = Nan::New<Object>();
+				runInAsyncScope(target, cb, 1, argv);
 				if (try_catch.HasCaught()) {
 					Nan::FatalException(try_catch);
 				}
@@ -65,7 +68,7 @@ typedef struct EventQueue {
 
 	private:
 		as_queue_mt events;
-		Nan::Callback callback;
+		Nan::Persistent<Function> callback;
 		LogInfo *log;
 
 		Local<Value> convert(as_cluster_event *event) {
@@ -91,7 +94,7 @@ typedef struct EventQueue {
 					Nan::New(event->node_address).ToLocalChecked());
 			return scope.Escape(jsEvent);
 		}
-} EventQueue;
+};
 
 //==========================================================
 // Globals.
@@ -146,7 +149,7 @@ static void
 cluster_event_callback(as_cluster_event *event)
 {
 	uv_async_t *handle = (uv_async_t *) event->udata;
-	EventQueue *queue = (EventQueue *) handle->data;
+	EventQueue* queue = reinterpret_cast<EventQueue*>(handle->data);
 	queue->push(event);
 	uv_async_send(handle);
 }
@@ -155,6 +158,6 @@ static void
 cluster_event_async(uv_async_t *handle)
 {
 	Nan::HandleScope scope;
-	EventQueue *queue = (EventQueue *) handle->data;
+	EventQueue* queue = reinterpret_cast<EventQueue*>(handle->data);
 	queue->process();
 }

--- a/src/main/events.cc
+++ b/src/main/events.cc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2017 Aerospike, Inc.
+ * Copyright 2013-2018 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/query.cc
+++ b/src/main/query.cc
@@ -22,6 +22,7 @@
 #include "conversions.h"
 #include "log.h"
 #include "query.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/as_query.h>
@@ -34,9 +35,9 @@ void setup_query(as_query* query, Local<Value> ns, Local<Value> set, Local<Value
     as_namespace as_ns  = {'\0'};
     as_set       as_set = {'\0'};
 
-	strncpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE);
+	strlcpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE);
 	if (set->IsString()) {
-		strncpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE);
+		strlcpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE);
 	}
 	as_query_init(query, as_ns, as_set);
 

--- a/src/main/scan.cc
+++ b/src/main/scan.cc
@@ -22,6 +22,7 @@
 #include "conversions.h"
 #include "log.h"
 #include "scan.h"
+#include "string.h"
 
 extern "C" {
 #include <aerospike/as_scan.h>
@@ -34,9 +35,9 @@ void setup_scan(as_scan* scan, Local<Value> ns, Local<Value> set, Local<Value> m
     as_namespace as_ns  = {'\0'};
     as_set       as_set = {'\0'};
 
-	strncpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE);
+	strlcpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE);
 	if (set->IsString()) {
-		strncpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE);
+		strlcpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE);
 	}
 	as_scan_init(scan, as_ns, as_set);
 

--- a/src/main/scan.cc
+++ b/src/main/scan.cc
@@ -35,10 +35,18 @@ void setup_scan(as_scan* scan, Local<Value> ns, Local<Value> set, Local<Value> m
     as_namespace as_ns  = {'\0'};
     as_set       as_set = {'\0'};
 
-	strlcpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE);
-	if (set->IsString()) {
-		strlcpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE);
+	if (as_strlcpy(as_ns, *String::Utf8Value(ns), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+		as_v8_error(log, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
+		// TODO: Return param error
 	}
+
+	if (set->IsString()) {
+		if (as_strlcpy(as_set, *String::Utf8Value(set), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
+			as_v8_error(log, "Set exceeds max. length (%d)", AS_SET_MAX_SIZE);
+			// TODO: Return param error
+		}
+	}
+
 	as_scan_init(scan, as_ns, as_set);
 
 	if (!maybe_options->IsObject()) {

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -1292,25 +1292,17 @@ Ret_Err:
 
 int batch_from_jsarray(as_batch* batch, Local<Array> arr, const LogInfo* log)
 {
+	uint32_t len = arr->Length();
+	as_batch_init(batch, len);
+	for (uint32_t i = 0; i < len; i++) {
+		Local<Object> key = arr->Get(i)->ToObject();
+		if (key_from_jsobject(as_batch_keyat(batch, i), key, log) != AS_NODE_PARAM_OK) {
+			as_v8_error(log, "Parsing batch key [%d] failed\n", i);
+			return AS_NODE_PARAM_ERR;
+		}
+	}
 
-    uint32_t capacity = arr->Length();
-
-    if(capacity > 0) {
-        as_batch_init(batch, capacity);
-    }
-    else {
-        return AS_NODE_PARAM_ERR;
-    }
-    for ( uint32_t i=0; i < capacity; i++) {
-        Local<Object> key = arr->Get(i)->ToObject();
-        int status = key_from_jsobject(as_batch_keyat(batch, i), key, log);
-        if(status != AS_NODE_PARAM_OK) {
-            as_v8_error(log, "Parsing batch keys failed \n");
-            return AS_NODE_PARAM_ERR;
-        }
-    }
-
-    return AS_NODE_PARAM_OK;
+	return AS_NODE_PARAM_OK;
 }
 
 int batch_read_records_from_jsarray(as_batch_read_records** records, Local<Array> arr, const LogInfo* log)

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -50,6 +50,7 @@ extern "C" {
 #include "conversions.h"
 #include "log.h"
 #include "enums.h"
+#include "string.h"
 
 using namespace node;
 using namespace v8;
@@ -516,7 +517,7 @@ Local<Object> error_to_jsobject(as_error* error, const LogInfo* log)
     // and populate the error object.
     if(error->code == AEROSPIKE_ERR_UDF && strstr(error->message, "LDT") != NULL) {
         char err_message[AS_ERROR_MESSAGE_MAX_LEN] = {"\0"};
-        strncpy(err_message, error->message, AS_ERROR_MESSAGE_MAX_LEN);
+        strlcpy(err_message, error->message, AS_ERROR_MESSAGE_MAX_LEN);
         char *ptr;
         ptr = strtok(err_message, ":");
         if(ptr != NULL) {
@@ -533,7 +534,7 @@ Local<Object> error_to_jsobject(as_error* error, const LogInfo* log)
         }
 
         if(ptr != NULL) {
-            strncpy(error->message, ptr, AS_ERROR_MESSAGE_MAX_LEN);
+            strlcpy(error->message, ptr, AS_ERROR_MESSAGE_MAX_LEN);
             ptr = strtok(NULL, ":");
         }
 
@@ -1127,7 +1128,7 @@ int key_from_jsobject(as_key* key, Local<Object> obj, const LogInfo* log)
 
     Local<Value> ns_obj = obj->Get(Nan::New("ns").ToLocalChecked());
     if (ns_obj->IsString()) {
-        strncpy(ns, *String::Utf8Value(ns_obj), AS_NAMESPACE_MAX_SIZE);
+        strlcpy(ns, *String::Utf8Value(ns_obj), AS_NAMESPACE_MAX_SIZE);
         if (strlen(ns) == 0) {
             as_v8_error(log, "The key namespace must not be empty");
             return AS_NODE_PARAM_ERR;
@@ -1140,7 +1141,7 @@ int key_from_jsobject(as_key* key, Local<Object> obj, const LogInfo* log)
 
     Local<Value> set_obj = obj->Get(Nan::New("set").ToLocalChecked());
     if (set_obj->IsString()) {
-        strncpy(set, *String::Utf8Value(set_obj), AS_SET_MAX_SIZE);
+        strlcpy(set, *String::Utf8Value(set_obj), AS_SET_MAX_SIZE);
         if (strlen(set) == 0) {
             as_v8_debug(log, "Key set passed is empty string");
         }
@@ -1239,7 +1240,7 @@ int key_from_jsarray(as_key* key, Local<Array> arr, const LogInfo* log)
         goto Ret_Err;
     }
     if ( ns_obj->IsString() ) {
-        strncpy(ns, *String::Utf8Value(ns_obj), AS_NAMESPACE_MAX_SIZE);
+        strlcpy(ns, *String::Utf8Value(ns_obj), AS_NAMESPACE_MAX_SIZE);
     }
     else {
         goto Ret_Err;
@@ -1250,7 +1251,7 @@ int key_from_jsarray(as_key* key, Local<Array> arr, const LogInfo* log)
     }
 
     if ( set_obj->IsString() ) {
-        strncpy(set, *String::Utf8Value(set_obj), AS_SET_MAX_SIZE);
+        strlcpy(set, *String::Utf8Value(set_obj), AS_SET_MAX_SIZE);
     }
     else {
         goto Ret_Err;
@@ -1344,7 +1345,7 @@ int bins_from_jsarray(char*** bins, uint32_t* num_bins, Local<Array> arr, const 
     for( int i = 0; i < arr_length; i++) {
         Local<Value> bname = arr->Get(i);
         c_bins[i] = (char*)cf_malloc(AS_BIN_NAME_MAX_SIZE);
-        strncpy(c_bins[i], *String::Utf8Value(bname), AS_BIN_NAME_MAX_SIZE);
+        strlcpy(c_bins[i], *String::Utf8Value(bname), AS_BIN_NAME_MAX_SIZE);
         as_v8_detail(log, "name of the bin %s", c_bins[i]);
     }
     // The last entry should be NULL because we are passing to select API calls.
@@ -1388,7 +1389,7 @@ int udfargs_from_jsobject(char** filename, char** funcname, as_list** args, Loca
             if (*filename == NULL) {
                 *filename = (char*) cf_malloc(sizeof(char) * size);
             }
-            strncpy(*filename, *String::Utf8Value(module), size);
+            strlcpy(*filename, *String::Utf8Value(module), size);
             as_v8_detail(log, "Filename in the udf args is set to %s", *filename);
         } else {
             as_v8_error(log, "UDF module name should be string");
@@ -1407,7 +1408,7 @@ int udfargs_from_jsobject(char** filename, char** funcname, as_list** args, Loca
             if (*funcname == NULL) {
                 *funcname = (char*) cf_malloc(sizeof(char) * size);
             }
-            strncpy(*funcname, *String::Utf8Value(v8_funcname), size);
+            strlcpy(*funcname, *String::Utf8Value(v8_funcname), size);
             as_v8_detail(log, "The function name in the UDF args set to %s", *funcname);
         } else {
             as_v8_error(log, "UDF function name should be string");

--- a/test/batch_exists.js
+++ b/test/batch_exists.js
@@ -64,4 +64,9 @@ describe('client.batchExists()', function () {
       done()
     })
   })
+
+  it('returns an empty array when no keys are passed', () => {
+    client.batchExists([])
+      .then(results => expect(results).to.eql([]))
+  })
 })

--- a/test/batch_get.js
+++ b/test/batch_get.js
@@ -64,4 +64,9 @@ describe('client.batchGet()', function () {
       done()
     })
   })
+
+  it('returns an empty array when no keys are passed', () => {
+    client.batchGet([])
+      .then(results => expect(results).to.eql([]))
+  })
 })

--- a/test/batch_select.js
+++ b/test/batch_select.js
@@ -64,4 +64,9 @@ describe('client.batchSelect()', function () {
       done()
     })
   })
+
+  it('returns an empty array when no keys are passed', () => {
+    client.batchExists([], ['i'])
+      .then(results => expect(results).to.eql([]))
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ context('secondary indexes', function () {
       let options = {
         ns: helper.namespace,
         set: helper.set,
-        bin: testIndex.bin + 'slkfjslkdfjslkdfjlskdfjslf',
+        bin: testIndex.bin,
         index: testIndex.name,
         datatype: Aerospike.indexDataType.NUMERIC
       }


### PR DESCRIPTION
To fix #254, we should upgrade `nan` to v2.10.0. However, that version of `nan` deprecates `MakeCallback`. Building the module using `nan@v2.10.0` causes a long list of deprecation warnings when the native addon gets compiled. In order to avoid the deprecation warnings, we need to replace `MakeCallback` with the new `Nan::AsyncResource` class. See the [nan docs](https://github.com/nodejs/nan/blob/master/doc/node_misc.md) for more details.