### PR TITLE
Pass client config through to test cases launched in separate process

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -191,12 +191,14 @@ exports.fail = function fail (message) {
   expect().fail(message)
 }
 
-exports.runInNewProcess = function (fn, timeout) {
-  let env = {
-    NODE_PATH: path.join(process.cwd(), 'node_modules'),
-    AEROSPIKE_HOSTS: utils.hostsToString(client.config.hosts)
+exports.runInNewProcess = function (fn, data) {
+  if (data === undefined) {
+    data = null
   }
-  return runInNewProcessFn(fn, timeout, env)
+  let env = {
+    NODE_PATH: path.join(process.cwd(), 'node_modules')
+  }
+  return runInNewProcessFn(fn, env, data)
 }
 
 if (process.env.GLOBAL_CLIENT !== 'false') {

--- a/test/util/options.js
+++ b/test/util/options.js
@@ -114,6 +114,8 @@ options.getConfig = function () {
   }
   if (options.host !== null) {
     config.hosts = [{addr: options.host, port: options.port || 3000}]
+  } else if (process.env['AEROSPIKE_HOSTS']) {
+    config.hosts = process.env['AEROSPIKE_HOSTS']
   }
   if (options.user !== null) {
     config.user = options.user


### PR DESCRIPTION
Some test cases that are launched in a separate Node.js process fail if the server uses user auth. Need to pass all the client config, incl. user/pwd, through to the spawned process.