### PR TITLE
Support using server's alternate-access-address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+* **Bug Fixes**
+  * Support using alternate-access-address. [#267](https://github.com/aerospike/aerospike-client-nodejs/issue/267)
+
 ## [3.7.0] - 2018-10-02
 
 * **New Features**

--- a/lib/config.js
+++ b/lib/config.js
@@ -368,6 +368,18 @@ class Config {
     if (typeof config.sharedMemory === 'object') {
       this.sharedMemory = config.sharedMemory
     }
+
+    /**
+     * @name Config#useAlternateAccessAddress
+     * @summary Whether the client should use the server's
+     * <code>alternate-access-address</code> instead of the
+     * <code>access-address</code>.
+     *
+     * @type {boolean}
+     * @default false
+     * @since v3.7.1
+     */
+    this.useAlternateAccessAddress = Boolean(config.useAlternateAccessAddress)
   }
 
   /**

--- a/src/main/config.cc
+++ b/src/main/config.cc
@@ -230,6 +230,9 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 	if ((rc = get_optional_uint32_property(&config->max_conns_per_node, NULL, configObj, "maxConnsPerNodeSync", log)) != AS_NODE_PARAM_OK) {
 		goto Cleanup;
 	}
+	if ((rc = get_optional_bool_property(&config->use_services_alternate, NULL, configObj, "useAlternateAccessAddress", log)) != AS_NODE_PARAM_OK) {
+		goto Cleanup;
+	}
 
 Cleanup:
 	if (cluster_name) free(cluster_name);


### PR DESCRIPTION
Adds a new useAlternateAccessAddress config flag, which, when set to
true`, instructs the client to use the alternate access address published
by the server(s).

This was _kind_ _of_ supported in client v3.4 and earlier but required
that the client's seed address list contains the complete list of the
alternate access addresses of all cluster nodes. The v3.4 and earlier
clients were not able to automatically detect new cluster hosts, not
included in the seed address list, using the alternate access address.

This partial support for alternate-access-address was broken in Node.js
client v3.5.0 (using C client v4.3.14) due to the introduction of a new
feature that automatically detects if the seed address used by the
client is a load balancer address. Due to this change, the v3.5.0 and
later client will always lookup the cluster nodes' actual access-address
and use that instead of the address used as the seed address.

Resolves #267.