### PR TITLE
Fix Linux build by linking to ssl

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -104,7 +104,8 @@
         ['OS=="linux"',{
           'libraries': [
             '../aerospike-client-c/lib/libaerospike.a',
-            '-lz'
+            '-lz',
+            '-lssl',
           ],
           'cflags': [ '-Wall', '-g', '-Warray-bounds', '-fpermissive', '-fno-strict-aliasing'],
         }],


### PR DESCRIPTION
Link to ssl on Linux, to resolve linking problem that otherwise arises on Alpine Linux. See #286.