### PR TITLE
Support "deserialize" read policy setting

### DIFF
--- a/lib/policies/batch_policy.js
+++ b/lib/policies/batch_policy.js
@@ -45,6 +45,15 @@ class BatchPolicy extends BasePolicy {
     this.consistencyLevel = props.consistencyLevel
 
     /**
+     * Should CDT data types (Lists / Maps) be deserialized to JS data types
+     * (Arrays / Objects) or returned as raw bytes (Buffer).
+     *
+     * @type boolean
+     * @default <code>true</code>
+     */
+    this.deserialize = props.deserialize
+
+    /**
      * Allow batch to be processed immediately in the server's receiving thread
      * when the server deems it to be appropriate. If false, the batch will
      * always be processed in separate transaction threads.

--- a/lib/policies/operate_policy.js
+++ b/lib/policies/operate_policy.js
@@ -86,6 +86,15 @@ class OperatePolicy extends BasePolicy {
     this.commitLevel = props.commitLevel
 
     /**
+     * Should CDT data types (Lists / Maps) be deserialized to JS data types
+     * (Arrays / Objects) or returned as raw bytes (Buffer).
+     *
+     * @type boolean
+     * @default <code>true</code>
+     */
+    this.deserialize = props.deserialize
+
+    /**
      * Specifies whether a {@link
      * http://www.aerospike.com/docs/guide/durable_deletes.html|tombstone}
      * should be written in place of a record that gets deleted as a result of

--- a/lib/policies/query_policy.js
+++ b/lib/policies/query_policy.js
@@ -35,6 +35,15 @@ class QueryPolicy extends BasePolicy {
     super(props)
 
     /**
+     * Should CDT data types (Lists / Maps) be deserialized to JS data types
+     * (Arrays / Objects) or returned as raw bytes (Buffer).
+     *
+     * @type boolean
+     * @default <code>true</code>
+     */
+    this.deserialize = props.deserialize
+
+    /**
      * Terminate the query if the cluster is in migration state.
      *
      * Requires Aerospike Server version 4.2.0.2 or later.

--- a/lib/policies/read_policy.js
+++ b/lib/policies/read_policy.js
@@ -68,6 +68,15 @@ class ReadPolicy extends BasePolicy {
      * @default <code>false</code>
      */
     this.linearizeRead = props.linearizeRead
+
+    /**
+     * Should CDT data types (lists, maps) be deserialized to JS arrays,
+     * objects or returned as raw bytes (Buffer).
+     *
+     * @type boolean
+     * @default <code>true</code>
+     */
+    this.deserialize = props.deserialize
   }
 }
 

--- a/lib/policies/read_policy.js
+++ b/lib/policies/read_policy.js
@@ -61,6 +61,15 @@ class ReadPolicy extends BasePolicy {
     this.consistencyLevel = props.consistencyLevel
 
     /**
+     * Should CDT data types (Lists / Maps) be deserialized to JS data types
+     * (Arrays / Objects) or returned as raw bytes (Buffer).
+     *
+     * @type boolean
+     * @default <code>true</code>
+     */
+    this.deserialize = props.deserialize
+
+    /**
      * Force reads to be linearized for server namespaces that support strong
      * consistency (aka CP mode).
      *
@@ -68,15 +77,6 @@ class ReadPolicy extends BasePolicy {
      * @default <code>false</code>
      */
     this.linearizeRead = props.linearizeRead
-
-    /**
-     * Should CDT data types (lists, maps) be deserialized to JS arrays,
-     * objects or returned as raw bytes (Buffer).
-     *
-     * @type boolean
-     * @default <code>true</code>
-     */
-    this.deserialize = props.deserialize
   }
 }
 

--- a/src/main/policy.cc
+++ b/src/main/policy.cc
@@ -113,6 +113,9 @@ int operatepolicy_from_jsobject(as_policy_operate* policy, Local<Object> obj, co
 	if ((rc = get_optional_uint32_property((uint32_t*) &policy->consistency_level, NULL, obj, "consistencyLevel", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
+	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
 	if ((rc = get_optional_bool_property(&policy->durable_delete, NULL, obj, "durableDelete", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
@@ -131,6 +134,9 @@ int batchpolicy_from_jsobject(as_policy_batch* policy, Local<Object> obj, const 
 		return rc;
 	}
 	if ((rc = get_optional_uint32_property((uint32_t*) &policy->consistency_level, NULL, obj, "consistencyLevel", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
+	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
 	if ((rc = get_optional_bool_property(&policy->allow_inline, NULL, obj, "allowInline", log)) != AS_NODE_PARAM_OK) {
@@ -188,10 +194,10 @@ int readpolicy_from_jsobject(as_policy_read* policy, Local<Object> obj, const Lo
 	if ((rc = get_optional_uint32_property((uint32_t*) &policy->consistency_level, NULL, obj, "consistencyLevel", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
-	if ((rc = get_optional_bool_property(&policy->linearize_read, NULL, obj, "linearizeRead", log)) != AS_NODE_PARAM_OK) {
+	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
-	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
+	if ((rc = get_optional_bool_property(&policy->linearize_read, NULL, obj, "linearizeRead", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
 	as_v8_detail(log, "Parsing read policy: success");
@@ -261,6 +267,9 @@ int querypolicy_from_jsobject(as_policy_query* policy, Local<Object> obj, const 
 	int rc = 0;
 	as_policy_query_init(policy);
 	if ((rc = basepolicy_from_jsobject(&policy->base, obj, log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
+	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
 	if ((rc = get_optional_bool_property(&policy->fail_on_cluster_change, NULL, obj, "failOnClusterChange", log)) != AS_NODE_PARAM_OK) {

--- a/src/main/policy.cc
+++ b/src/main/policy.cc
@@ -191,6 +191,9 @@ int readpolicy_from_jsobject(as_policy_read* policy, Local<Object> obj, const Lo
 	if ((rc = get_optional_bool_property(&policy->linearize_read, NULL, obj, "linearizeRead", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
+	if ((rc = get_optional_bool_property(&policy->deserialize, NULL, obj, "deserialize", log)) != AS_NODE_PARAM_OK) {
+		return rc;
+	}
 	as_v8_detail(log, "Parsing read policy: success");
 	return AS_NODE_PARAM_OK;
 }

--- a/test/query.js
+++ b/test/query.js
@@ -435,6 +435,25 @@ describe('Queries', function () {
         expect(records[0].bins.name).to.eq('int match')
       })
     })
+
+    context('with QueryPolicy', function () {
+      context('with deserialize: false', function () {
+        const policy = new Aerospike.QueryPolicy({
+          deserialize: false
+        })
+
+        it('returns lists and maps as byte buffers', function () {
+          const query = client.query(helper.namespace, testSet)
+          query.where(filter.equal('name', 'int list match'))
+
+          return query.results(policy)
+            .then(records => {
+              expect(records.length).to.eq(1)
+              expect(records[0].bins.li).to.eql(Buffer.from([0x93, 0x01, 0x05, 0x09]))
+            })
+        })
+      })
+    })
   })
 
   describe('query.apply()', function () {


### PR DESCRIPTION
When setting `ReadPolicy#deserialize` to `false` (default is `true`) the
client will return CDT (list/map) bins as raw byte buffers.