### PR TITLE
Support CDT Relative Range OPs

### DIFF
--- a/lib/lists.js
+++ b/lib/lists.js
@@ -81,7 +81,7 @@ class ListOperation {
    *
    * @example <caption>Fetch the first three list elements and return the values</caption>
    *
-   * const Aerospike = require('./')
+   * const Aerospike = require('aerospike')
    * const lists = Aerospike.lists
    * const key = new Aerospike.Key('test', 'demo', 'listsTest')
    *
@@ -112,7 +112,7 @@ class ListOperation {
    *
    * @example <caption>Remove all tags except for yellow from the record</caption>
    *
-   * const Aerospike = require('./')
+   * const Aerospike = require('aerospike')
    * const lists = Aerospike.lists
    * const key = new Aerospike.Key('test', 'demo', 'listsTest')
    *
@@ -569,8 +569,9 @@ exports.removeRange = function (bin, index, count) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  *
@@ -615,8 +616,9 @@ exports.removeByIndex = function (bin, index, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -641,8 +643,9 @@ exports.removeByIndexRange = function (bin, index, count, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -666,8 +669,9 @@ exports.removeByValue = function (bin, value, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -696,8 +700,9 @@ exports.removeByValueList = function (bin, values, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -705,6 +710,76 @@ exports.removeByValueRange = function (bin, begin, end, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE_RANGE, bin, {
     begin: begin,
     end: end,
+    returnType: returnType
+  })
+}
+
+/**
+ * @summary Removes list items nearest to value and greater, by relative rank.
+ * @description This operation returns the data specified by <code>returnType</code>.
+ *
+ * Examples for ordered list [0, 4, 5, 9, 11, 15]:
+ *
+ * * (value, rank, count) = [removed items]
+ * * (5, 0, 2) = [5, 9]
+ * * (5, 1, 1) = [9]
+ * * (5, -1, 2) = [4, 5]
+ * * (3, 0, 1) = [4]
+ * * (3, 3, 7) = [11, 15]
+ * * (3, -3, 2) = []
+ *
+ * Without count:
+ *
+ * * (value, rank) = [removed items]
+ * * (5, 0) = [5, 9, 11, 15]
+ * * (5, 1) = [9, 11, 15]
+ * * (5, -1) = [4, 5, 9, 11, 15]
+ * * (3, 0) = [4, 5, 9, 11, 15]
+ * * (3, 3) = [11, 15]
+ * * (3, -3) = [0, 4, 5, 9, 11, 15]
+ *
+ * Requires Aerospike Server v4.3.0 or later.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain a List value.
+ * @param {any} value - Find list items nearest to this value and greater.
+ * @param {number} rank - Rank of the items to be removed relative to the given value.
+ * @param {number} [count] - Number of items to remove. If undefined, the range
+ * includes all items nearest to value and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/lists.returnType|return type}
+ * indicating what data of the removed item(s) to return (if any).
+ * @returns {module:aerospike/lists~ListOperation} List operation that can be
+ * used with the {@link Client#operate} command.
+ *
+ * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
+ * invert the selection of items affected by this operation.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const lists = Aerospike.lists
+ * const key = new Aerospike.Key('test', 'demo', 'listKey')
+ *
+ * Aerospike.connect().then(async client => {
+ *   await client.put(key, { list: [0, 4, 5, 9, 11, 15] })
+ *   let result = await client.operate(key, [
+ *     lists.removeByValueRelRankRange('list', 3, 3)
+ *       .andReturn(lists.returnType.VALUE)])
+ *   console.info(result.bins.list) // => [ 11, 15 ]
+ *   let record = await client.get(key)
+ *   console.info(record.bins.list) // => [ 0, 4, 5, 9 ]
+ *   client.close()
+ * })
+ */
+exports.removeByValueRelRankRange = function (bin, value, rank, count, returnType) {
+  return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE_REL_RANK_RANGE, bin, {
+    value: value,
+    rank: rank,
+    count: count,
     returnType: returnType
   })
 }
@@ -722,8 +797,9 @@ exports.removeByValueRange = function (bin, begin, end, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -740,8 +816,8 @@ exports.removeByRank = function (bin, rank, returnType) {
  *
  * @param {string} bin - The name of the bin. The bin must contain a List value.
  * @param {number} index - Starting rank.
- * @param {?number} count - Number of items to remove; if not specified, the
- * range includes all items starting from <code>rank</code>.
+ * @param {number} [count] - Number of items to remove; if undefined, the range
+ * includes all items starting from <code>rank</code>.
  * @param {number} [returnType] - The {@link module:aerospike/lists.returnType|return type}
  * indicating what data of the removed item(s) to return (if any).
  * @returns {module:aerospike/lists~ListOperation} List operation that can be
@@ -749,8 +825,9 @@ exports.removeByRank = function (bin, rank, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -968,8 +1045,9 @@ exports.getRange = function (bin, index, count) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  *
@@ -1012,8 +1090,9 @@ exports.getByIndex = function (bin, index, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -1038,8 +1117,9 @@ exports.getByIndexRange = function (bin, index, count, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -1063,8 +1143,9 @@ exports.getByValue = function (bin, value, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -1093,8 +1174,9 @@ exports.getByValueList = function (bin, values, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -1102,6 +1184,75 @@ exports.getByValueRange = function (bin, begin, end, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE_RANGE, bin, {
     begin: begin,
     end: end,
+    returnType: returnType
+  })
+}
+
+/**
+ * @summary Retrieves list items nearest to value and greater, by relative rank.
+ * @description This operation returns the data specified by <code>returnType</code>.
+ *
+ * Examples for ordered list [0, 4, 5, 9, 11, 15]:
+ *
+ * * (value, rank, count) = [selected items]
+ * * (5, 0, 2) = [5, 9]
+ * * (5, 1, 1) = [9]
+ * * (5, -1, 2) = [4, 5]
+ * * (3, 0, 1) = [4]
+ * * (3, 3, 7) = [11, 15]
+ * * (3, -3, 2) = []
+ *
+ * Without count:
+ *
+ * * (value, rank) = [selected items]
+ * * (5, 0) = [5, 9, 11, 15]
+ * * (5, 1) = [9, 11, 15]
+ * * (5, -1) = [4, 5, 9, 11, 15]
+ * * (3, 0) = [4, 5, 9, 11, 15]
+ * * (3, 3) = [11, 15]
+ * * (3, -3) = [0, 4, 5, 9, 11, 15]
+ *
+ * Requires Aerospike Server v4.3.0 or later.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain a List value.
+ * @param {any} value - Find list items nearest to this value and greater.
+ * @param {number} rank - Rank of the items to be retrieved relative to the given value.
+ * @param {number} [count] - Number of items to retrieve. If undefined, the
+ * range includes all items nearest to value and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/lists.returnType|return type}
+ * indicating what data of the selected item(s) to return.
+ * @returns {module:aerospike/lists~ListOperation} List operation that can be
+ * used with the {@link Client#operate} command.
+ *
+ * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
+ * invert the selection of items affected by this operation.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const lists = Aerospike.lists
+ * const key = new Aerospike.Key('test', 'demo', 'listKey')
+ *
+ * Aerospike.connect().then(async client => {
+ *   await client.put(key, { list: [0, 4, 5, 9, 11, 15] })
+ *   await client.operate(key, [ lists.setOrder('list', lists.order.ORDERED) ])
+ *   let result = await client.operate(key, [
+ *     lists.getByValueRelRankRange('list', 5, -1, 2)
+ *       .andReturn(lists.returnType.VALUE)])
+ *   console.info(result.bins.list) // => [ 4, 5 ]
+ *   client.close()
+ * })
+ */
+exports.getByValueRelRankRange = function (bin, value, rank, count, returnType) {
+  return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE_REL_RANK_RANGE, bin, {
+    value: value,
+    rank: rank,
+    count: count,
     returnType: returnType
   })
 }
@@ -1119,8 +1270,9 @@ exports.getByValueRange = function (bin, begin, end, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */
@@ -1137,7 +1289,7 @@ exports.getByRank = function (bin, rank, returnType) {
  *
  * @param {string} bin - The name of the bin. The bin must contain a List value.
  * @param {number} index - Starting rank.
- * @param {?number} count - Number of items to retrieve; if not specified, the
+ * @param {number} [count] - Number of items to retrieve. If undefined, the
  * range includes all items starting from <code>rank</code>.
  * @param {number} [returnType] - The {@link module:aerospike/lists.returnType|return type}
  * indicating what data of the removed item(s) to return (if any).
@@ -1146,8 +1298,9 @@ exports.getByRank = function (bin, rank, returnType) {
  *
  * @see Use {@link module:aerospike/lists~ListOperation#invertSelection|ListOperation#invertSelection} to
  * invert the selection of items affected by this operation.
- * @see Use {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
- * select what data of the affected item(s) the server should return.
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/lists~ListOperation#andReturn|ListOperation#andReturn} to
+ * select what data to return.
  *
  * @since v3.4.0
  */

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -72,16 +72,17 @@ const policy = require('./policy')
  *
  * const Aerospike = require('aerospike')
  * const maps = Aerospike.maps
- * const key = new Aerospike.Key('test', 'demo', 'key1')
+ * const key = new Aerospike.Key('test', 'demo', 'mapKey')
  *
- * var keyOrderedPolicy = { order: maps.order.KEY_ORDERED }
- * var createOnlyPolicy = { writeMode: maps.writeMode.CREATE_ONLY }
- * var ops = [
+ * let keyOrderedPolicy = { order: maps.order.KEY_ORDERED }
+ * let createOnlyPolicy = { writeMode: maps.writeMode.CREATE_ONLY }
+ * let ops = [
  *   maps.put('map', 'e', 5, keyOrderedPolicy),                    // => { map: { e: 5 } }
  *   maps.putItems('map', { d: 4, b: 2, c: 3 }),                   // => { map: { b: 2, c: 3, d: 4, e: 5 } }
  *   maps.putItems('map', { c: 99, a: 1 }, createOnlyPolicy),      // => { map: { a: 1, b: 2, c: 3, d: 4, e: 5 } }
  *   maps.removeByValue('map', 3),                                 // => { map: { a: 1, b: 2, d: 4, e: 5 } }
- *   maps.removeByIndexRange('map', -2, 2, maps.returnType.KEY)    // => { map: { a: 1, b: 2 } }
+ *   maps.removeByIndexRange('map', -2)
+ *     .andReturn(maps.returnType.KEY)                             // => { map: { a: 1, b: 2 } }
  * ]
  *
  * Aerospike.connect((error, client) => {
@@ -99,11 +100,54 @@ const policy = require('./policy')
   */
 
 /**
- * @private
+ * @summary Map operation
+ *
+ * @description Use the methods in the {@link module:aerospike/maps|maps}
+ * module to create map operations for use with the {@link Client#operate}
+ * command.
  */
-function MapOperation (op, bin) {
-  this.op = op
-  this.bin = bin
+class MapOperation {
+  /**
+   * @private
+   */
+  constructor (op, bin, props) {
+    this.op = op
+    this.bin = bin
+    if (props) {
+      Object.assign(this, props)
+    }
+  }
+
+  /**
+   * @summary Set the return type for certain map operations.
+   * @description The return type only affects <code>getBy\*</code> and
+   * <code>removeBy\*</code> map operations.
+   *
+   * @param {number} returnType - The {@link
+   * module:aerospike/maps.returnType|return type} indicating what data of the
+   * selected items to return.
+   *
+   * @example <caption>Remove map keys in a given range and return the values</caption>
+   *
+   * const Aerospike = require('aerospike')
+   * const maps = Aerospike.maps
+   * const key = new Aerospike.Key('test', 'demo', 'mapKey')
+   *
+   * Aerospike.connect().then(async client => {
+   *   await client.put(key, { map: { a: 1, b: 2, c: 3, d: 4, e: 5 } })
+   *   const ops = [
+   *     maps.removeByKeyRange('map', 'b', 'd')
+   *       .andReturn(maps.returnType.VALUE)
+   *   ]
+   *   const result = await client.operate(key, ops)
+   *   console.info('Result:', result.bins.map) // => Result: [ 2, 3 ]
+   *   client.close()
+   * })
+   */
+  andReturn (returnType) {
+    this.returnType = returnType
+    return this
+  }
 }
 
 /**
@@ -306,9 +350,13 @@ exports.clear = function (bin) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {any} key - The map key.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByKey = function (bin, key, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_KEY, bin)
@@ -324,9 +372,13 @@ exports.removeByKey = function (bin, key, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {Array<any>} keys - An array of map keys.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByKeyList = function (bin, keys, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_KEY_LIST, bin)
@@ -347,9 +399,13 @@ exports.removeByKeyList = function (bin, keys, returnType) {
  * @param {?any} end - End key in the range (exclusive). If set to
  * <code>null</code>, the range includes all keys greater than or equal to the
  * <code>begin</code> key.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByKeyRange = function (bin, begin, end, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_KEY_RANGE, bin)
@@ -360,15 +416,86 @@ exports.removeByKeyRange = function (bin, begin, end, returnType) {
 }
 
 /**
+ * Removes map items nearest to key and greater, by index, from the map.
+ *
+ * This operation returns the removed data specified by <code>returnType</code>.
+ *
+ * Examples for map { a: 17, e: 2, f: 15, j: 10 }:
+ *
+ * * (value, index, count) = [removed items]
+ * * ('f', 0, 1) = { f: 15 }
+ * * ('f', 1, 2) = { j: 10 }
+ * * ('f', -1, 1) = { e: 2 }
+ * * ('b', 2, 1) = { j: 10 }
+ * * ('b', -2, 2) = { a: 17 }
+ *
+ * Without count:
+ *
+ * * (value, index) = [removed items]
+ * * ('f', 0) = { f: 15, j: 10 }
+ * * ('f', 1) = { j: 10 }
+ * * ('f', -1) = { e: 2, f: 15, j: 10 }
+ * * ('b', 2) = { j: 10 }
+ * * ('b', -2) = { a: 17, e: 2, f: 15, j: 10 }
+ *
+ * Requires Aerospike Server v4.3.0 or later.
+ *
+ * @param {string} bin - The name of the bin, which must contain a Map value.
+ * @param {any} key - Find map items nearest to this key and greater.
+ * @param {number} index - Index of items to be removed relative to the given key.
+ * @param {number} [count] - Number of items to remove. If undefined, the range
+ * includes all items nearest to key and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const maps = Aerospike.maps
+ * const key = new Aerospike.Key('test', 'demo', 'mapKey')
+ *
+ * Aerospike.connect()
+ *   .then(async client => {
+ *     await client.put(key, { map: { a: 17, e: 2, f: 15, j: 10 } })
+ *     let result = await client.operate(key, [
+ *       maps.removeByKeyRelIndexRange('map', 'f', -1, 1)
+ *         .andReturn(maps.returnType.KEY_VALUE)])
+ *     console.info(result.bins.map) // => [ 'e', 2 ]
+ *     let record = await client.get(key)
+ *     console.info(record.bins.map) // => { a: 17, f: 15, j: 10 }
+ *     client.close()
+ *   })
+ */
+exports.removeByKeyRelIndexRange = function (bin, key, index, count, returnType) {
+  return new MapOperation(opcodes.MAP_REMOVE_BY_KEY_REL_INDEX_RANGE, bin, {
+    key: key,
+    index: index,
+    count: count,
+    returnType: returnType
+  })
+}
+
+/**
  * Removes one or more items identified by a single value from the map.
  *
  * This operation returns the removed data specified by <code>returnType</code>.
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {any} value - The map value.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByValue = function (bin, value, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_VALUE, bin)
@@ -384,9 +511,13 @@ exports.removeByValue = function (bin, value, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {Array<any>} values - An array of map values.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByValueList = function (bin, values, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_VALUE_LIST, bin)
@@ -407,9 +538,13 @@ exports.removeByValueList = function (bin, values, returnType) {
  * @param {?any} end - End value in the range (exclusive). If set to
  * <code>null</code>, the range includes all values greater than or equal to the
  * <code>begin</code> value.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByValueRange = function (bin, begin, end, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_VALUE_RANGE, bin)
@@ -420,15 +555,79 @@ exports.removeByValueRange = function (bin, begin, end, returnType) {
 }
 
 /**
+ * Removes map items nearest to value and greater, by relative rank.
+ *
+ * This operation returns the removed data specified by <code>returnType</code>.
+ *
+ *
+ * Examples for map { e: 2, j: 10, f: 15, a: 17 }:
+ *
+ * * (value, rank, count) = [removed items]
+ * * (11, 1, 1) = { a: 17 }
+ * * (11, -1, 1) = { j: 10 }
+ *
+ * Without count:
+ *
+ * * (value, rank) = [removed items]
+ * * (11, 1) = { a: 17 }
+ * * (11, -1) = { j: 10, f: 15, a: 17 }
+ *
+ * @param {string} bin - The name of the bin, which must contain a Map value.
+ * @param {any} value - Find map items nearest to this value and greater.
+ * @param {number} rank - Rank of items to be removed relative to the given value.
+ * @param {number} [count] - Number of items to remove. If undefined, the range
+ * includes all items nearest to value and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const maps = Aerospike.maps
+ * const key = new Aerospike.Key('test', 'demo', 'mapKey')
+ *
+ * Aerospike.connect()
+ *   .then(async client => {
+ *     await client.put(key, { map: { e: 2, j: 10, f: 15, a: 17 } })
+ *     let result = await client.operate(key, [
+ *       maps.removeByValueRelRankRange('map', 11, -1)
+ *         .andReturn(maps.returnType.KEY_VALUE)])
+ *     console.info(result.bins.map) // => [ 'j', 10, 'f', 15, 'a', 17 ]
+ *     let record = await client.get(key)
+ *     console.info(record.bins.map) // => { e: 2 }
+ *     client.close()
+ *   })
+ */
+exports.removeByValueRelRankRange = function (bin, value, rank, count, returnType) {
+  return new MapOperation(opcodes.MAP_REMOVE_BY_VALUE_REL_RANK_RANGE, bin, {
+    value: value,
+    rank: rank,
+    count: count,
+    returnType: returnType
+  })
+}
+
+/**
  * Removes a single item identified by its index value from the map.
  *
  * This operation returns the removed data specified by <code>returnType</code>.
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Index of the entry to remove.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByIndex = function (bin, index, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_INDEX, bin)
@@ -444,11 +643,15 @@ exports.removeByIndex = function (bin, index, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Starting index.
- * @param {?number} count - Number of items to delete; if not specified, the
- * range includes all items starting from <code>index</code>.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [count] - Number of items to delete. If undefined, the range
+ * includes all items starting from <code>index</code>.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByIndexRange = function (bin, index, count, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_INDEX_RANGE, bin)
@@ -465,9 +668,13 @@ exports.removeByIndexRange = function (bin, index, count, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} rank - Rank of the item to remove.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByRank = function (bin, rank, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_RANK, bin)
@@ -483,11 +690,15 @@ exports.removeByRank = function (bin, rank, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Starting rank.
- * @param {?number} count - Number of items to delete; if not specified, the
- * range includes all items starting from <code>rank</code>.
- * @param {number} [returnType] - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [count] - Number of items to delete. If undefined, the range
+ * includes all items starting from <code>rank</code>.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the affected item(s) to return (if any).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.removeByRankRange = function (bin, rank, count, returnType) {
   var op = new MapOperation(opcodes.MAP_REMOVE_BY_RANK_RANGE, bin)
@@ -514,9 +725,13 @@ exports.size = function (bin) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {any} key - The map key.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByKey = function (bin, key, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_KEY, bin)
@@ -537,9 +752,13 @@ exports.getByKey = function (bin, key, returnType) {
  * @param {?any} end - End key in the range (exclusive). If set to
  * <code>null</code>, the range includes all keys greater than or equal to the
  * <code>begin</code> key.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByKeyRange = function (bin, begin, end, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_KEY_RANGE, bin)
@@ -550,15 +769,84 @@ exports.getByKeyRange = function (bin, begin, end, returnType) {
 }
 
 /**
+ * Retrieves map items nearest to key and greater, by index, from the map.
+ *
+ * This operation returns the selected data specified by <code>returnType</code>.
+ *
+ * Examples for map { a: 17, e: 2, f: 15, j: 10 }:
+ *
+ * * (value, index, count) = [selected items]
+ * * ('f', 0, 1) = { f: 15 }
+ * * ('f', 1, 2) = { j: 10 }
+ * * ('f', -1, 1) = { e: 2 }
+ * * ('b', 2, 1) = { j: 10 }
+ * * ('b', -2, 2) = { a: 17 }
+ *
+ * Without count:
+ *
+ * * (value, index) = [selected items]
+ * * ('f', 0) = { f: 15, j: 10 }
+ * * ('f', 1) = { j: 10 }
+ * * ('f', -1) = { e: 2, f: 15, j: 10 }
+ * * ('b', 2) = { j: 10 }
+ * * ('b', -2) = { a: 17, e: 2, f: 15, j: 10 }
+ *
+ * Requires Aerospike Server v4.3.0 or later.
+ *
+ * @param {string} bin - The name of the bin, which must contain a Map value.
+ * @param {any} key - Find map items nearest to this key and greater.
+ * @param {number} index - Index of items to be retrieved relative to the given key.
+ * @param {number} [count] - Number of items to retrieve. If undefined, the
+ * range includes all items nearest to key and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const maps = Aerospike.maps
+ * const key = new Aerospike.Key('test', 'demo', 'mapKey')
+ *
+ * Aerospike.connect()
+ *   .then(async client => {
+ *     await client.put(key, { map: { a: 17, e: 2, f: 15, j: 10 } })
+ *     let result = await client.operate(key, [
+ *       maps.getByKeyRelIndexRange('map', 'b', 2, 1)
+ *         .andReturn(maps.returnType.KEY_VALUE)])
+ *     console.info(result.bins.map) // => [ 'j', 10 ]
+ *     client.close()
+ *   })
+ */
+exports.getByKeyRelIndexRange = function (bin, key, index, count, returnType) {
+  return new MapOperation(opcodes.MAP_GET_BY_KEY_REL_INDEX_RANGE, bin, {
+    key: key,
+    index: index,
+    count: count,
+    returnType: returnType
+  })
+}
+
+/**
  * Retrieves one or more items identified by a single value from the map.
  *
  * This operation returns the data specified by <code>returnType</code>.
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {any} value - The map value.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByValue = function (bin, value, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_VALUE, bin)
@@ -579,9 +867,13 @@ exports.getByValue = function (bin, value, returnType) {
  * @param {?any} end - End value in the range (exclusive). If set to
  * <code>null</code>, the range includes all values greater than or equal to the
  * <code>begin</code> value.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByValueRange = function (bin, begin, end, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_VALUE_RANGE, bin)
@@ -592,15 +884,76 @@ exports.getByValueRange = function (bin, begin, end, returnType) {
 }
 
 /**
+ * Retrieves map items nearest to value and greater, by relative rank.
+ *
+ * This operation returns the selected data specified by <code>returnType</code>.
+ *
+ * Examples for map { e: 2, j: 10, f: 15, a: 17 }:
+ *
+ * * (value, rank, count) = [selected items]
+ * * (11, 1, 1) = { a: 17 }
+ * * (11, -1, 1) = { j: 10 }
+ *
+ * Without count:
+ *
+ * * (value, rank) = [selected items]
+ * * (11, 1) = { a: 17 }
+ * * (11, -1) = { j: 10, f: 15, a: 17 }
+ *
+ * @param {string} bin - The name of the bin, which must contain a Map value.
+ * @param {any} value - Find map items nearest to this value and greater.
+ * @param {number} rank - Rank of items to be retrieved relative to the given value.
+ * @param {number} [count] - Number of items to retrieve. If undefined, the
+ * range includes all items nearest to value and greater, until the end.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
+ *
+ * @since v3.5.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const maps = Aerospike.maps
+ * const key = new Aerospike.Key('test', 'demo', 'mapKey')
+ *
+ * Aerospike.connect()
+ *   .then(async client => {
+ *     await client.put(key, { map: { e: 2, j: 10, f: 15, a: 17 } })
+ *     let result = await client.operate(key, [
+ *       maps.getByValueRelRankRange('map', 11, 1, 1)
+ *         .andReturn(maps.returnType.KEY_VALUE)])
+ *     console.info(result.bins.map) // => [ 'a', 17 ]
+ *     client.close()
+ *   })
+ */
+exports.getByValueRelRankRange = function (bin, value, rank, count, returnType) {
+  return new MapOperation(opcodes.MAP_GET_BY_VALUE_REL_RANK_RANGE, bin, {
+    value: value,
+    rank: rank,
+    count: count,
+    returnType: returnType
+  })
+}
+
+/**
  * Retrieves a single item identified by it's index value from the map.
  *
  * This operation returns the data specified by <code>returnType</code>.
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Index of the entry to remove.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByIndex = function (bin, index, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_INDEX, bin)
@@ -616,11 +969,15 @@ exports.getByIndex = function (bin, index, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Starting index.
- * @param {?number} count - Number of items to delete; if not specified, the
- * range includes all items starting from <code>index</code>.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [count] - Number of items to delete. If undefined, the range
+ * includes all items starting from <code>index</code>.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByIndexRange = function (bin, index, count, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_INDEX_RANGE, bin)
@@ -637,9 +994,13 @@ exports.getByIndexRange = function (bin, index, count, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} rank - Rank of the entry to remove.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByRank = function (bin, rank, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_RANK, bin)
@@ -655,11 +1016,15 @@ exports.getByRank = function (bin, rank, returnType) {
  *
  * @param {string} bin - The name of the bin, which must contain a Map value.
  * @param {number} index - Starting rank.
- * @param {?number} count - Number of items to delete; if not specified, the
+ * @param {number} count - Number of items to delete; if not specified, the
  * range includes all items starting from <code>rank</code>.
- * @param {number} returnType - The return type indicating what data of the
- * removed item(s) to return (if any); see {@link module:aerospike/maps.returnType} for possible values.
+ * @param {number} [returnType] - The {@link module:aerospike/maps.returnType|return type}
+ * indicating what data of the selected item(s) to return.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ *
+ * @see Instead of passing <code>returnType</code>, you can also use
+ * {@link module:aerospike/maps~MapOperation#andReturn|MapOperation#andReturn} to
+ * select what data to return.
  */
 exports.getByRankRange = function (bin, rank, count, returnType) {
   var op = new MapOperation(opcodes.MAP_GET_BY_RANK_RANGE, bin)

--- a/src/main/operations.cc
+++ b/src/main/operations.cc
@@ -733,6 +733,46 @@ int add_list_remove_by_value_range_op(as_operations* ops, Local<Object> op, LogI
 	return AS_NODE_PARAM_OK;
 }
 
+int add_list_remove_by_value_rel_rank_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* value = NULL;
+	if (get_asval_property(&value, op, "value", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t rank;
+	if (get_int64_property(&rank, op, "rank", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_list_return_type return_type;
+	if (get_list_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, count=%i, return_type=%i", binName, as_val_tostring(value), rank, count, return_type);
+		as_operations_add_list_remove_by_value_rel_rank_range(ops, binName, value, rank, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, return_type=%i", binName, as_val_tostring(value), rank, return_type);
+		as_operations_add_list_remove_by_value_rel_rank_range_to_end(ops, binName, value, rank, return_type);
+	}
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
 int add_list_remove_by_rank_op(as_operations* ops, Local<Object> op, LogInfo* log)
 {
 	char* binName;
@@ -1029,6 +1069,46 @@ int add_list_get_by_value_range_op(as_operations* ops, Local<Object> op, LogInfo
 
 	as_v8_debug(log, "bin=%s, begin=%s, end=%s, return_type=%i", binName, as_val_tostring(begin), as_val_tostring(end), return_type);
 	as_operations_add_list_get_by_value_range(ops, binName, begin, end, return_type);
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
+int add_list_get_by_value_rel_rank_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* value = NULL;
+	if (get_asval_property(&value, op, "value", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t rank;
+	if (get_int64_property(&rank, op, "rank", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_list_return_type return_type;
+	if (get_list_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, count=%i, return_type=%i", binName, as_val_tostring(value), rank, count, return_type);
+		as_operations_add_list_get_by_value_rel_rank_range(ops, binName, value, rank, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, return_type=%i", binName, as_val_tostring(value), rank, return_type);
+		as_operations_add_list_get_by_value_rel_rank_range_to_end(ops, binName, value, rank, return_type);
+	}
 
 	if (binName != NULL) free(binName);
 	return AS_NODE_PARAM_OK;
@@ -1370,6 +1450,46 @@ int add_map_remove_by_key_range_op(as_operations* ops, Local<Object> obj, LogInf
 	return AS_NODE_PARAM_OK;
 }
 
+int add_map_remove_by_key_rel_index_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName = NULL;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* key;
+	if (get_asval_property(&key, op, "key", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t index;
+	if (get_int64_property(&index, op, "index", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_map_return_type return_type;
+	if (get_map_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, key=%s, index=%i, count=%i, return_type=%i", binName, as_val_tostring(key), index, count, return_type);
+		as_operations_add_map_remove_by_key_rel_index_range(ops, binName, key, index, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, key=%s, index=%i, return_type=%i", binName, as_val_tostring(key), index, return_type);
+		as_operations_add_map_remove_by_key_rel_index_range_to_end(ops, binName, key, index, return_type);
+	}
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
 int add_map_remove_by_value_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 {
 	char* binName = NULL;
@@ -1444,6 +1564,46 @@ int add_map_remove_by_value_range_op(as_operations* ops, Local<Object> obj, LogI
 
 	as_v8_debug(log, "bin=%s, begin=%s, end=%s, return_type=%i", binName, as_val_tostring(begin), as_val_tostring(end), return_type);
 	as_operations_add_map_remove_by_value_range(ops, binName, begin, end, return_type);
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
+int add_map_remove_by_value_rel_rank_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName = NULL;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* value = NULL;
+	if (get_asval_property(&value, op, "value", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t rank;
+	if (get_int64_property(&rank, op, "rank", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_map_return_type return_type;
+	if (get_map_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, count=%i, return_type=%i", binName, as_val_tostring(value), rank, count, return_type);
+		as_operations_add_map_remove_by_value_rel_rank_range(ops, binName, value, rank, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, return_type=%i", binName, as_val_tostring(value), rank, return_type);
+		as_operations_add_map_remove_by_value_rel_rank_range_to_end(ops, binName, value, rank, return_type);
+	}
 
 	if (binName != NULL) free(binName);
 	return AS_NODE_PARAM_OK;
@@ -1636,6 +1796,46 @@ int add_map_get_by_key_range_op(as_operations* ops, Local<Object> obj, LogInfo* 
 	return AS_NODE_PARAM_OK;
 }
 
+int add_map_get_by_key_rel_index_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName = NULL;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* key;
+	if (get_asval_property(&key, op, "key", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t index;
+	if (get_int64_property(&index, op, "index", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_map_return_type return_type;
+	if (get_map_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, key=%s, index=%i, count=%i, return_type=%i", binName, as_val_tostring(key), index, count, return_type);
+		as_operations_add_map_get_by_key_rel_index_range(ops, binName, key, index, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, key=%s, index=%i, return_type=%i", binName, as_val_tostring(key), index, return_type);
+		as_operations_add_map_get_by_key_rel_index_range_to_end(ops, binName, key, index, return_type);
+	}
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
 int add_map_get_by_value_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 {
 	char* binName = NULL;
@@ -1686,6 +1886,46 @@ int add_map_get_by_value_range_op(as_operations* ops, Local<Object> obj, LogInfo
 
 	as_v8_debug(log, "bin=%s, begin=%s, end=%s, return_type=%i", binName, as_val_tostring(begin), as_val_tostring(end), return_type);
 	as_operations_add_map_get_by_value_range(ops, binName, begin, end, return_type);
+
+	if (binName != NULL) free(binName);
+	return AS_NODE_PARAM_OK;
+}
+
+int add_map_get_by_value_rel_rank_range_op(as_operations* ops, Local<Object> op, LogInfo* log)
+{
+	char* binName = NULL;
+	if (get_string_property(&binName, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_val* value = NULL;
+	if (get_asval_property(&value, op, "value", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	int64_t rank;
+	if (get_int64_property(&rank, op, "rank", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool count_defined;
+	int64_t count;
+	if (get_optional_int64_property(&count, &count_defined, op, "count", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_map_return_type return_type;
+	if (get_map_return_type(&return_type, op, log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	if (count_defined) {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, count=%i, return_type=%i", binName, as_val_tostring(value), rank, count, return_type);
+		as_operations_add_map_get_by_value_rel_rank_range(ops, binName, value, rank, count, return_type);
+	} else {
+		as_v8_debug(log, "bin=%s, value=%s, rank=%i, return_type=%i", binName, as_val_tostring(value), rank, return_type);
+		as_operations_add_map_get_by_value_rel_rank_range_to_end(ops, binName, value, rank, return_type);
+	}
 
 	if (binName != NULL) free(binName);
 	return AS_NODE_PARAM_OK;
@@ -1838,6 +2078,7 @@ const ops_table_entry ops_table[] = {
 	{ "LIST_REMOVE_BY_VALUE", add_list_remove_by_value_op },
 	{ "LIST_REMOVE_BY_VALUE_LIST", add_list_remove_by_value_list_op },
 	{ "LIST_REMOVE_BY_VALUE_RANGE", add_list_remove_by_value_range_op },
+	{ "LIST_REMOVE_BY_VALUE_REL_RANK_RANGE", add_list_remove_by_value_rel_rank_range_op },
 	{ "LIST_REMOVE_BY_RANK", add_list_remove_by_rank_op },
 	{ "LIST_REMOVE_BY_RANK_RANGE", add_list_remove_by_rank_range_op },
 	{ "LIST_CLEAR", add_list_clear_op },
@@ -1850,6 +2091,7 @@ const ops_table_entry ops_table[] = {
 	{ "LIST_GET_BY_VALUE", add_list_get_by_value_op },
 	{ "LIST_GET_BY_VALUE_LIST", add_list_get_by_value_list_op },
 	{ "LIST_GET_BY_VALUE_RANGE", add_list_get_by_value_range_op },
+	{ "LIST_GET_BY_VALUE_REL_RANK_RANGE", add_list_get_by_value_rel_rank_range_op },
 	{ "LIST_GET_BY_RANK", add_list_get_by_rank_op },
 	{ "LIST_GET_BY_RANK_RANGE", add_list_get_by_rank_range_op },
 	{ "LIST_INCREMENT", add_list_increment_op },
@@ -1863,9 +2105,11 @@ const ops_table_entry ops_table[] = {
 	{ "MAP_REMOVE_BY_KEY", add_map_remove_by_key_op },
 	{ "MAP_REMOVE_BY_KEY_LIST", add_map_remove_by_key_list_op },
 	{ "MAP_REMOVE_BY_KEY_RANGE", add_map_remove_by_key_range_op },
+	{ "MAP_REMOVE_BY_KEY_REL_INDEX_RANGE", add_map_remove_by_key_rel_index_range_op },
 	{ "MAP_REMOVE_BY_VALUE", add_map_remove_by_value_op },
 	{ "MAP_REMOVE_BY_VALUE_LIST", add_map_remove_by_value_list_op },
 	{ "MAP_REMOVE_BY_VALUE_RANGE", add_map_remove_by_value_range_op },
+	{ "MAP_REMOVE_BY_VALUE_REL_RANK_RANGE", add_map_remove_by_value_rel_rank_range_op },
 	{ "MAP_REMOVE_BY_INDEX", add_map_remove_by_index_op },
 	{ "MAP_REMOVE_BY_INDEX_RANGE", add_map_remove_by_index_range_op },
 	{ "MAP_REMOVE_BY_RANK", add_map_remove_by_rank_op },
@@ -1873,8 +2117,10 @@ const ops_table_entry ops_table[] = {
 	{ "MAP_SIZE", add_map_size_op },
 	{ "MAP_GET_BY_KEY", add_map_get_by_key_op },
 	{ "MAP_GET_BY_KEY_RANGE", add_map_get_by_key_range_op },
+	{ "MAP_GET_BY_KEY_REL_INDEX_RANGE", add_map_get_by_key_rel_index_range_op },
 	{ "MAP_GET_BY_VALUE", add_map_get_by_value_op },
 	{ "MAP_GET_BY_VALUE_RANGE", add_map_get_by_value_range_op },
+	{ "MAP_GET_BY_VALUE_REL_RANK_RANGE", add_map_get_by_value_rel_rank_range_op },
 	{ "MAP_GET_BY_INDEX", add_map_get_by_index_op },
 	{ "MAP_GET_BY_INDEX_RANGE", add_map_get_by_index_range_op },
 	{ "MAP_GET_BY_RANK", add_map_get_by_rank_op },

--- a/test/query.js
+++ b/test/query.js
@@ -16,7 +16,8 @@
 
 'use strict'
 
-/* global expect, describe, it, beforeEach, before, after, context */
+/* eslint-env mocha */
+/* global expect */
 
 const Aerospike = require('../lib/aerospike')
 const Query = require('../lib/query')
@@ -218,11 +219,7 @@ describe('Queries', function () {
     })
 
     context('with nobins set to true', function () {
-      beforeEach(function () {
-        if (!helper.cluster.build_gte('3.15.0')) {
-          this.skip('query with nobins flag not supported')
-        }
-      })
+      helper.cluster.skip_unless_version('3.15.0', this)
 
       it('should return only meta data', function (done) {
         var query = client.query(helper.namespace, testSet)

--- a/test/remove.js
+++ b/test/remove.js
@@ -82,29 +82,20 @@ describe('client.remove()', function () {
     })
   })
 
-  it('should apply the durable delete policy', function (done) {
-    if (!helper.cluster.is_enterprise()) {
-      return this.skip('durable delete requires enterprise edition')
-    }
-    let key = keygen.string(helper.namespace, helper.set, {prefix: 'test/remove/gen/'})()
-    let meta = { ttl: 1000 }
-    let record = recgen.record({i: valgen.integer(), s: valgen.string(), b: valgen.bytes()})()
-    let policy = new Aerospike.RemovePolicy({
-      durableDelete: true
-    })
+  context('with durable delete policy', function () {
+    helper.cluster.skip_unless_enterprise(this)
 
-    client.put(key, record, meta, function (err) {
-      if (err) throw err
-
-      client.remove(key, policy, function (err) {
-        if (err) throw err
-
-        client.exists(key, function (error, result) {
-          if (error) throw error
-          expect(result).to.be.false()
-          done()
-        })
+    it('should apply the durable delete policy', function () {
+      let key = keygen.string(helper.namespace, helper.set, {prefix: 'test/remove/gen/'})()
+      let record = recgen.record({i: valgen.integer(), s: valgen.string(), b: valgen.bytes()})()
+      let policy = new Aerospike.RemovePolicy({
+        durableDelete: true
       })
+
+      return client.put(key, record)
+        .then(() => client.remove(key, policy))
+        .then(() => client.exists(key))
+        .then(result => expect(result).to.be.false())
     })
   })
 })

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -112,16 +112,32 @@ function ServerInfoHelper () {
   this.cluster = []
 }
 
-ServerInfoHelper.prototype.supports_feature = function (feature) {
-  return this.features.has(feature)
+ServerInfoHelper.prototype.skip_unless_supports_feature = function (feature, ctx) {
+  let cluster = this
+  ctx.beforeEach(function () {
+    if (!cluster.features.has(feature)) {
+      this.skip('requires server feature "' + feature + '"')
+    }
+  })
 }
 
-ServerInfoHelper.prototype.is_enterprise = function () {
-  return this.edition.match('Enterprise')
+ServerInfoHelper.prototype.skip_unless_enterprise = function (ctx) {
+  let cluster = this
+  ctx.beforeEach(function () {
+    if (!cluster.edition.match('Enterprise')) {
+      this.skip('requires enterprise edition')
+    }
+  })
 }
 
-ServerInfoHelper.prototype.build_gte = function (minVer) {
-  return semver.compare(this.build, minVer) >= 0
+ServerInfoHelper.prototype.skip_unless_version = function (minVer, ctx) {
+  let cluster = this
+  ctx.beforeEach(function () {
+    let build = process.env.AEROSPIKE_VERSION_OVERRIDE || cluster.build
+    if (semver.compare(build, minVer) < 0) {
+      this.skip('requires server version ' + minVer + ' or later')
+    }
+  })
 }
 
 ServerInfoHelper.prototype.fetch_info = function () {

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-/* global describe, it, beforeEach */
+/* eslint-env mocha */
 
 const Aerospike = require('../lib/aerospike')
 const helper = require('./test_helper')
@@ -32,13 +32,9 @@ const recgen = helper.recgen
 const putgen = helper.putgen
 
 describe('client.truncate()', function () {
-  var client = helper.client
+  helper.cluster.skip_unless_version('3.12.0', this)
 
-  beforeEach(function () {
-    if (!helper.cluster.build_gte('3.12.0')) {
-      this.skip('truncate ns/set feature not supported')
-    }
-  })
+  var client = helper.client
 
   // Generates a number of records; the callback function is called with a list
   // of the record keys.


### PR DESCRIPTION
Implements support for 6 new list/map "relative range" operations:
* `lists.getByValueRelRankRange` - retrieves list items nearest to value and greater, by relative rank range
* `lists.removeByValueRelRankRange` - removes list items nearest to value and greater, by relative rank range
* `maps.getByKeyRelIndexRange` - retrieves map items nearest to key and greater, by relative index range
* `maps.getByValueRelRankRange` - retrieves map items nearest to value and greater, by relative rank range
* `maps.removeByKeyRelIndexRange` - removes map items nearest to key and greater, by relative index range
* `maps.removeByValueRelRankRange` - removes map items nearest to value and greater, by relative rank range

Requires C client v4.3.14 and server v4.3 or later. (Unit tests for new operations should be skipped until server version 4.3.0 is released to www.aerospike.com.)

References:
* https://www.aerospike.com/docs/guide/cdt-list-ops.html
* https://www.aerospike.com/docs/guide/cdt-map-ops.html