### PR TITLE
Fix parsing for set/<ns>/<set> info command response

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -16,6 +16,8 @@
 
 'use strict'
 
+const minimatch = require('minimatch')
+
 /**
  * @module aerospike/info
  *
@@ -69,7 +71,7 @@ function parse (info) {
   Object.keys(infoHash).forEach(key => {
     let separators = getSeparators(key)
     let value = infoHash[key]
-    infoHash[key] = splitString(value, separators)
+    infoHash[key] = deepSplitString(value, separators)
   })
   return infoHash
 }
@@ -137,33 +139,14 @@ function smartParse (str, sep1, sep2) {
 }
 
 /**
- * Normalizes the key name in an info hash by turning a parameterized key into
- * a unique key name.
- *
- * Ex.:
- *   - normalizeKey('sindex/test/idx-name') => 'sindex-stats'
- *
- * @private
- */
-function normalizeKey (key) {
-  if (key.startsWith('sindex')) {
-    return key.split('/').length === 3 ? 'sindex-stats' : 'sindex-list'
-  } else if (key.startsWith('bins/')) {
-    return 'bins-ns'
-  } else if (key.startsWith('namespace/')) {
-    return 'namespace'
-  }
-  return key
-}
-
-/**
  * Returns separators to use for the given info key.
  *
  * @private
  */
 function getSeparators (key) {
-  let name = normalizeKey(key)
-  return separators[name] || defaultSeparators
+  let pattern = Object.keys(separators).find(p => minimatch(key, p))
+  const seps = separators[pattern] || defaultSeparators
+  return seps.slice() // return a copy of the array
 }
 
 /**
@@ -172,30 +155,48 @@ function getSeparators (key) {
  *
  * @private
  */
-function splitString (str, separators) {
-  if (separators.length === 0) {
-    return str
+function deepSplitString (input, separators) {
+  if (input === null || typeof input === 'undefined') {
+    return input
   }
-  var sep = separators[0]
+  if (separators.length === 0) {
+    return input
+  }
+
+  const sep = separators.shift()
+  let output = input
+
+  if (typeof input === 'string') {
+    output = splitString(input, sep)
+  } else if (Array.isArray(input)) {
+    output = input.map(i => splitString(i, sep))
+  } else if (typeof input === 'object') {
+    output = {}
+    Object.keys(input).forEach(key => {
+      output[key] = splitString(input[key], sep)
+    })
+  }
+
+  if (separators.length > 0) {
+    return deepSplitString(output, separators)
+  } else {
+    return output
+  }
+}
+
+function splitString (input, sep) {
   switch (typeof sep) {
     case 'function':
-      return sep(str)
+      return sep(input)
     case 'string':
       if (sep.length === 2) {
-        var map = parseKeyValue(str, sep[0], sep[1])
-        Object.keys(map).forEach(function (key) {
-          var value = map[key]
-          map[key] = splitString(value, separators.slice(1))
-        })
-        return map
+        return parseKeyValue(input, sep[0], sep[1])
       } else {
-        var list = str.split(sep)
-        if (list.slice(-1)[0].length === 0) {
+        let list = input.split(sep)
+        if (list[list.length - 1].length === 0) {
           list.pop()
         }
-        return list.map(function (e) {
-          return splitString(e, separators.slice(1))
-        })
+        return list
       }
   }
 }
@@ -212,14 +213,19 @@ function splitString (str, separators) {
  */
 let separators = {
   'bins': [';:', splitBins],
-  'bins-ns': [splitBins],
-  'namespace': [';='],
+  'bins/*': [splitBins],
+  'namespace/*': [';='],
   'service': [';'],
-  'sindex-list': [';', ':='],
+  'sindex': [';', ':='],
+  'sindex/*': [';', ':='],
+  'sindex/*/**': [';='],
   'statistics': [';='],
   'udf-list': [';', ',='],
   'udf-stats': [';='],
-  'get-dc-config': [';', ':=']
+  'get-dc-config': [';', ':='],
+  'sets': [';', ':='],
+  'sets/*': [';', ':='],
+  'sets/*/**': [chop, ':='] // remove trailing ';' to return single object rather than list of objects
 }
 
 let defaultSeparators = [smartParse]
@@ -227,6 +233,11 @@ let defaultSeparators = [smartParse]
 /**********************************************************
  * Functions for dealing with specific info command results
  **********************************************************/
+
+/** Returns a new string with the last character removed */
+function chop (str) {
+  return str.substring(0, str.length - 1)
+}
 
 function splitBins (str) {
   var stats = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,8 +198,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -223,10 +222,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -475,8 +473,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1695,7 +1692,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.0",
+    "minimatch": "^3.0.4",
     "nan": "^2.10.0"
   },
   "devDependencies": {

--- a/test/info.js
+++ b/test/info.js
@@ -155,6 +155,12 @@ context('Info commands', function () {
       ])
     })
 
+    it('should parse empty udf-list info key and return empty array', function () {
+      var infoStr = 'udf-list\t'
+      var infoHash = info.parse(infoStr)
+      expect(infoHash['udf-list']).to.eql([])
+    })
+
     it('should parse the bins info key', function () {
       let infoStr = 'bins\ttest:bin_names=2,bin_names_quota=32768,bin1,bin2;'
       let infoHash = info.parse(infoStr)
@@ -165,6 +171,18 @@ context('Info commands', function () {
         }
       }
       expect(infoHash['bins']).to.deep.equal(expected)
+    })
+
+    it('should pick the right separators to parse based on the key pattern', function () {
+      let infoStr = 'sets/test/foo/bar\tobjects=0:tombstones=0:truncate_lut=275452156000:disable-eviction=false;'
+      let infoHash = info.parse(infoStr)
+      let expected = {
+        objects: 0,
+        tombstones: 0,
+        truncate_lut: 275452156000,
+        'disable-eviction': 'false'
+      }
+      expect(infoHash['sets/test/foo/bar']).to.deep.equal(expected)
     })
   })
 })


### PR DESCRIPTION
* Use ':=' separators rather than the default ';='.
* Remove trailing ';' to parse response as single object rather than
  list of objects.
* Use minimatch library to match info keys to separators; remove need
  for normalizeKey function.

Ref. CLIENT-1044