### PR TITLE
Support BigInt as record key & bin value

### DIFF
--- a/lib/bigint.js
+++ b/lib/bigint.js
@@ -1,0 +1,30 @@
+// *****************************************************************************
+// Copyright 2013-2020 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+// keep eslint happy
+const BigInt = global.BigInt || (() => {})
+const MAX_SAFE_BIGINT = BigInt(2) ** BigInt(63) - BigInt(1)
+const MIN_SAFE_BIGINT = BigInt(-2) ** BigInt(63)
+
+exports.BigInt = global.BigInt ||
+  (() => { throw new Error('BigInt not supported on this version of Node.js') })
+exports.bigIntSupported = !!global.BigInt
+
+exports.isInt64 = function (value) {
+  return MIN_SAFE_BIGINT <= value && value <= MAX_SAFE_BIGINT
+}

--- a/lib/bigint.js
+++ b/lib/bigint.js
@@ -18,13 +18,13 @@
 
 // keep eslint happy
 const BigInt = global.BigInt || (() => {})
-const MAX_SAFE_BIGINT = BigInt(2) ** BigInt(63) - BigInt(1)
-const MIN_SAFE_BIGINT = BigInt(-2) ** BigInt(63)
+const MIN_INT64 = BigInt(-2) ** BigInt(63)
+const MAX_INT64 = BigInt(2) ** BigInt(63) - BigInt(1)
 
 exports.BigInt = global.BigInt ||
   (() => { throw new Error('BigInt not supported on this version of Node.js') })
 exports.bigIntSupported = !!global.BigInt
 
 exports.isInt64 = function (value) {
-  return MIN_SAFE_BIGINT <= value && value <= MAX_SAFE_BIGINT
+  return MIN_INT64 <= BigInt(value) && BigInt(value) <= MAX_INT64
 }

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2017 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 
 const MAX_NAMESPACE_NAME_LENGTH = 32
 const MAX_SET_NAME_LENGTH = 64
-const MAX_SAFE_BIGINT = 2n ** 63n - 1n
-const MIN_SAFE_BIGINT = -(2n ** 63n)
 const DIGEST_LENGTH = 20
 
 /**
@@ -122,14 +120,15 @@ function validateStringKey (key) {
   }
 }
 
-function validateNumberKey(key) {
+function validateNumberKey (key) {
   if (!Number.isInteger(key)) {
     throw new TypeError('Invalid user key: Only integer numbers are allowed')
   }
 }
 
+const isInt64 = global.BigInt ? require('./bigint').isInt64 : () => {}
 function validateBigIntKey (key) {
-  if ((key < MIN_SAFE_BIGINT) || (MAX_SAFE_BIGINT < key)) {
+  if (!isInt64(key)) {
     throw new TypeError('Invalid user key: BigInt key is outside valid range -2^63 ... 2^63-1')
   }
 }
@@ -142,17 +141,14 @@ function validateBufferKey (key) {
 
 function validateKey (key) {
   switch (typeof key) {
-    case 'string':
-      return validateStringKey(key)
-    case 'number':
-      return validateNumberKey(key)
-    case 'bigint':
-      return validateBigIntKey(key)
+    case 'string': return validateStringKey(key)
+    case 'number': return validateNumberKey(key)
+    case 'bigint': return validateBigIntKey(key)
     case 'object':
       if (Buffer.isBuffer(key)) {
         return validateBufferKey(key)
       }
-      // fall-through
+      // eslint-disable-next-line: no-fallthrough
     default:
       throw new TypeError('Invalid user key: Must by string, integer, BigInt, or Buffer')
   }

--- a/lib/key.js
+++ b/lib/key.js
@@ -16,6 +16,12 @@
 
 'use strict'
 
+const MAX_NAMESPACE_NAME_LENGTH = 32
+const MAX_SET_NAME_LENGTH = 64
+const MAX_SAFE_BIGINT = 2n ** 63n - 1n
+const MIN_SAFE_BIGINT = -(2n ** 63n)
+const DIGEST_LENGTH = 20
+
 /**
  * @class Key
  *
@@ -59,9 +65,7 @@ function Key (ns, set, key, digest) {
 
   /** @member {(string|integer|Buffer)} [Key#key] */
   const hasKey = isSet(key)
