### PR TITLE
Fix deprecation warnings in Node 10.12 & 11 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,9 +4,9 @@ image:
 platform: x64
 environment:
   matrix:
+    - nodejs_version: "10"
     - nodejs_version: "8"
     - nodejs_version: "6"
-    - nodejs_version: "4"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform

--- a/binding.gyp
+++ b/binding.gyp
@@ -100,6 +100,19 @@
         'src/include',
         "<!(node -e \"require('nan')\")",
       ],
+      'configurations': {
+        'Release': {
+            "cflags": [
+              "-Wno-deprecated-declarations",
+            ],
+            "xcode_settings": {
+              "OTHER_CFLAGS": [
+                "-Wno-deprecated-declarations",
+              ],
+            },
+            'msvs_disabled_warnings': [4996],
+          },
+      },
       'conditions': [
         ['OS=="linux"',{
           'libraries': [

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -46,7 +46,7 @@ NAN_METHOD(register_as_event_loop)
 
 	as_policy_event policy;
 	as_policy_event_init(&policy);
-	eventpolicy_from_jsobject(&policy, info[0]->ToObject(), &g_log_info);
+	eventpolicy_from_jsobject(&policy, info[0].As<Object>(), &g_log_info);
 
 	as_event_loop* loop;
 	as_error err;
@@ -76,7 +76,7 @@ NAN_METHOD(setDefaultLogging)
 {
 	Nan::HandleScope();
 	if (info[0]->IsObject()){
-		if (log_from_jsobject(&g_log_info, info[0]->ToObject()) == AS_NODE_PARAM_OK) {
+		if (log_from_jsobject(&g_log_info, info[0].As<Object>()) == AS_NODE_PARAM_OK) {
 			if (g_log_info.level < 0) {
 				// common logging does not support log level "OFF"
 				as_log_set_level(AS_LOG_LEVEL_ERROR);

--- a/src/main/async.cc
+++ b/src/main/async.cc
@@ -155,7 +155,7 @@ bool async_scan_listener(as_error* err, as_record* record, void* udata, as_event
 
 	bool continue_scan = true;
 	if (result->IsBoolean()) {
-		continue_scan = result->ToBoolean()->Value();
+		continue_scan = Nan::To<bool>(result).FromJust();
 		as_v8_debug(log, "Async scan callback returned: %s", continue_scan ? "true" : "false");
 	}
 	return continue_scan;

--- a/src/main/client.cc
+++ b/src/main/client.cc
@@ -64,18 +64,16 @@ NAN_METHOD(AerospikeClient::New)
 	as_config config;
 	as_config_init(&config);
 
-	if (info[0]->IsObject()) {
-		Local<Value> v8_log_info = info[0]->ToObject()->Get(Nan::New("log").ToLocalChecked()) ;
-		if (v8_log_info->IsObject()) {
-			log_from_jsobject(client->log, v8_log_info->ToObject());
-		}
+	Local<Object> v8Config = info[0].As<Object>();
+
+	Local<Value> v8LogInfo = v8Config->Get(Nan::New("log").ToLocalChecked()) ;
+	if (v8LogInfo->IsObject()) {
+		log_from_jsobject(client->log, v8LogInfo.As<Object>());
 	}
 
-	if (info[0]->IsObject()) {
-		int result = config_from_jsobject(&config, info[0]->ToObject(), client->log);
-		if (result != AS_NODE_PARAM_OK) {
-			Nan::ThrowError("Invalid client configuration");
-		}
+	int result = config_from_jsobject(&config, v8Config, client->log);
+	if (result != AS_NODE_PARAM_OK) {
+		Nan::ThrowError("Invalid client configuration");
 	}
 
 	aerospike_init(client->as, &config);
@@ -159,8 +157,8 @@ NAN_METHOD(AerospikeClient::AddSeedHost)
 	TYPE_CHECK_REQ(info[0], IsString, "hostname must be a string");
 	TYPE_CHECK_REQ(info[1], IsNumber, "port must be a number");
 
-	Nan::Utf8String hostname(info[0]->ToString());
-	uint16_t port = (uint16_t) info[1]->ToInteger()->Value();
+	Nan::Utf8String hostname(info[0].As<String>());
+	uint16_t port = (uint16_t) Nan::To<uint32_t>(info[1]).FromJust();
 
 	as_cluster_add_seed(client->as->cluster, *hostname, NULL, port);
 }
@@ -176,8 +174,8 @@ NAN_METHOD(AerospikeClient::RemoveSeedHost)
 	TYPE_CHECK_REQ(info[0], IsString, "hostname must be a string");
 	TYPE_CHECK_REQ(info[1], IsNumber, "port must be a number");
 
-	Nan::Utf8String hostname(info[0]->ToString());
-	uint16_t port = (uint16_t) info[1]->ToInteger()->Value();
+	Nan::Utf8String hostname(info[0].As<String>());
+	uint16_t port = (uint16_t) Nan::To<uint32_t>(info[1]).FromJust();
 
 	as_cluster_remove_seed(client->as->cluster, *hostname, port);
 }
@@ -186,7 +184,7 @@ NAN_METHOD(AerospikeClient::SetLogLevel)
 {
 	AerospikeClient* client = Nan::ObjectWrap::Unwrap<AerospikeClient>(info.Holder());
 	if (info[0]->IsObject()) {
-		log_from_jsobject(client->log, info[0]->ToObject());
+		log_from_jsobject(client->log, info[0].As<Object>());
 	}
 	info.GetReturnValue().Set(info.Holder());
 }

--- a/src/main/commands/apply_async.cc
+++ b/src/main/commands/apply_async.cc
@@ -46,19 +46,19 @@ NAN_METHOD(AerospikeClient::ApplyAsync)
 	char* udf_module = NULL;
 	char* udf_function = NULL;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
-	if (udfargs_from_jsobject(&udf_module, &udf_function, &udf_args, info[1]->ToObject(), log) != AS_NODE_PARAM_OK ) {
+	if (udfargs_from_jsobject(&udf_module, &udf_function, &udf_args, info[1].As<Object>(), log) != AS_NODE_PARAM_OK ) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "UDF args object invalid");
 		goto Cleanup;
 	}
 
 	if (info[2]->IsObject()) {
-		if (applypolicy_from_jsobject(&policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (applypolicy_from_jsobject(&policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/batch_exists.cc
+++ b/src/main/commands/batch_exists.cc
@@ -93,7 +93,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	if (info[1]->IsObject()) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (batchpolicy_from_jsobject(cmd->policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}

--- a/src/main/commands/batch_get.cc
+++ b/src/main/commands/batch_get.cc
@@ -94,7 +94,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	if (info[1]->IsObject() ) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-		if (batchpolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (batchpolicy_from_jsobject(cmd->policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}

--- a/src/main/commands/batch_read_async.cc
+++ b/src/main/commands/batch_read_async.cc
@@ -44,7 +44,7 @@ NAN_METHOD(AerospikeClient::BatchReadAsync)
 	}
 
 	if (info[1]->IsObject()) {
-		if (batchpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (batchpolicy_from_jsobject(&policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			free_batch_records(records);
 			goto Cleanup;

--- a/src/main/commands/batch_select.cc
+++ b/src/main/commands/batch_select.cc
@@ -105,7 +105,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	if (info[2]->IsObject() ) {
 		cmd->policy = (as_policy_batch*) cf_malloc(sizeof(as_policy_batch));
-		if (batchpolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (batchpolicy_from_jsobject(cmd->policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Batch policy parameter invalid");
 		}
 	}

--- a/src/main/commands/exists_async.cc
+++ b/src/main/commands/exists_async.cc
@@ -39,14 +39,14 @@ NAN_METHOD(AerospikeClient::ExistsAsync)
 	as_policy_read* p_policy = NULL;
 	as_status status;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
-		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (readpolicy_from_jsobject(&policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/get_async.cc
+++ b/src/main/commands/get_async.cc
@@ -39,14 +39,14 @@ NAN_METHOD(AerospikeClient::GetAsync)
 	as_policy_read* p_policy = NULL;
 	as_status status = AEROSPIKE_ERR;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
-		if (readpolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (readpolicy_from_jsobject(&policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/index_create.cc
+++ b/src/main/commands/index_create.cc
@@ -57,27 +57,27 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	IndexCreateCommand* cmd = new IndexCreateCommand(client, info[7].As<Function>());
 	LogInfo* log = client->log;
 
-	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0].As<String>()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
 		return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
 	}
 
 	if (info[1]->IsString()) {
-		if (as_strlcpy(cmd->set, *Nan::Utf8String(info[1]->ToString()), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
+		if (as_strlcpy(cmd->set, *Nan::Utf8String(info[1].As<String>()), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Set exceeds max. length (%d)", AS_SET_MAX_SIZE);
 		}
 	}
 
-	if (as_strlcpy(cmd->bin, *Nan::Utf8String(info[2]->ToString()), AS_BIN_NAME_MAX_LEN) > AS_BIN_NAME_MAX_LEN) {
+	if (as_strlcpy(cmd->bin, *Nan::Utf8String(info[2].As<String>()), AS_BIN_NAME_MAX_LEN) > AS_BIN_NAME_MAX_LEN) {
 		return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Bin name exceeds max. length (%d)", AS_BIN_NAME_MAX_LEN);
 	}
 
-	cmd->index = strdup(*Nan::Utf8String(info[3]->ToString()));
-	cmd->itype = (as_index_type) info[4]->ToInteger()->Value();
-	cmd->dtype = (as_index_datatype) info[5]->ToInteger()->Value();
+	cmd->index = strdup(*Nan::Utf8String(info[3].As<String>()));
+	cmd->itype = (as_index_type) Nan::To<int>(info[4]).FromJust();
+	cmd->dtype = (as_index_datatype) Nan::To<int>(info[5]).FromJust();
 
 	if (info[6]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[6]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (infopolicy_from_jsobject(cmd->policy, info[6].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/index_remove.cc
+++ b/src/main/commands/index_remove.cc
@@ -53,15 +53,15 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	IndexRemoveCommand* cmd = new IndexRemoveCommand(client, info[3].As<Function>());
 	LogInfo* log = cmd->log = client->log;
 
-	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0].As<String>()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
 		return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
 	}
 
-	cmd->index = strdup(*Nan::Utf8String(info[1]->ToString()));
+	cmd->index = strdup(*Nan::Utf8String(info[1].As<String>()));
 
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*)cf_malloc(sizeof(as_policy_info));
-		if(infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if(infopolicy_from_jsobject(cmd->policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/info.cc
+++ b/src/main/commands/info.cc
@@ -60,7 +60,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	if (info[0]->IsString()) {
 		cmd->request = (char*) cf_malloc(MAX_INFO_REQUEST_LEN);
-		size_t reqlen = as_strlcpy(cmd->request, *Nan::Utf8String(info[0]->ToString()), MAX_INFO_REQUEST_LEN);
+		size_t reqlen = as_strlcpy(cmd->request, *Nan::Utf8String(info[0].As<String>()), MAX_INFO_REQUEST_LEN);
 		if (reqlen > MAX_INFO_REQUEST_LEN) {
 			as_v8_info(log, "Info request exceeds max. length (%zu > %i): \"%s...\"", reqlen, MAX_INFO_REQUEST_LEN, cmd->request);
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Info request exceeds max. length");
@@ -70,14 +70,14 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 	}
 
 	if (info[1]->IsObject()) {
-		if (host_from_jsobject(info[1]->ToObject(), &cmd->addr, &cmd->port, log) != AS_NODE_PARAM_OK) {
+		if (host_from_jsobject(info[1].As<Object>(), &cmd->addr, &cmd->port, log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Host parameter is invalid");
 		}
 	}
 
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK ) {
+		if (infopolicy_from_jsobject(cmd->policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK ) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/info_foreach.cc
+++ b/src/main/commands/info_foreach.cc
@@ -95,7 +95,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	if (info[0]->IsString()) {
 		cmd->request = (char*) malloc(INFO_REQUEST_LEN);
-		if (as_strlcpy(cmd->request, *Nan::Utf8String(info[0]->ToString()), INFO_REQUEST_LEN) > INFO_REQUEST_LEN) {
+		if (as_strlcpy(cmd->request, *Nan::Utf8String(info[0].As<String>()), INFO_REQUEST_LEN) > INFO_REQUEST_LEN) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Info request exceeds max. length (%d)", INFO_REQUEST_LEN);
 		}
 	} else {
@@ -104,7 +104,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	if (info[1]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK ) {
+		if (infopolicy_from_jsobject(cmd->policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK ) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/job_info.cc
+++ b/src/main/commands/job_info.cc
@@ -54,12 +54,12 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	JobInfoCommand* cmd = new JobInfoCommand(client, info[3].As<Function>());
 	LogInfo* log = client->log;
 
-	cmd->job_id = info[0]->ToInteger()->Value();
-	cmd->module = strdup(*Nan::Utf8String(info[1]->ToString()));
+	cmd->job_id = Nan::To<int64_t>(info[0]).FromJust();
+	cmd->module = strdup(*Nan::Utf8String(info[1].As<String>()));
 
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (infopolicy_from_jsobject(cmd->policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/operate_async.cc
+++ b/src/main/commands/operate_async.cc
@@ -44,7 +44,7 @@ NAN_METHOD(AerospikeClient::OperateAsync)
 	as_policy_operate* p_policy = NULL;
 	as_status status;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
@@ -57,13 +57,13 @@ NAN_METHOD(AerospikeClient::OperateAsync)
 	operations_initalized = true;
 
 	if (info[2]->IsObject()) {
-		Local<Object> metadata = info[2]->ToObject();
+		Local<Object> metadata = info[2].As<Object>();
 		setTTL(metadata, &operations.ttl, log);
 		setGeneration(metadata, &operations.gen, log);
 	}
 
 	if (info[3]->IsObject()) {
-		if (operatepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (operatepolicy_from_jsobject(&policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/put_async.cc
+++ b/src/main/commands/put_async.cc
@@ -43,27 +43,27 @@ NAN_METHOD(AerospikeClient::PutAsync)
 	as_policy_write* p_policy = NULL;
 	as_status status;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
-	if (recordbins_from_jsobject(&record, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (recordbins_from_jsobject(&record, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Record object invalid");
 		goto Cleanup;
 	}
 	record_initalized = true;
 
 	if (info[2]->IsObject()) {
-		if (recordmeta_from_jsobject(&record, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (recordmeta_from_jsobject(&record, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Meta object invalid");
 			goto Cleanup;
 		}
 	}
 
 	if (info[3]->IsObject()) {
-		if (writepolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (writepolicy_from_jsobject(&policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -69,7 +69,7 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
-		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (querypolicy_from_jsobject(cmd->policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/query_async.cc
+++ b/src/main/commands/query_async.cc
@@ -52,7 +52,7 @@ NAN_METHOD(AerospikeClient::QueryAsync)
 	setup_query(&query, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (querypolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (querypolicy_from_jsobject(&policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -58,13 +58,13 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_write*) cf_malloc(sizeof(as_policy_write));
-		if (writepolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (writepolicy_from_jsobject(cmd->policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 
 	if (info[4]->IsNumber()) {
-		cmd->query_id = info[4]->ToInteger()->Value();
+		cmd->query_id = Nan::To<int64_t>(info[4]).FromJust();
 		as_v8_info(log, "Using query ID %lli for background query.", cmd->query_id);
 	}
 

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -155,7 +155,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_query*) cf_malloc(sizeof(as_policy_query));
-		if (querypolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (querypolicy_from_jsobject(cmd->policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/remove_async.cc
+++ b/src/main/commands/remove_async.cc
@@ -39,14 +39,14 @@ NAN_METHOD(AerospikeClient::RemoveAsync)
 	as_policy_remove* p_policy = NULL;
 	as_status status;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
 	key_initalized = true;
 
 	if (info[1]->IsObject()) {
-		if (removepolicy_from_jsobject(&policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (removepolicy_from_jsobject(&policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/scan_async.cc
+++ b/src/main/commands/scan_async.cc
@@ -54,7 +54,7 @@ NAN_METHOD(AerospikeClient::ScanAsync)
 	setup_scan(&scan, info[0], info[1], info[2], log);
 
 	if (info[3]->IsObject()) {
-		if (scanpolicy_from_jsobject(&policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (scanpolicy_from_jsobject(&policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}
@@ -62,7 +62,7 @@ NAN_METHOD(AerospikeClient::ScanAsync)
 	}
 
 	if (info[4]->IsNumber()) {
-		scan_id = info[4]->ToInteger()->Value();
+		scan_id = Nan::To<int64_t>(info[4]).FromJust();
 		as_v8_info(log, "Using scan ID %lli for async scan.", scan_id);
 	}
 

--- a/src/main/commands/scan_background.cc
+++ b/src/main/commands/scan_background.cc
@@ -58,13 +58,13 @@ prepare(const Nan::FunctionCallbackInfo<v8::Value> &info)
 
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_scan*) cf_malloc(sizeof(as_policy_scan));
-		if (scanpolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (scanpolicy_from_jsobject(cmd->policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}
 
 	if (info[4]->IsNumber()) {
-		cmd->scan_id = info[4]->ToInteger()->Value();
+		cmd->scan_id = Nan::To<int64_t>(info[4]).FromJust();
 		as_v8_info(log, "Using scan ID %lli for background scan.", cmd->scan_id);
 	}
 

--- a/src/main/commands/select_async.cc
+++ b/src/main/commands/select_async.cc
@@ -42,7 +42,7 @@ NAN_METHOD(AerospikeClient::SelectAsync)
 	as_policy_read* p_policy = NULL;
 	as_status status;
 
-	if (key_from_jsobject(&key, info[0]->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (key_from_jsobject(&key, info[0].As<Object>(), log) != AS_NODE_PARAM_OK) {
 		CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Key object invalid");
 		goto Cleanup;
 	}
@@ -54,7 +54,7 @@ NAN_METHOD(AerospikeClient::SelectAsync)
 	}
 
 	if (info[2]->IsObject()) {
-		if (readpolicy_from_jsobject(&policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (readpolicy_from_jsobject(&policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdErrorCallback(cmd, AEROSPIKE_ERR_PARAM, "Policy object invalid");
 			goto Cleanup;
 		}

--- a/src/main/commands/truncate.cc
+++ b/src/main/commands/truncate.cc
@@ -50,23 +50,23 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	TruncateCommand* cmd = new TruncateCommand(client, info[4].As<Function>());
 	LogInfo* log = client->log;
 
-	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0]->ToString()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
+	if (as_strlcpy(cmd->ns, *Nan::Utf8String(info[0].As<String>()), AS_NAMESPACE_MAX_SIZE) > AS_NAMESPACE_MAX_SIZE) {
 		return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Namespace exceeds max. length (%d)", AS_NAMESPACE_MAX_SIZE);
 	}
 
 	if (info[1]->IsString()) {
-		if (as_strlcpy(cmd->set, *Nan::Utf8String(info[1]->ToString()), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
+		if (as_strlcpy(cmd->set, *Nan::Utf8String(info[1].As<String>()), AS_SET_MAX_SIZE) > AS_SET_MAX_SIZE) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Set exceeds max. length (%d)", AS_SET_MAX_SIZE);
 		}
 	}
 
 	if (info[2]->IsNumber()) {
-		cmd->before_nanos = (uint64_t) info[2]->ToInteger()->Value();
+		cmd->before_nanos = (uint64_t) Nan::To<int64_t>(info[2]).FromJust();
 	}
 
 	if (info[3]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[3]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (infopolicy_from_jsobject(cmd->policy, info[3].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/commands/udf_register.cc
+++ b/src/main/commands/udf_register.cc
@@ -59,7 +59,7 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	UdfRegisterCommand* cmd = new UdfRegisterCommand(client, info[3].As<Function>());
 	LogInfo* log = client->log;
 
-	char* filepath = strdup(*Nan::Utf8String(info[0]->ToString()));
+	char* filepath = strdup(*Nan::Utf8String(info[0].As<String>()));
 	FILE * file = fopen(filepath, "r");
 	if (!file) {
 		CmdSetError(cmd, AEROSPIKE_ERR, "Cannot open file: %s", filepath);
@@ -121,14 +121,14 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	as_bytes_init_wrap(&cmd->content, file_content, size, true);
 
 	if (info[1]->IsNumber()) {
-		cmd->type = (as_udf_type) info[1]->IntegerValue();
+		cmd->type = (as_udf_type) Nan::To<int>(info[1]).FromJust();
 	} else {
 		cmd->type = AS_UDF_TYPE_LUA;
 	}
 
 	if (info[2]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[2]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (infopolicy_from_jsobject(cmd->policy, info[2].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 			if (filepath != NULL) cf_free(filepath);
 			return cmd;

--- a/src/main/commands/udf_remove.cc
+++ b/src/main/commands/udf_remove.cc
@@ -52,11 +52,11 @@ prepare(const Nan::FunctionCallbackInfo<Value> &info)
 	UdfRemoveCommand* cmd = new UdfRemoveCommand(client, info[2].As<Function>());
 	LogInfo* log = client->log;
 
-	cmd->module = strdup(*Nan::Utf8String(info[0]->ToString()));
+	cmd->module = strdup(*Nan::Utf8String(info[0].As<String>()));
 
 	if (info[1]->IsObject()) {
 		cmd->policy = (as_policy_info*) cf_malloc(sizeof(as_policy_info));
-		if (infopolicy_from_jsobject(cmd->policy, info[1]->ToObject(), log) != AS_NODE_PARAM_OK) {
+		if (infopolicy_from_jsobject(cmd->policy, info[1].As<Object>(), log) != AS_NODE_PARAM_OK) {
 			return CmdSetError(cmd, AEROSPIKE_ERR_PARAM, "Policy parameter is invalid");
 		}
 	}

--- a/src/main/config.cc
+++ b/src/main/config.cc
@@ -68,13 +68,13 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 	} else if (maybe_hosts->IsArray()) {
 		Local<Array> host_list = Local<Array>::Cast(maybe_hosts);
 		for (uint32_t i = 0; i < host_list->Length(); i++) {
-			Local<Object> host = host_list->Get(i)->ToObject();
+			Local<Object> host = host_list->Get(i).As<Object>();
 			Local<Value> maybe_addr = host->Get(Nan::New("addr").ToLocalChecked());
 			Local<Value> maybe_port = host->Get(Nan::New("port").ToLocalChecked());
 
 			uint16_t port = default_port;
 			if (maybe_port->IsNumber()) {
-				port = (uint16_t) maybe_port->IntegerValue();
+				port = (uint16_t) Nan::To<uint32_t>(maybe_port).FromJust();
 			} else if (maybe_port->IsUndefined()) {
 				// use default value
 			} else {
@@ -100,68 +100,68 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 	}
 
 	if (policies_val->IsObject()) {
-		Local<Object> policies_obj = policies_val->ToObject();
+		Local<Object> policies_obj = policies_val.As<Object>();
 		as_policies *policies = &config->policies;
 
 		Local<Value> policy_val = policies_obj->Get(Nan::New("apply").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = applypolicy_from_jsobject(&policies->apply, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = applypolicy_from_jsobject(&policies->apply, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("batch").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = batchpolicy_from_jsobject(&policies->batch, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = batchpolicy_from_jsobject(&policies->batch, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("info").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = infopolicy_from_jsobject(&policies->info, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = infopolicy_from_jsobject(&policies->info, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("operate").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = operatepolicy_from_jsobject(&policies->operate, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = operatepolicy_from_jsobject(&policies->operate, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("read").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = readpolicy_from_jsobject(&policies->read, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = readpolicy_from_jsobject(&policies->read, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("remove").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = removepolicy_from_jsobject(&policies->remove, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = removepolicy_from_jsobject(&policies->remove, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("scan").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = scanpolicy_from_jsobject(&policies->scan, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = scanpolicy_from_jsobject(&policies->scan, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("query").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = querypolicy_from_jsobject(&policies->query, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = querypolicy_from_jsobject(&policies->query, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
 
 		policy_val = policies_obj->Get(Nan::New("write").ToLocalChecked());
 		if (policy_val->IsObject()) {
-			if ((rc = writepolicy_from_jsobject(&policies->write, policy_val->ToObject(), log)) != AS_NODE_PARAM_OK) {
+			if ((rc = writepolicy_from_jsobject(&policies->write, policy_val.As<Object>(), log)) != AS_NODE_PARAM_OK) {
 				goto Cleanup;
 			}
 		}
@@ -171,7 +171,7 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 
 	// If modlua path is passed in config object, set those values here
 	if (configObj->Has(Nan::New("modlua").ToLocalChecked())) {
-		Local<Object> modlua = configObj->Get(Nan::New("modlua").ToLocalChecked())->ToObject();
+		Local<Object> modlua = configObj->Get(Nan::New("modlua").ToLocalChecked()).As<Object>();
 		if ((rc = get_optional_string_property(&user_path, &defined, modlua, "userPath", log)) != AS_NODE_PARAM_OK) {
 			goto Cleanup;
 		} else if (defined) {
@@ -196,7 +196,7 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 	}
 
 	if (configObj->Has(Nan::New("sharedMemory").ToLocalChecked())) {
-		Local<Object> shmConfigObj = configObj->Get(Nan::New("sharedMemory").ToLocalChecked())->ToObject();
+		Local<Object> shmConfigObj = configObj->Get(Nan::New("sharedMemory").ToLocalChecked()).As<Object>();
 		config->use_shm = true;
 		if ((rc = get_optional_bool_property(&config->use_shm, NULL, shmConfigObj, "enable", log)) != AS_NODE_PARAM_OK) {
 			goto Cleanup;

--- a/src/main/operations.cc
+++ b/src/main/operations.cc
@@ -44,12 +44,12 @@ int get_optional_list_policy(as_list_policy* policy, bool* has_policy, Local<Obj
 		return AS_NODE_PARAM_ERR;
 	}
 	if (has_policy != NULL) (*has_policy) = true;
-	Local<Object> policy_obj = maybe_policy_obj->ToObject();
+	Local<Object> policy_obj = maybe_policy_obj.As<Object>();
 
 	as_list_order order;
 	Local<Value> value = policy_obj->Get(Nan::New("order").ToLocalChecked());
 	if (value->IsNumber()) {
-		order = (as_list_order) value->IntegerValue();
+		order = (as_list_order) Nan::To<int>(value).FromJust();
 	} else if (value->IsUndefined()) {
 		order = AS_LIST_UNORDERED;
 	} else {
@@ -60,7 +60,7 @@ int get_optional_list_policy(as_list_policy* policy, bool* has_policy, Local<Obj
 	as_list_write_flags write_flags;
 	value = policy_obj->Get(Nan::New("writeFlags").ToLocalChecked());
 	if (value->IsNumber()) {
-		write_flags = (as_list_write_flags) value->IntegerValue();
+		write_flags = (as_list_write_flags) Nan::To<int>(value).FromJust();
 	} else if (value->IsUndefined()) {
 		write_flags = AS_LIST_WRITE_DEFAULT;
 	} else {
@@ -78,7 +78,7 @@ int get_list_return_type(as_list_return_type* return_type, Local<Object> obj, Lo
 	Nan::HandleScope scope;
 	Local<Value> value = obj->Get(Nan::New("returnType").ToLocalChecked());
 	if (value->IsNumber()) {
-		(*return_type) = (as_list_return_type) value->IntegerValue();
+		(*return_type) = (as_list_return_type) Nan::To<int>(value).FromJust();
 	} else if (value->IsUndefined()) {
 		(*return_type) = AS_LIST_RETURN_NONE;
 	} else {
@@ -112,7 +112,7 @@ int get_map_policy(as_map_policy* policy, Local<Object> obj, LogInfo* log)
 		as_v8_error(log, "Type error: policy should be an Object");
 		return AS_NODE_PARAM_ERR;
 	}
-	Local<Object> policy_obj = maybe_policy_obj->ToObject();
+	Local<Object> policy_obj = maybe_policy_obj.As<Object>();
 
 	as_map_order order = AS_MAP_UNORDERED;
 	bool order_set = false;
@@ -147,7 +147,7 @@ int get_map_return_type(as_map_return_type* return_type, Local<Object> obj, LogI
 	Nan::HandleScope scope;
 	Local<Value> value = obj->Get(Nan::New("returnType").ToLocalChecked());
 	if (value->IsNumber()) {
-		(*return_type) = (as_map_return_type) value->IntegerValue();
+		(*return_type) = (as_map_return_type) Nan::To<int>(value).FromJust();
 	} else if (value->IsUndefined()) {
 		(*return_type) = AS_MAP_RETURN_NONE;
 	} else {
@@ -174,7 +174,7 @@ int add_write_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 			rc = AS_NODE_PARAM_ERR;
 		}
 	} else if (v8val->IsNumber()) {
-		int64_t val = v8val->IntegerValue();
+		int64_t val = Nan::To<int64_t>(v8val).FromJust();
 		as_v8_debug(log, "bin=%s, value=%i", binName, val);
 		if (!as_operations_add_write_int64(ops, binName, val)) {
 			rc = AS_NODE_PARAM_ERR;
@@ -188,7 +188,7 @@ int add_write_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 	} else if (node::Buffer::HasInstance(v8val)) {
 		int len ;
 		uint8_t* data ;
-		if ((rc = extract_blob_from_jsobject(&data, &len, v8val->ToObject(), log)) == AS_NODE_PARAM_OK) {
+		if ((rc = extract_blob_from_jsobject(&data, &len, v8val.As<Object>(), log)) == AS_NODE_PARAM_OK) {
 			as_v8_debug(log, "bin=%s, value=<rawp>, len=%i", binName, len);
 			if (!as_operations_add_write_rawp(ops, binName, data, len, true)) {
 				rc = AS_NODE_PARAM_ERR;
@@ -266,7 +266,7 @@ int add_incr_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 		if (binName != NULL) free (binName);
 		return AS_NODE_PARAM_OK;
 	} else if (v8val->IsNumber()) {
-		int64_t binValue = v8val->IntegerValue();
+		int64_t binValue = Nan::To<int64_t>(v8val).FromJust();
 		as_v8_debug(log, "bin=%s, value=%i", binName, binValue);
 		as_operations_add_incr(ops, binName, binValue);
 		if (binName != NULL) free (binName);
@@ -294,7 +294,7 @@ int add_prepend_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 		if (binName) free(binName);
 		return AS_NODE_PARAM_OK;
 	} else if (v8val->IsObject()) {
-		Local<Object> binObj = v8val->ToObject();
+		Local<Object> binObj = v8val.As<Object>();
 		int len;
 		uint8_t* data;
 		if (extract_blob_from_jsobject(&data, &len, binObj, log) != AS_NODE_PARAM_OK) {
@@ -327,7 +327,7 @@ int add_append_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 		if (binName) free(binName);
 		return AS_NODE_PARAM_OK;
 	} else if (v8val->IsObject()) {
-		Local<Object> binObj = v8val->ToObject();
+		Local<Object> binObj = v8val.As<Object>();
 		int len ;
 		uint8_t* data ;
 		if (extract_blob_from_jsobject(&data, &len, binObj, log) != AS_NODE_PARAM_OK) {
@@ -1402,7 +1402,7 @@ int add_map_put_items_op(as_operations* ops, Local<Object> obj, LogInfo* log)
 		as_v8_error(log, "Type error: items property should be an Object");
 		return AS_NODE_PARAM_ERR;
 	}
-	if (map_from_jsobject(&items, v8items->ToObject(), log) != AS_NODE_PARAM_OK) {
+	if (map_from_jsobject(&items, v8items.As<Object>(), log) != AS_NODE_PARAM_OK) {
 		as_v8_error(log, "Type error: items property should be an Object");
 		return AS_NODE_PARAM_ERR;
 	}
@@ -2351,7 +2351,7 @@ int operations_from_jsarray(as_operations* ops, Local<Array> arr, LogInfo* log)
 	int result = AS_NODE_PARAM_OK;
 	int64_t op;
 	for (uint32_t i = 0; i < capacity; i++) {
-		Local<Object> obj = arr->Get(i)->ToObject();
+		Local<Object> obj = arr->Get(i).As<Object>();
 		setTTL(obj, &ops->ttl, log);
 		result = get_int64_property(&op, obj, "op", log);
 		if (result == AS_NODE_PARAM_OK) {

--- a/src/main/predexp.cc
+++ b/src/main/predexp.cc
@@ -92,7 +92,7 @@ const predex_table_entry predex_table[] = {
 as_predexp_base*
 convert_predexp(Local<Object> predexp)
 {
-	int code = (int) predexp->Get(Nan::New("code").ToLocalChecked())->ToObject()->IntegerValue();
+	int code = Nan::To<int>(predexp->Get(Nan::New("code").ToLocalChecked())).FromJust();
 	const predex_table_entry *entry = &predex_table[code];
 	if (!entry) {
 		return NULL;
@@ -111,13 +111,13 @@ convert_predexp(Local<Object> predexp)
 				return res;
 			}
 		case INT32_ARG:
-			return entry->conv.fint32((int32_t) arg->IntegerValue());
+			return entry->conv.fint32(Nan::To<int32_t>(arg).FromJust());
 		case INT64_ARG:
-			return entry->conv.fint64(arg->IntegerValue());
+			return entry->conv.fint64(Nan::To<int64_t>(arg).FromJust());
 		case UINT16_ARG:
-			return entry->conv.fuint16((uint16_t) arg->IntegerValue());
+			return entry->conv.fuint16(Nan::To<uint32_t>(arg).FromJust());
 		case UINT32_ARG:
-			return entry->conv.fuint32((uint32_t) arg->IntegerValue());
+			return entry->conv.fuint32(Nan::To<uint32_t>(arg).FromJust());
 		default:
 			return NULL;
 	}

--- a/src/main/scan.cc
+++ b/src/main/scan.cc
@@ -52,7 +52,7 @@ void setup_scan(as_scan* scan, Local<Value> ns, Local<Value> set, Local<Value> m
 	if (!maybe_options->IsObject()) {
 		return;
 	}
-	Local<Object> options = maybe_options->ToObject();
+	Local<Object> options = maybe_options.As<Object>();
 
 	Local<Value> selected = options->Get(Nan::New("selected").ToLocalChecked());
 	TYPE_CHECK_OPT(selected, IsArray, "selected must be an array");
@@ -75,25 +75,25 @@ void setup_scan(as_scan* scan, Local<Value> ns, Local<Value> set, Local<Value> m
 	Local<Value> nobins = options->Get(Nan::New("nobins").ToLocalChecked());
 	TYPE_CHECK_OPT(nobins, IsBoolean, "nobins must be a boolean");
 	if (nobins->IsBoolean()) {
-		as_scan_set_nobins(scan, nobins->ToBoolean()->Value());
+		as_scan_set_nobins(scan, Nan::To<bool>(nobins).FromJust());
 	}
 
 	Local<Value> concurrent = options->Get(Nan::New("concurrent").ToLocalChecked());
 	TYPE_CHECK_OPT(concurrent, IsBoolean, "concurrent must be a boolean");
 	if (concurrent->IsBoolean()) {
-		as_scan_set_concurrent(scan, concurrent->ToBoolean()->Value());
+		as_scan_set_concurrent(scan, Nan::To<bool>(concurrent).FromJust());
 	}
 
 	Local<Value> percent = options->Get(Nan::New("percent").ToLocalChecked());
 	TYPE_CHECK_OPT(percent, IsNumber, "percent must be a number");
 	if (percent->IsNumber()) {
-		as_scan_set_percent(scan, (uint8_t) percent->IntegerValue());
+		as_scan_set_percent(scan, (uint8_t) Nan::To<uint32_t>(percent).FromJust());
 	}
 
 	Local<Value> priority = options->Get(Nan::New("priority").ToLocalChecked());
 	TYPE_CHECK_OPT(priority, IsNumber, "prioriy must be a number");
 	if (priority->IsNumber()) {
-		as_scan_set_priority(scan, (as_scan_priority) priority->IntegerValue());
+		as_scan_set_priority(scan, (as_scan_priority) Nan::To<int>(priority).FromJust());
 	}
 
 	Local<Value> udf = options->Get(Nan::New("udf").ToLocalChecked());
@@ -104,7 +104,7 @@ void setup_scan(as_scan* scan, Local<Value> ns, Local<Value> set, Local<Value> m
 		char* filename = module;
 		char* funcname = func;
 		as_list* arglist = NULL;
-		int status = udfargs_from_jsobject(&filename, &funcname, &arglist, udf->ToObject(), log);
+		int status = udfargs_from_jsobject(&filename, &funcname, &arglist, udf.As<Object>(), log);
 		if (status != 0) {
 			as_v8_error(log, "Parsing UDF arguments for scan object failed");
 			Nan::ThrowTypeError("Error in parsing the UDF parameters");


### PR DESCRIPTION
* [x] Replace non-maybe version of `ToString`, `ToObject`, ... functions
* [x] Suppress deprecation warnings for Release builds (build with `--debug` to see all warnings)
* [ ] Update `nan` package with fix for nodejs/nan#811 (once available)