-  if (hasKey && !isValidKey(key)) {
-    throw new TypeError('Key must be a string, integer, or Buffer')
-  }
+  if (hasKey) validateKey(key)
   this.key = key
 
   /**
@@ -103,24 +107,59 @@ function isSet (value) {
 function isValidNamespace (ns) {
   return (typeof ns === 'string') &&
     (ns.length > 0) &&
-    (ns.length <= 32)
+    (ns.length <= MAX_NAMESPACE_NAME_LENGTH)
 }
 
 function isValidSetName (set) {
   return (typeof set === 'string') &&
     (set.length > 0) &&
-    (set.length <= 64)
+    (set.length <= MAX_SET_NAME_LENGTH)
 }
 
-function isValidKey (key) {
-  return (typeof key === 'string' && key.length > 0) ||
-    (typeof key === 'bigint') ||
-    (Number.isInteger(key)) ||
-    (Buffer.isBuffer(key) && Buffer.byteLength(key) > 0)
+function validateStringKey (key) {
+  if (key.length === 0) {
+    throw new TypeError('Invalid user key: Empty string not allowed')
+  }
+}
+
+function validateNumberKey(key) {
+  if (!Number.isInteger(key)) {
+    throw new TypeError('Invalid user key: Only integer numbers are allowed')
+  }
+}
+
+function validateBigIntKey (key) {
+  if ((key < MIN_SAFE_BIGINT) || (MAX_SAFE_BIGINT < key)) {
+    throw new TypeError('Invalid user key: BigInt key is outside valid range -2^63 ... 2^63-1')
+  }
+}
+
+function validateBufferKey (key) {
+  if (Buffer.byteLength(key) === 0) {
+    throw new TypeError('Invalid user key: Empty Buffer not allowed')
+  }
+}
+
+function validateKey (key) {
+  switch (typeof key) {
+    case 'string':
+      return validateStringKey(key)
+    case 'number':
+      return validateNumberKey(key)
+    case 'bigint':
+      return validateBigIntKey(key)
+    case 'object':
+      if (Buffer.isBuffer(key)) {
+        return validateBufferKey(key)
+      }
+      // fall-through
+    default:
+      throw new TypeError('Invalid user key: Must by string, integer, BigInt, or Buffer')
+  }
 }
 
 function isValidDigest (digest) {
-  return (Buffer.isBuffer(digest) && digest.length === 20)
+  return (Buffer.isBuffer(digest) && digest.length === DIGEST_LENGTH)
 }
 
 module.exports = Key

--- a/lib/key.js
+++ b/lib/key.js
@@ -58,7 +58,7 @@ function Key (ns, set, key, digest) {
   this.set = set
 
   /** @member {(string|integer|Buffer)} [Key#key] */
-  var hasKey = isSet(key)
+  const hasKey = isSet(key)
   if (hasKey && !isValidKey(key)) {
     throw new TypeError('Key must be a string, integer, or Buffer')
   }
@@ -114,6 +114,7 @@ function isValidSetName (set) {
 
 function isValidKey (key) {
   return (typeof key === 'string' && key.length > 0) ||
+    (typeof key === 'bigint') ||
     (Number.isInteger(key)) ||
     (Buffer.isBuffer(key) && Buffer.byteLength(key) > 0)
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "standard": {
     "ignore": [
       "apidocs",
-      "tmp-*.js"
+      "tmp-*.js",
+      "/*.js"
     ]
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "test": "mocha",
+    "test-noserver": "GLOBAL_CLIENT=false mocha -g '#noserver'",
     "lint": "standard",
     "posttest": "npm run lint",
     "coverage": "nyc npm test && nyc --reporter=lcov report",

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2019 Aerospike, Inc.
+ * Copyright 2013-2020 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -1241,6 +1241,17 @@ int key_from_jsobject(as_key* key, Local<Object> obj, const LogInfo* log)
         as_key_init_int64(key, ns, set, value);
         as_v8_detail(log, "key.key = %d", value);
         has_value = true;
+    } else if (val_obj->IsBigInt()) {
+        Local<BigInt> big_int = val_obj.As<BigInt>();
+        bool lossless = true;
+        int64_t value = big_int->Int64Value(&lossless);
+        if (!lossless) {
+            as_v8_error(log, "Invalid key value: BigInt value could not be converted to int64_t losslessly");
+            return AS_NODE_PARAM_ERR;
+        }
+        as_key_init_int64(key, ns, set, value);
+        as_v8_detail(log, "key.key = %d", value);
+        has_value = true;
     } else if (val_obj->IsObject()) {
         Local<Object> obj = val_obj.As<Object>();
         int size ;

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -612,49 +612,48 @@ Local<Object> error_to_jsobject(as_error* error, const LogInfo* log)
 Local<Value> val_to_jsvalue(as_val* val, const LogInfo* log)
 {
     Nan::EscapableHandleScope scope;
-    if ( val == NULL) {
+    if (val == NULL) {
         as_v8_debug(log, "value = NULL");
         return scope.Escape(Nan::Null());
     }
 
-    switch ( as_val_type(val) ) {
+    switch (as_val_type(val)) {
         case AS_NIL: {
             as_v8_detail(log,"value is of type as_null");
             return scope.Escape(Nan::Null());
         }
-        case AS_INTEGER : {
-            as_integer * ival = as_integer_fromval(val);
-            if ( ival ) {
+        case AS_INTEGER: {
+            as_integer* ival = as_integer_fromval(val);
+            if (ival) {
                 int64_t data = as_integer_getorelse(ival, -1);
-                as_v8_detail(log, "value = %lld ", data);
+                as_v8_detail(log, "value = %lld", data);
                 return scope.Escape(Nan::New((double)data));
             }
             break;
         }
-        case AS_DOUBLE : {
+        case AS_DOUBLE: {
             as_double* dval = as_double_fromval(val);
-            if( dval ) {
-                double d    = as_double_getorelse(dval, -1);
-                as_v8_detail(log, "value = %lf ",d);
-                return scope.Escape(Nan::New((double)d));
+            if (dval) {
+                double d = as_double_getorelse(dval, -1);
+                as_v8_detail(log, "value = %lf", d);
+                return scope.Escape(Nan::New((double) d));
             }
             break;
         }
-        case AS_STRING : {
+        case AS_STRING: {
             as_string * sval = as_string_fromval(val);
-            if ( sval ) {
-                char * data = as_string_getorelse(sval, NULL);
+            if (sval) {
+                char* data = as_string_getorelse(sval, NULL);
                 as_v8_detail(log, "value = \"%s\"", data);
                 return scope.Escape(Nan::New(data).ToLocalChecked());
             }
             break;
         }
-        case AS_BYTES : {
+        case AS_BYTES: {
             as_bytes * bval = as_bytes_fromval(val);
-            if ( bval ) {
-
-                uint8_t * data = as_bytes_getorelse(bval, NULL);
-                uint32_t size  = as_bytes_size(bval);
+            if (bval) {
+                uint8_t* data = as_bytes_getorelse(bval, NULL);
+                uint32_t size = as_bytes_size(bval);
 
                 as_v8_detail(log,
                         "value = <%x %x %x%s>",
@@ -670,26 +669,26 @@ Local<Value> val_to_jsvalue(as_val* val, const LogInfo* log)
             }
             break;
         }
-        case AS_LIST : {
+        case AS_LIST: {
             as_arraylist* listval = (as_arraylist*) as_list_fromval((as_val*)val);
             int size = as_arraylist_size(listval);
             Local<Array> jsarray = Nan::New<Array>(size);
-            for ( int i = 0; i < size; i++ ) {
-                as_val * arr_val = as_arraylist_get(listval, i);
+            for (int i = 0; i < size; i++) {
+                as_val* arr_val = as_arraylist_get(listval, i);
                 Local<Value> jsval = val_to_jsvalue(arr_val, log);
                 Nan::Set(jsarray, i, jsval);
             }
 
             return scope.Escape(jsarray);
         }
-        case AS_MAP : {
+        case AS_MAP: {
             Local<Object> jsobj = Nan::New<Object>();
             as_hashmap* map = (as_hashmap*) as_map_fromval(val);
-            as_hashmap_iterator  it;
+            as_hashmap_iterator it;
             as_hashmap_iterator_init(&it, map);
 
-            while ( as_hashmap_iterator_has_next(&it) ) {
-                as_pair *p = (as_pair*) as_hashmap_iterator_next(&it);
+            while (as_hashmap_iterator_has_next(&it)) {
+                as_pair* p = (as_pair*) as_hashmap_iterator_next(&it);
                 as_val* key = as_pair_1(p);
                 as_val* val = as_pair_2(p);
                 Nan::Set(jsobj, val_to_jsvalue(key, log), val_to_jsvalue(val, log));
@@ -697,10 +696,10 @@ Local<Value> val_to_jsvalue(as_val* val, const LogInfo* log)
 
             return scope.Escape(jsobj);
         }
-        case AS_GEOJSON : {
-            as_geojson * gval = as_geojson_fromval(val);
-            if ( gval ) {
-                char * data = as_geojson_getorelse(gval, NULL);
+        case AS_GEOJSON: {
+            as_geojson* gval = as_geojson_fromval(val);
+            if (gval) {
+                char* data = as_geojson_getorelse(gval, NULL);
                 as_v8_detail(log, "geojson = \"%s\"", data);
                 return scope.Escape(Nan::New<String>(data).ToLocalChecked());
             }

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -1241,6 +1241,7 @@ int key_from_jsobject(as_key* key, Local<Object> obj, const LogInfo* log)
         as_key_init_int64(key, ns, set, value);
         as_v8_detail(log, "key.key = %d", value);
         has_value = true;
+#if (NODE_MAJOR_VERSION > 10) || (NODE_MAJOR_VERSION == 10  && NODE_MINOR_VERSION >= 4)
     } else if (val_obj->IsBigInt()) {
         Local<BigInt> big_int = val_obj.As<BigInt>();
         bool lossless = true;
@@ -1252,6 +1253,7 @@ int key_from_jsobject(as_key* key, Local<Object> obj, const LogInfo* log)
         as_key_init_int64(key, ns, set, value);
         as_v8_detail(log, "key.key = %d", value);
         has_value = true;
+#endif
     } else if (val_obj->IsObject()) {
         Local<Object> obj = val_obj.As<Object>();
         int size ;

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright 2013-2020 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+/* eslint-env mocha */
+/* global expect */
+
+const helper = require('./test_helper')
+const bigint = require('../lib/bigint')
+
+describe('bigint', function () {
+  context('BigInt supported - Node.js 10 and later', function () {
+    helper.skipUnless(this, bigint.bigIntSupported)
+
+    describe('BigInt', function () {
+      it('is an alias for the built-in BigInt', function () {
+        expect(bigint.BigInt(42)).to.eq(global.BigInt(42))
+      })
+    })
+  })
+
+  context('BigInt not supported - Node.js 8 and earlier', function () {
+    helper.skipUnless(this, !bigint.bigIntSupported)
+
+    describe('BigInt', function () {
+      it('raises an exception if used', function () {
+        expect(() => { bigint.BigInt(42) }).to.throw(Error, 'BigInt not supported')
+      })
+    })
+  })
+})

--- a/test/key.js
+++ b/test/key.js
@@ -85,10 +85,15 @@ describe('Key #noserver', function () {
         expect(new Key('ns', 'set', -1234)).to.be.ok()
       })
 
-      it('allows bigint user key', function () {
+      it('allows BigInt user key', function () {
         expect(new Key('ns', 'set', 42n)).to.be.ok()
-        expect(new Key('ns', 'set', BigInt(Number.MAX_SAFE_INTEGER) + 2n)).to.be.ok()
-        expect(new Key('ns', 'set', BigInt(Number.MIN_SAFE_INTEGER) - 2n)).to.be.ok()
+        expect(new Key('ns', 'set', 2n ** 63n - 1n)).to.be.ok()
+        expect(new Key('ns', 'set', (-2n) ** 63n)).to.be.ok()
+      })
+
+      it('rejects BigInt user keys outside valid range', function () {
+        expect(() => { new Key('ns', 'set', 2n ** 63n) }).to.throw(TypeError, /Invalid user key/)
+        expect(() => { new Key('ns', 'set', -(2n ** 63n) - 1n) }).to.throw(TypeError, /Invalid user key/)
       })
 
       it('allows byte array user key', function () {
@@ -105,15 +110,19 @@ describe('Key #noserver', function () {
       })
 
       it('rejects empty string user key', function () {
-        expect(function () { return new Key('ns', 'set', '') }).to.throw('Key must be a string, integer, or Buffer')
+        expect(function () { return new Key('ns', 'set', '') }).to.throw(TypeError, /Invalid user key/)
       })
 
       it('rejects empty byte array user key', function () {
-        expect(function () { return new Key('ns', 'set', Buffer.from([])) }).to.throw('Key must be a string, integer, or Buffer')
+        expect(function () { return new Key('ns', 'set', Buffer.from([])) }).to.throw(TypeError, /Invalid user key/)
       })
 
       it('rejects float user key', function () {
-        expect(function () { return new Key('ns', 'set', 3.1415) }).to.throw('Key must be a string, integer, or Buffer')
+        expect(function () { return new Key('ns', 'set', 3.1415) }).to.throw(TypeError, /Invalid user key/)
+      })
+
+      it('rejects Object user key', function () {
+        expect(function () { return new Key('ns', 'set', { key: 'myKey' }) }).to.throw(TypeError, /Invalid user key/)
       })
 
       it('requires either key or digest', function () {

--- a/test/key.js
+++ b/test/key.js
@@ -89,7 +89,7 @@ describe('Key #noserver', function () {
       })
 
       context('BigInt keys', function () {
-        helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
+        helper.skipUnless(this, bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
         it('allows BigInt user key', function () {
           expect(new Key('ns', 'set', BigInt(42))).to.be.ok()

--- a/test/key.js
+++ b/test/key.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/test/key.js
+++ b/test/key.js
@@ -85,6 +85,12 @@ describe('Key #noserver', function () {
         expect(new Key('ns', 'set', -1234)).to.be.ok()
       })
 
+      it('allows bigint user key', function () {
+        expect(new Key('ns', 'set', 42n)).to.be.ok()
+        expect(new Key('ns', 'set', BigInt(Number.MAX_SAFE_INTEGER) + 2n)).to.be.ok()
+        expect(new Key('ns', 'set', BigInt(Number.MIN_SAFE_INTEGER) - 2n)).to.be.ok()
+      })
+
       it('allows byte array user key', function () {
         var buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])
         expect(new Key('ns', 'set', buf)).to.be.ok()

--- a/test/key.js
+++ b/test/key.js
@@ -23,6 +23,9 @@ const Key = Aerospike.Key
 const status = Aerospike.status
 const helper = require('./test_helper')
 
+const bigint = require('../lib/bigint')
+const BigInt = bigint.BigInt
+
 describe('Key #noserver', function () {
   describe('constructor', function () {
     context('namespace', function () {
@@ -85,15 +88,19 @@ describe('Key #noserver', function () {
         expect(new Key('ns', 'set', -1234)).to.be.ok()
       })
 
-      it('allows BigInt user key', function () {
-        expect(new Key('ns', 'set', 42n)).to.be.ok()
-        expect(new Key('ns', 'set', 2n ** 63n - 1n)).to.be.ok()
-        expect(new Key('ns', 'set', (-2n) ** 63n)).to.be.ok()
-      })
+      context('BigInt keys', function () {
+        helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
-      it('rejects BigInt user keys outside valid range', function () {
-        expect(() => { new Key('ns', 'set', 2n ** 63n) }).to.throw(TypeError, /Invalid user key/)
-        expect(() => { new Key('ns', 'set', -(2n ** 63n) - 1n) }).to.throw(TypeError, /Invalid user key/)
+        it('allows BigInt user key', function () {
+          expect(new Key('ns', 'set', BigInt(42))).to.be.ok()
+          expect(new Key('ns', 'set', BigInt(2) ** BigInt(63) - BigInt(1))).to.be.ok()
+          expect(new Key('ns', 'set', BigInt(-2) ** BigInt(63))).to.be.ok()
+        })
+
+        it('rejects BigInt user keys outside valid range', function () {
+          expect(() => new Key('ns', 'set', BigInt(2) ** BigInt(63))).to.throw(TypeError, /Invalid user key/)
+          expect(() => new Key('ns', 'set', BigInt(-2) ** BigInt(63) - BigInt(1))).to.throw(TypeError, /Invalid user key/)
+        })
       })
 
       it('allows byte array user key', function () {
@@ -110,23 +117,23 @@ describe('Key #noserver', function () {
       })
 
       it('rejects empty string user key', function () {
-        expect(function () { return new Key('ns', 'set', '') }).to.throw(TypeError, /Invalid user key/)
+        expect(() => new Key('ns', 'set', '')).to.throw(TypeError, /Invalid user key/)
       })
 
       it('rejects empty byte array user key', function () {
-        expect(function () { return new Key('ns', 'set', Buffer.from([])) }).to.throw(TypeError, /Invalid user key/)
+        expect(() => new Key('ns', 'set', Buffer.from([]))).to.throw(TypeError, /Invalid user key/)
       })
 
       it('rejects float user key', function () {
-        expect(function () { return new Key('ns', 'set', 3.1415) }).to.throw(TypeError, /Invalid user key/)
+        expect(() => new Key('ns', 'set', 3.1415)).to.throw(TypeError, /Invalid user key/)
       })
 
       it('rejects Object user key', function () {
-        expect(function () { return new Key('ns', 'set', { key: 'myKey' }) }).to.throw(TypeError, /Invalid user key/)
+        expect(() => new Key('ns', 'set', { key: 'myKey' })).to.throw(TypeError, /Invalid user key/)
       })
 
       it('requires either key or digest', function () {
-        expect(function () { return new Key('ns', 'set') }).to.throw('Either key or digest must be set')
+        expect(() => new Key('ns', 'set')).to.throw('Either key or digest must be set')
       })
     })
 

--- a/test/put.js
+++ b/test/put.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ const status = Aerospike.status
 const AerospikeError = Aerospike.AerospikeError
 const Double = Aerospike.Double
 const GeoJSON = Aerospike.GeoJSON
+
+const bigint = require('../lib/bigint')
+const BigInt = bigint.BigInt
 
 describe('client.put()', function () {
   var client = helper.client
@@ -94,14 +97,18 @@ describe('client.put()', function () {
       })
     })
 
-    it('should write a record w/ BigInt key', async function () {
-      const key = new Aerospike.Key(helper.namespace, helper.set, 2n ** 63n - 1n)
-      const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+    context('BigInt keys', function () {
+      helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
-      await client.put(key, record)
-      const result = await client.get(key)
-      expect(result.bins).to.eql(record)
-      await client.remove(key)
+      it('should write a record w/ BigInt key', async function () {
+        const key = new Aerospike.Key(helper.namespace, helper.set, BigInt(2) ** BigInt(63) - BigInt(1))
+        const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+
+        await client.put(key, record)
+        const result = await client.get(key)
+        expect(result.bins).to.eql(record)
+        await client.remove(key)
+      })
     })
 
     it('should write a record w/ byte array key', function (done) {

--- a/test/put.js
+++ b/test/put.js
@@ -245,8 +245,8 @@ describe('client.put()', function () {
       helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
       it('writes bin with BigInt value and reads it back as a Number', function (done) {
-        let record = { bigint: BigInt(42) }
-        let expected = { bigint: 42 }
+        const record = { bigint: BigInt(42) }
+        const expected = { bigint: 42 }
         putGetVerify(record, expected, done)
       })
     })

--- a/test/put.js
+++ b/test/put.js
@@ -98,7 +98,7 @@ describe('client.put()', function () {
     })
 
     context('BigInt keys', function () {
-      helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
+      helper.skipUnless(this, bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
       it('should write a record w/ BigInt key', async function () {
         const key = new Aerospike.Key(helper.namespace, helper.set, BigInt(2) ** BigInt(63) - BigInt(1))
@@ -242,7 +242,7 @@ describe('client.put()', function () {
     })
 
     context('BigInt values', function () {
-      helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
+      helper.skipUnless(this, bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
 
       it('writes bin with BigInt value and reads it back as a Number', function (done) {
         const record = { bigint: BigInt(42) }

--- a/test/put.js
+++ b/test/put.js
@@ -94,6 +94,16 @@ describe('client.put()', function () {
       })
     })
 
+    it('should write a record w/ BigInt key', async function () {
+      const key = new Aerospike.Key(helper.namespace, helper.set, 2n ** 63n - 1n)
+      const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+
+      await client.put(key, record)
+      const result = await client.get(key)
+      expect(result.bins).to.eql(record)
+      await client.remove(key)
+    })
+
     it('should write a record w/ byte array key', function (done) {
       var key = keygen.bytes(helper.namespace, helper.set)()
       var record = recgen.record({ i: valgen.integer(), s: valgen.string() })()

--- a/test/put.js
+++ b/test/put.js
@@ -241,6 +241,16 @@ describe('client.put()', function () {
       putGetVerify(record, expected, done)
     })
 
+    context('BigInt values', function () {
+      helper.skipIf(this, !bigint.bigIntSupported, 'BigInt not supported in this Node.js version')
+
+      it('writes bin with BigInt value and reads it back as a Number', function (done) {
+        let record = { bigint: BigInt(42) }
+        let expected = { bigint: 42 }
+        putGetVerify(record, expected, done)
+      })
+    })
+
     context('invalid bin values', function () {
       it('should fail with a parameter error when trying to write an undefined bin value', function (done) {
         var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()

--- a/test/put.js
+++ b/test/put.js
@@ -249,6 +249,13 @@ describe('client.put()', function () {
         const expected = { bigint: 42 }
         putGetVerify(record, expected, done)
       })
+
+      it('writes bin with BigInt value outside safe Number range', function (done) {
+        const tooLargeForNumber = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(2)
+        const record = { bigint: tooLargeForNumber }
+        const expected = { bigint: tooLargeForNumber }
+        putGetVerify(record, expected, done)
+      })
     })
 
     context('invalid bin values', function () {

--- a/test/put.js
+++ b/test/put.js
@@ -35,11 +35,11 @@ const bigint = require('../lib/bigint')
 const BigInt = bigint.BigInt
 
 describe('client.put()', function () {
-  var client = helper.client
+  const client = helper.client
 
   it('should write and validate records', function (done) {
-    var meta = { ttl: 1000 }
-    var putAndGet = function (key, bins, cb) {
+    const meta = { ttl: 1000 }
+    const putAndGet = function (key, bins, cb) {
       client.put(key, bins, meta, function (err) {
         if (err) throw err
         client.get(key, function (err, record) {
@@ -50,15 +50,15 @@ describe('client.put()', function () {
       })
     }
 
-    var kgen = keygen.string(helper.namespace, helper.set, {
+    const kgen = keygen.string(helper.namespace, helper.set, {
       prefix: 'test/put/putAndGet/',
       random: false
     })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() })
-    var total = 50
-    var count = 0
+    const rgen = recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() })
+    const total = 50
+    let count = 0
 
-    for (var i = 0; i < total; i++) {
+    for (let i = 0; i < total; i++) {
       putAndGet(kgen(), rgen(), function () {
         count++
         if (count === total) {
@@ -70,8 +70,8 @@ describe('client.put()', function () {
 
   context('records with various key types', function () {
     it('should write a record w/ string key', function (done) {
-      var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
-      var record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+      const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+      const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
 
       client.put(key, record, function (err) {
         if (err) throw err
@@ -84,8 +84,8 @@ describe('client.put()', function () {
     })
 
     it('should write a record w/ integer key', function (done) {
-      var key = keygen.integer(helper.namespace, helper.set)()
-      var record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+      const key = keygen.integer(helper.namespace, helper.set)()
+      const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
 
       client.put(key, record, function (err) {
         if (err) throw err
@@ -112,8 +112,8 @@ describe('client.put()', function () {
     })
 
     it('should write a record w/ byte array key', function (done) {
-      var key = keygen.bytes(helper.namespace, helper.set)()
-      var record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
+      const key = keygen.bytes(helper.namespace, helper.set)()
+      const record = recgen.record({ i: valgen.integer(), s: valgen.string() })()
 
       client.put(key, record, function (err, key) {
         if (err) throw err
@@ -133,7 +133,7 @@ describe('client.put()', function () {
     })
 
     function putGetVerify (bins, expected, done) {
-      var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+      const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
       client.put(key, bins, meta, policy, function (err) {
         if (err) throw err
         client.get(key, function (err, record) {
@@ -145,47 +145,47 @@ describe('client.put()', function () {
     }
 
     it('writes bin with string values and reads it back', function (done) {
-      var record = { string: 'hello world' }
-      var expected = { string: 'hello world' }
+      const record = { string: 'hello world' }
+      const expected = { string: 'hello world' }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with integer values and reads it back', function (done) {
-      var record = { low: Number.MIN_SAFE_INTEGER, high: Number.MAX_SAFE_INTEGER }
-      var expected = { low: -9007199254740991, high: 9007199254740991 }
+      const record = { low: Number.MIN_SAFE_INTEGER, high: Number.MAX_SAFE_INTEGER }
+      const expected = { low: -9007199254740991, high: 9007199254740991 }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with Buffer value and reads it back', function (done) {
-      var record = { buffer: Buffer.from([0x61, 0x65, 0x72, 0x6f, 0x73, 0x70, 0x69, 0x6b, 0x65]) }
-      var expected = { buffer: Buffer.from([0x61, 0x65, 0x72, 0x6f, 0x73, 0x70, 0x69, 0x6b, 0x65]) }
+      const record = { buffer: Buffer.from([0x61, 0x65, 0x72, 0x6f, 0x73, 0x70, 0x69, 0x6b, 0x65]) }
+      const expected = { buffer: Buffer.from([0x61, 0x65, 0x72, 0x6f, 0x73, 0x70, 0x69, 0x6b, 0x65]) }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with float value as double and reads it back', function (done) {
-      var record = { double: 3.141592653589793 }
-      var expected = { double: 3.141592653589793 }
+      const record = { double: 3.141592653589793 }
+      const expected = { double: 3.141592653589793 }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with Double value as double and reads it back', function (done) {
-      var record = { double: new Double(3.141592653589793) }
-      var expected = { double: 3.141592653589793 }
+      const record = { double: new Double(3.141592653589793) }
+      const expected = { double: 3.141592653589793 }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with GeoJSON value and reads it back as string', function (done) {
-      var record = { geo: new GeoJSON.Point(103.8, 1.283) }
-      var expected = { geo: '{"type":"Point","coordinates":[103.8,1.283]}' }
+      const record = { geo: new GeoJSON.Point(103.8, 1.283) }
+      const expected = { geo: '{"type":"Point","coordinates":[103.8,1.283]}' }
       putGetVerify(record, expected, done)
     })
 
     it('writes bin with array value as list and reads it back', function (done) {
-      var record = {
+      const record = {
         list: [1, 'foo', 1.23, new Double(3.14), Buffer.from('bar'),
           GeoJSON.Point(103.8, 1.283), [1, 2, 3], { a: 1, b: 2 }]
       }
-      var expected = {
+      const expected = {
         list: [1, 'foo', 1.23, 3.14, Buffer.from('bar'),
           '{"type":"Point","coordinates":[103.8,1.283]}', [1, 2, 3], { a: 1, b: 2 }]
       }
@@ -193,7 +193,7 @@ describe('client.put()', function () {
     })
 
     it('writes bin with object value as map and reads it back', function (done) {
-      var record = {
+      const record = {
         map: {
           a: 1,
           b: 'foo',
@@ -205,7 +205,7 @@ describe('client.put()', function () {
           h: { a: 1, b: 2 }
         }
       }
-      var expected = {
+      const expected = {
         map: {
           a: 1,
           b: 'foo',
@@ -221,12 +221,12 @@ describe('client.put()', function () {
     })
 
     it.skip('writes bin with Map value as map and reads it back', function (done) {
-      var record = {
+      const record = {
         map: new Map([['a', 1], ['b', 'foo'], ['c', 1.23],
           ['d', new Double(3.14)], ['e', Buffer.from('bar')], ['f', GeoJSON.Point(103.8, 1.283)],
           ['g', [1, 2, 3]], ['h', { a: 1, b: 2 }]])
       }
-      var expected = {
+      const expected = {
         map: {
           a: 1,
           b: 'foo',
@@ -253,8 +253,8 @@ describe('client.put()', function () {
 
     context('invalid bin values', function () {
       it('should fail with a parameter error when trying to write an undefined bin value', function (done) {
-        var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
-        var record = { valid: 123, invalid: undefined }
+        const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+        const record = { valid: 123, invalid: undefined }
 
         client.put(key, record, function (err) {
           expect(err.code).to.equal(status.ERR_PARAM)
@@ -267,8 +267,8 @@ describe('client.put()', function () {
       })
 
       it('should fail with a parameter error when trying to write a boolean bin value', function (done) {
-        var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
-        var record = { valid: 'true', invalid: true }
+        const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+        const record = { valid: 'true', invalid: true }
 
         client.put(key, record, function (err) {
           expect(err.code).to.equal(status.ERR_PARAM)
@@ -313,18 +313,18 @@ describe('client.put()', function () {
   })
 
   it('should delete a bin when writing null to it', function (done) {
-    var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
-    var record = { bin1: 123, bin2: 456 }
+    const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+    const record = { bin1: 123, bin2: 456 }
     client.put(key, record, function (err) {
       if (err) throw err
 
-      var update = { bin1: null }
+      const update = { bin1: null }
       client.put(key, update, function (err, result) {
         if (err) throw err
 
         client.get(key, function (err, record) {
           if (err) throw err
-          var expected = { bin2: 456 }
+          const expected = { bin2: 456 }
           expect(record.bins).to.eql(expected)
 
           client.remove(key, function (err) {
@@ -337,13 +337,13 @@ describe('client.put()', function () {
   })
 
   it('should write, read, write, and check gen', function (done) {
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string() })
+    const kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
+    const mgen = metagen.constant({ ttl: 1000 })
+    const rgen = recgen.record({ i: valgen.integer(), s: valgen.string() })
 
-    var key = kgen()
-    var meta = mgen(key)
-    var bins = rgen(key, meta)
+    const key = kgen()
+    const meta = mgen(key)
+    const bins = rgen(key, meta)
 
     // write the record then check
     client.put(key, bins, meta, function (err, key1) {
@@ -378,13 +378,13 @@ describe('client.put()', function () {
   })
 
   it('should write, read, remove, read, write, and check gen', function (done) {
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string() })
+    const kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
+    const mgen = metagen.constant({ ttl: 1000 })
+    const rgen = recgen.record({ i: valgen.integer(), s: valgen.string() })
 
-    var key = kgen()
-    var meta = mgen(key)
-    var bins = rgen(key, meta)
+    const key = kgen()
+    const meta = mgen(key)
+    const bins = rgen(key, meta)
 
     // write the record then check
     client.put(key, bins, meta, function (err, key1) {
@@ -453,9 +453,9 @@ describe('client.put()', function () {
 
   it('should write null for bins with empty list and map', function (done) {
     // generators
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({
+    const kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })
+    const mgen = metagen.constant({ ttl: 1000 })
+    const rgen = recgen.record({
       l: valgen.constant([1, 2, 3]),
       le: valgen.constant([]),
       m: valgen.constant({ a: 1, b: 2 }),
@@ -463,9 +463,9 @@ describe('client.put()', function () {
     })
 
     // values
-    var key = kgen()
-    var meta = mgen(key)
-    var bins = rgen(key, meta)
+    const key = kgen()
+    const meta = mgen(key)
+    const bins = rgen(key, meta)
 
     // write the record then check
     client.put(key, bins, meta, function (err, key1) {
@@ -486,9 +486,9 @@ describe('client.put()', function () {
   })
 
   it('should write a key without set name', function (done) {
-    var noSet = null
-    var key = keygen.string(helper.namespace, noSet, { prefix: 'test/put/' })()
-    var record = { bin1: 123, bin2: 456 }
+    const noSet = null
+    const key = keygen.string(helper.namespace, noSet, { prefix: 'test/put/' })()
+    const record = { bin1: 123, bin2: 456 }
 
     client.put(key, record, function (err) {
       if (err) throw err
@@ -501,8 +501,8 @@ describe('client.put()', function () {
   })
 
   it('should write a map with undefined entry and verify the record', function (done) {
-    var key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
-    var record = {
+    const key = keygen.string(helper.namespace, helper.set, { prefix: 'test/put/' })()
+    const record = {
       list: [1, 2, 3, undefined],
       map: { a: 1, b: 2, c: undefined }
     }

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -172,24 +172,35 @@ exports.runInNewProcess = function (fn, data) {
   return runInNewProcessFn(fn, env, data)
 }
 
-function skipConditional (ctx, condition, message) {
+exports.skip = function (ctx, message) {
   ctx.beforeEach(function () {
-    if (condition()) {
+    this.skip(message)
+  })
+}
+
+function skipIf (ctx, condition, message) {
+  ctx.beforeEach(function () {
+    let shouldSkip = condition
+    if (typeof condition === 'function') {
+      shouldSkip = condition()
+    }
+    if (shouldSkip) {
       this.skip(message)
     }
   })
 }
+exports.skipIf = skipIf
 
 exports.skipUnlessSupportsFeature = function (feature, ctx) {
-  skipConditional(ctx, () => !this.cluster.hasFeature(feature), `requires server feature "${feature}"`)
+  skipIf(ctx, () => !this.cluster.hasFeature(feature), `requires server feature "${feature}"`)
 }
 
 exports.skipUnlessEnterprise = function (ctx) {
-  skipConditional(ctx, () => !this.cluster.isEnterprise(), 'requires enterprise edition')
+  skipIf(ctx, () => !this.cluster.isEnterprise(), 'requires enterprise edition')
 }
 
 exports.skipUnlessVersion = function (versionRange, ctx) {
-  skipConditional(ctx, () => !this.cluster.isVersionInRange(versionRange), `cluster version does not meet requirements: "${versionRange}"`)
+  skipIf(ctx, () => !this.cluster.isVersionInRange(versionRange), `cluster version does not meet requirements: "${versionRange}"`)
 }
 
 if (process.env.GLOBAL_CLIENT !== 'false') {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -178,29 +178,30 @@ exports.skip = function (ctx, message) {
   })
 }
 
-function skipIf (ctx, condition, message) {
+function skipUnless (ctx, condition, message) {
   ctx.beforeEach(function () {
-    let shouldSkip = condition
+    let dontSkip = condition
     if (typeof condition === 'function') {
-      shouldSkip = condition()
+      dontSkip = condition()
     }
+    const shouldSkip = !dontSkip
     if (shouldSkip) {
       this.skip(message)
     }
   })
 }
-exports.skipIf = skipIf
+exports.skipUnless = skipUnless
 
 exports.skipUnlessSupportsFeature = function (feature, ctx) {
-  skipIf(ctx, () => !this.cluster.hasFeature(feature), `requires server feature "${feature}"`)
+  skipUnless(ctx, () => this.cluster.hasFeature(feature), `requires server feature "${feature}"`)
 }
 
 exports.skipUnlessEnterprise = function (ctx) {
-  skipIf(ctx, () => !this.cluster.isEnterprise(), 'requires enterprise edition')
+  skipUnless(ctx, () => this.cluster.isEnterprise(), 'requires enterprise edition')
 }
 
 exports.skipUnlessVersion = function (versionRange, ctx) {
-  skipIf(ctx, () => !this.cluster.isVersionInRange(versionRange), `cluster version does not meet requirements: "${versionRange}"`)
+  skipUnless(ctx, () => this.cluster.isVersionInRange(versionRange), `cluster version does not meet requirements: "${versionRange}"`)
 }
 
 if (process.env.GLOBAL_CLIENT !== 'false') {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds support for creating record keys using the BigInt data type as well as reading/writing BigInt bin values. BigInt was introduced in Node.js 10.4, so on older Node.js versions, only regular integers (`Number` type) can be used.

Resolves #347.

Todo:
* [x] Add support for BigInt as record key.
* [x] Add support for writing BigInt bin values.
* [x] Add support for reading back integer bin values as BigInt instead of Number, if the value is outside the range -(2^53 - 1) to (2^53 - 1).
