### PR TITLE
HyperLogLog operations

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -50,7 +50,6 @@ network {
 namespace test {
   replication-factor 2
   memory-size 1G
-  default-ttl 30d # 30 days, use 0 to never expire/evict.
-  nsup-period 1m
+  allow-ttl-without-nsup true
   storage-engine memory
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 * **New Features**
-  * Added a max records option for sampling with basic scans. Requires server version 4.9 or later. [#359](https://github.com/aerospike/aerospike-client-nodejs/pull/359)
+  * Adds a max records option for sampling with basic scans. Requires server version 4.9 or later. [#359](https://github.com/aerospike/aerospike-client-nodejs/pull/359)
+  * Adds support for HyperLogLog data type and operations. Requires server version 4.9 or later. [#361](https://github.com/aerospike/aerospike-client-nodejs/pull/361)
 
 * **Updates**
   * *BREAKING*: The client no longer supports the percent-based scan sampling for server versions 4.9 or later. Use the new max records scan policy option instead.

--- a/binding.gyp
+++ b/binding.gyp
@@ -91,6 +91,7 @@
         'src/main/commands/udf_remove.cc',
         'src/main/enums/predicates.cc',
         'src/main/enums/bitwise_enum.cc',
+        'src/main/enums/hll_enum.cc',
         'src/main/enums/maps.cc',
         'src/main/enums/lists.cc',
         'src/main/enums/index.cc',

--- a/binding.gyp
+++ b/binding.gyp
@@ -55,6 +55,7 @@
         'src/main/list_operations.cc',
         'src/main/map_operations.cc',
         'src/main/bit_operations.cc',
+        'src/main/hll_operations.cc',
         'src/main/policy.cc',
         'src/main/query.cc',
         'src/main/scan.cc',

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -96,6 +96,7 @@ exports.lists = require('./lists')
  * HyperLogLog data type.
  *
  * @summary {@link module:aerospike/hll|aerospike/hll} module
+ *
  * @since v3.16.0
  */
 exports.hll = require('./hll')

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -96,6 +96,7 @@ exports.lists = require('./lists')
  * HyperLogLog data type.
  *
  * @summary {@link module:aerospike/hll|aerospike/hll} module
+ * @since v3.16.0
  */
 exports.hll = require('./hll')
 

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -92,6 +92,14 @@ exports.info = require('./info')
 exports.lists = require('./lists')
 
 /**
+ * The {@link module:aerospike/hll|hll} module defines operations on the
+ * HyperLogLog data type.
+ *
+ * @summary {@link module:aerospike/hll|aerospike/hll} module
+ */
+exports.hll = require('./hll')
+
+/**
  * The {@link module:aerospike/maps|maps} module defines operations on the Maps
  * complex data type.
  *

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -1,0 +1,103 @@
+// *****************************************************************************
+// Copyright 2020 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+/**
+ * @module aerospike/hll
+ *
+ * @description This module defines operations on the HyperLogLog data type.
+ * Create HLL operations used by the {@link Client#operate} command.
+ *
+ * @see {@link Client#operate}
+ */
+
+const as = require('bindings')('aerospike.node')
+const opcodes = as.hllOperations
+const Context = require('./cdt_context')
+const AerospikeError = require('./error')
+const Operation = require('./operations').Operation
+
+/**
+ * @class module:aerospike/hll~HLLOperation
+ *
+ * @classdesc Use the methods in the {@link module:aerospike/hll|hll}
+ * module to create HLL operations for use with the {@link Client#operate}
+ * command.
+ */
+class HLLOperation extends Operation {
+
+  /**
+   * @summary By setting the context, the HLL operation will be executed on a
+   * nested HLL value, instead of the bin value itself.
+   *
+   * @param { CdtContext | function } context - Either a Context object, or a
+   * function which accepts a Context object.
+   * @returns { ListOperation } The list operation itself.
+   *
+   */
+  withContext (contextOrFunction) {
+    if (contextOrFunction instanceof Context) {
+      this.context = contextOrFunction
+    } else if (typeof contextOrFunction === 'function') {
+      this.context = new Context()
+      contextOrFunction(this.context)
+    } else {
+      throw new AerospikeError('Context param must be a CDT Context or a function that accepts a context')
+    }
+    return this
+  }
+}
+
+exports.init = function (bin, indexBitCount, mhBitCount = -1, policy = undefined) {
+  return new HLLOperation(opcodes.INIT, bin, {
+    indexBitCount,
+    mhBitCount,
+    policy
+  })
+}
+
+exports.add = function (bin, list, indexBitCount, mhBitCount = -1, policy = undefined) {
+  return new HLLOperation(opcodes.ADD, bin, {
+    list,
+    indexBitCount,
+    mhBitCount,
+    policy
+  })
+}
+
+exports.update = function (bin, list, policy) {
+  return new HLLOperation(opcodes.ADD, bin, {
+    list,
+    indexBitCount: -1,
+    mhBitCount: -1,
+    policy
+  })
+}
+
+exports.refreshCount = function (bin) {
+  return new HLLOperation(opcodes.REFRESH_COUNT, bin)
+}
+
+exports.fold = function (bin, indexBitCount) {
+  return new HLLOperation(opcodes.FOLD, bin, {
+    indexBitCount
+  })
+}
+
+exports.getCount = function (bin) {
+  return new HLLOperation(opcodes.GET_COUNT, bin)
+}

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -31,6 +31,14 @@ const Context = require('./cdt_context')
 const AerospikeError = require('./error')
 const Operation = require('./operations').Operation
 
+// Command codes for HLL read/readList operations.
+const GET_COUNT_COMMAND = 50
+const GET_UNION_COMMAND = 51
+const GET_UNION_COUNT_COMMAND = 52
+const GET_INTERSECT_COUNT_COMMAND = 53
+const GET_SIMILARITY_COMMAND = 54
+const DESCRIBE_COMMAND = 55
+
 /**
  * @class module:aerospike/hll~HLLOperation
  *
@@ -125,6 +133,26 @@ exports.update = function (bin, list) {
   })
 }
 
+/**
+ * Sets a union of the specified HLL objects with the HLL bin.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - List of HLL objects (of type Buffer).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.setUnion = function (bin, list) {
+  return new HLLOperation(opcodes.SET_UNION, bin, {
+    list
+  })
+}
+
+/**
+ * Updates the cached count (if stale), and returns the estimated number of
+ * elements in the HLL bin.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
 exports.refreshCount = function (bin) {
   return new HLLOperation(opcodes.REFRESH_COUNT, bin)
 }
@@ -150,7 +178,68 @@ exports.fold = function (bin, indexBitCount) {
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
 exports.getCount = function (bin) {
-  return new HLLOperation(opcodes.GET_COUNT, bin)
+  return new HLLOperation(opcodes.READ, bin, {
+    command: GET_COUNT_COMMAND
+  })
+}
+
+/**
+ * Returns an HLL object, which is the union of all specified HLL objects in
+ * the list with the HLL bin.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - List of HLL objects (of type Buffer).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.getUnion = function (bin, list) {
+  return new HLLOperation(opcodes.READ_LIST, bin, {
+    list,
+    command: GET_UNION_COMMAND
+  })
+}
+
+/**
+ * Returns the estimated number of elements that would be contained by the
+ * union of these HLL objects.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - List of HLL objects (of type Buffer).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.getUnionCount = function (bin, list) {
+  return new HLLOperation(opcodes.READ_LIST, bin, {
+    list,
+    command: GET_UNION_COUNT_COMMAND
+  })
+}
+
+/**
+ * Returns the estimated number of elements that would be contained by the
+ * intersection of these HLL objects.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - List of HLL objects (of type Buffer).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.getIntersectCount = function (bin, list) {
+  return new HLLOperation(opcodes.READ_LIST, bin, {
+    list,
+    command: GET_INTERSECT_COUNT_COMMAND
+  })
+}
+
+/**
+ * Returns the estimated similarity of these HLL objects. Return type is double.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - List of HLL objects (of type Buffer).
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.getSimilarity = function (bin, list) {
+  return new HLLOperation(opcodes.READ_LIST, bin, {
+    list,
+    command: GET_SIMILARITY_COMMAND
+  })
 }
 
 /**
@@ -161,5 +250,7 @@ exports.getCount = function (bin) {
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
 exports.describe = function (bin) {
-  return new HLLOperation(opcodes.DESCRIBE, bin)
+  return new HLLOperation(opcodes.READ, bin, {
+    command: DESCRIBE_COMMAND
+  })
 }

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -29,7 +29,7 @@
  * @see {@link Client#operate}
  * @since v3.16.0
  *
- * @example
+ * @example <caption>Adds items to HyperLogLog bin and gets approximate count</caption>
  *
  * const Aerospike = require('aerospike')
  * const hll = Aerospike.hll
@@ -44,6 +44,38 @@
  *     hll.getCount('demo')
  *   ])
  *   console.info('Count:', result.bins) // => Count: 5
+ *   client.close()
+ * })
+ *
+ * @example <caption>Performs a union of multiple sets</caption>
+ *
+ * const Aerospike = require('aerospike')
+ * const hll = Aerospike.hll
+ * const ops = Aerospike.operations
+ *
+ * const key1 = new Aerospike.Key('test', 'demo', 'hllDemo1')
+ * const key2 = new Aerospike.Key('test', 'demo', 'hllDemo2')
+ * const key3 = new Aerospike.Key('test', 'demo', 'hllDemo3')
+ *
+ * Aerospike.connect().then(async client => {
+ *   const { bins: { colors: colors1 } } = await client.operate(key1, [
+ *     hll.add('colors', ['blue', 'green', 'orange', 'yellow'], 12),
+ *     ops.read('colors')
+ *   ])
+ *
+ *   const { bins: { colors: colors2 } } = await client.operate(key2, [
+ *     hll.add('colors', ['violet', 'purple', 'pink', 'orange'], 8),
+ *     ops.read('colors')
+ *   ])
+ *
+ *   const { bins: { colors: count } } = await client.operate(key3, [
+ *     hll.add('colors', ['red', 'yellow', 'brown', 'green'], 10),
+ *     hll.setUnion('colors', [colors1, colors2])
+         .withPolicy({ writeFlags: hll.writeFlags.ALLOW_FOLD }),
+ *     hll.getCount('colors')
+ *   ])
+ *
+ *   console.info('Count:', count) // => Count: 9
  *   client.close()
  * })
  */

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -143,6 +143,12 @@ exports.fold = function (bin, indexBitCount) {
   })
 }
 
+/**
+ * Returns the estimated number of elements in the HLL bin.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
 exports.getCount = function (bin) {
   return new HLLOperation(opcodes.GET_COUNT, bin)
 }

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -32,8 +32,6 @@
 
 const as = require('bindings')('aerospike.node')
 const opcodes = as.hllOperations
-const Context = require('./cdt_context')
-const AerospikeError = require('./error')
 const Operation = require('./operations').Operation
 
 // Command codes for HLL read/readList operations.
@@ -52,27 +50,6 @@ const DESCRIBE_COMMAND = 55
  * command.
  */
 class HLLOperation extends Operation {
-  /**
-   * @summary By setting the context, the HLL operation will be executed on a
-   * nested HLL value, instead of the bin value itself.
-   *
-   * @param { CdtContext | function } context - Either a Context object, or a
-   * function which accepts a Context object.
-   * @returns { ListOperation } The list operation itself.
-   *
-   */
-  withContext (contextOrFunction) {
-    if (contextOrFunction instanceof Context) {
-      this.context = contextOrFunction
-    } else if (typeof contextOrFunction === 'function') {
-      this.context = new Context()
-      contextOrFunction(this.context)
-    } else {
-      throw new AerospikeError('Context param must be a CDT Context or a function that accepts a context')
-    }
-    return this
-  }
-
   /**
    * @summary Applies a {@link HLLPolicy} to the operation.
    *

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -39,7 +39,6 @@ const Operation = require('./operations').Operation
  * command.
  */
 class HLLOperation extends Operation {
-
   /**
    * @summary By setting the context, the HLL operation will be executed on a
    * nested HLL value, instead of the bin value itself.
@@ -60,31 +59,69 @@ class HLLOperation extends Operation {
     }
     return this
   }
+
+  /**
+   * @summary Applies a {@link HLLPolicy} to the operation.
+   *
+   * @param {HLLPolicy} policy - Policy to apply to the operation.
+   */
+  withPolicy (policy) {
+    this.policy = policy
+    return this
+  }
 }
 
-exports.init = function (bin, indexBitCount, mhBitCount = -1, policy = undefined) {
+/**
+ * Initializes a HLL bin, using the specified index and (optional) min hash
+ * counts.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
+ * @param {number} [mhBitCount] - Number of min hash bits. If specified, must
+ * be between 4 and 58 inclusive.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.init = function (bin, indexBitCount, mhBitCount = -1) {
   return new HLLOperation(opcodes.INIT, bin, {
     indexBitCount,
-    mhBitCount,
-    policy
+    mhBitCount
   })
 }
 
-exports.add = function (bin, list, indexBitCount, mhBitCount = -1, policy = undefined) {
+/**
+ * Adds one or more entries to an HLL set, an returns the number of entries
+ * that caused HLL to update a register. If the HLL bin does not yet exist, the
+ * operation creates it, using the specified bit counts.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - Entries to be added to the HLL set.
+ * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
+ * @param {number} [mhBitCount] - Number of min hash bits. If specified, must
+ * be between 4 and 58 inclusive.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.add = function (bin, list, indexBitCount, mhBitCount = -1) {
   return new HLLOperation(opcodes.ADD, bin, {
     list,
     indexBitCount,
-    mhBitCount,
-    policy
+    mhBitCount
   })
 }
 
-exports.update = function (bin, list, policy) {
+/**
+ * Updates one or more entries on an existing HLL set, and returns the number of
+ * entries that caused HLL to update a register. This operation assumes HLL bin
+ * already exists.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {array} list - Entries to be added to the HLL set.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.update = function (bin, list) {
   return new HLLOperation(opcodes.ADD, bin, {
     list,
     indexBitCount: -1,
-    mhBitCount: -1,
-    policy
+    mhBitCount: -1
   })
 }
 
@@ -100,4 +137,15 @@ exports.fold = function (bin, indexBitCount) {
 
 exports.getCount = function (bin) {
   return new HLLOperation(opcodes.GET_COUNT, bin)
+}
+
+/**
+ * Returns the index and min hash bit counts used to create the HLL bin as a
+ * list of integers.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
+exports.describe = function (bin) {
+  return new HLLOperation(opcodes.DESCRIBE, bin)
 }

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -28,6 +28,24 @@
  *
  * @see {@link Client#operate}
  * @since v3.16.0
+ *
+ * @example
+ *
+ * const Aerospike = require('aerospike')
+ * const hll = Aerospike.hll
+ * const key = new Aerospike.Key('test', 'demo', 'hllDemo')
+ *
+ * Aerospike.connect().then(async client => {
+ *   const result = await client.operate(key, [
+ *     hll.init('demo', 10),
+ *     hll.add('demo', ['blue', 'green', 'red']),
+ *     hll.add('demo', ['green', 'orange', 'yellow']),
+ *     hll.add('demo', ['red', 'blue']),
+ *     hll.getCount('demo')
+ *   ])
+ *   console.info('Count:', result.bins) // => Count: 5
+ *   client.close()
+ * })
  */
 
 const as = require('bindings')('aerospike.node')
@@ -80,70 +98,75 @@ class HLLOperation extends Operation {
 exports.writeFlags = as.hll.writeFlags
 
 /**
- * Initializes a HLL bin, using the specified index and (optional) min hash
- * counts.
+ * Creates a new HLL or re-initializes an existing HLL. Re-initialization
+ * clears existing contents.
+ *
+ * The <code>init</code> operation supports the following {@link
+ * module:aerospike/hll.writeFlags|HLL Policy write flags}:
+ * * <code>CREATE_ONLY</code>
+ * * <code>UPDATE_ONLY</code>
+ * * <code>NO_FAIL</code>
  *
  * @param {string} bin - The name of the bin. The bin must contain an HLL value.
- * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
- * @param {number} [mhBitCount] - Number of min hash bits. If specified, must
+ * @param {number} indexBits - Number of index bits. Must be between 4 and 16 inclusive.
+ * @param {number} [minhashBits] - Number of minhash bits. If specified, must
  * be between 4 and 58 inclusive.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
-exports.init = function (bin, indexBitCount, mhBitCount = -1) {
-  return new HLLOperation(opcodes.INIT, bin, {
-    indexBitCount,
-    mhBitCount
-  })
+exports.init = function (bin, indexBits, minhashBits = -1) {
+  return new HLLOperation(opcodes.INIT, bin, { indexBits, minhashBits })
 }
 
 /**
- * Adds one or more entries to an HLL set, an returns the number of entries
- * that caused HLL to update a register. If the HLL bin does not yet exist, the
- * operation creates it, using the specified bit counts.
+ * Adds elements to the HLL set. If the bin does not exist, create the HLL with
+ * the <code>indexBits</code> and <code>minhashBits</code> parameters.
+ *
+ * Returns an integer indicating number of entries that caused HLL to update a
+ * register.
+ *
+ * The <code>add</code> operation supports the following {@link
+ * module:aerospike/hll.writeFlags|HLL Policy write flags}:
+ * * <code>CREATE_ONLY</code>
+ * * <code>NO_FAIL</code>
+ *
+ * Not specifying the bit count, implies <code>UPDATE_ONLY</code>.
  *
  * @param {string} bin - The name of the bin. The bin must contain an HLL value.
  * @param {array} list - Entries to be added to the HLL set.
- * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
- * @param {number} [mhBitCount] - Number of min hash bits. If specified, must
+ * @param {number} [indexBits] - Number of index bits. If specified, must
+ * be between 4 and 16 inclusive.
+ * @param {number} [minhashBits] - Number of minhash bits. If specified, must
  * be between 4 and 58 inclusive.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
-exports.add = function (bin, list, indexBitCount, mhBitCount = -1) {
-  return new HLLOperation(opcodes.ADD, bin, {
-    list,
-    indexBitCount,
-    mhBitCount
-  })
+exports.add = function (bin, list, indexBits = -1, minhashBits = -1) {
+  return new HLLOperation(opcodes.ADD, bin, { list, indexBits, minhashBits })
 }
 
 /**
- * Updates one or more entries on an existing HLL set, and returns the number of
- * entries that caused HLL to update a register. This operation assumes HLL bin
- * already exists.
+ * Sets a union of the specified HLLs with the HLL bin value (if it exists)
+ * back into the HLL bin.
  *
- * @param {string} bin - The name of the bin. The bin must contain an HLL value.
- * @param {array} list - Entries to be added to the HLL set.
- * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
- */
-exports.update = function (bin, list) {
-  return new HLLOperation(opcodes.ADD, bin, {
-    list,
-    indexBitCount: -1,
-    mhBitCount: -1
-  })
-}
-
-/**
- * Sets a union of the specified HLL objects with the HLL bin.
+ * The <code>setUnion</code> operation supports the following {@link
+ * module:aerospike/hll.writeFlags|HLL Policy write flags}:
+ * * <code>CREATE_ONLY</code>
+ * * <code>UPDATE_ONLY</code>
+ * * <code>ALLOW_FOLD</code>
+ * * <code>NO_FAIL</code>
+ *
+ * If <code>ALLOW_FOLD</code> is not set, all provided HLLs and the target bin
+ * (if it exists) must have matching index bits and minhash bits. If
+ * <code>ALLOW_FOLD</code> is set, server will union down to the minimum index
+ * bits of all provided HLLs and the target bin (if it exists). Additionally,
+ * if minhash bits differs on any HLL, the resulting union will have 0 minhash
+ * bits.
  *
  * @param {string} bin - The name of the bin. The bin must contain an HLL value.
  * @param {array} list - List of HLL objects (of type Buffer).
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
 exports.setUnion = function (bin, list) {
-  return new HLLOperation(opcodes.SET_UNION, bin, {
-    list
-  })
+  return new HLLOperation(opcodes.SET_UNION, bin, { list })
 }
 
 /**
@@ -162,13 +185,11 @@ exports.refreshCount = function (bin) {
  * when the min hash count on the HLL bin is 0.
  *
  * @param {string} bin - The name of the bin. The bin must contain an HLL value.
- * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
+ * @param {number} indexBits - Number of index bits. Must be between 4 and 16 inclusive.
  * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
  */
-exports.fold = function (bin, indexBitCount) {
-  return new HLLOperation(opcodes.FOLD, bin, {
-    indexBitCount
-  })
+exports.fold = function (bin, indexBits) {
+  return new HLLOperation(opcodes.FOLD, bin, { indexBits })
 }
 
 /**

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -129,6 +129,14 @@ exports.refreshCount = function (bin) {
   return new HLLOperation(opcodes.REFRESH_COUNT, bin)
 }
 
+/**
+ * Folds the index bit count to the specified value. This can only be applied
+ * when the min hash count on the HLL bin is 0.
+ *
+ * @param {string} bin - The name of the bin. The bin must contain an HLL value.
+ * @param {number} indexBitCount - Number of index bits. Must be between 4 and 16 inclusive.
+ * @returns {Object} Operation that can be passed to the {@link Client#operate} command.
+ */
 exports.fold = function (bin, indexBitCount) {
   return new HLLOperation(opcodes.FOLD, bin, {
     indexBitCount

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -62,6 +62,24 @@ class HLLOperation extends Operation {
 }
 
 /**
+ * @summary HLL write flags.
+ *
+ * @type Object
+ * @property {number} DEFAULT - Allow create or update. Default.
+ * @property {number} CREATE_ONLY - If the bin already exists, the operation
+ * will be denied. If the bin does not exist, a new bin will be created.
+ * @property {number} UPDATE_ONLY - If the bin already exists, the bin will be
+ * overwritten. If the bin does not exist, the operation will be denied.
+ * @property {number} NO_FAIL - Do not raise error if operation is denied.
+ * @property {number} ALLOW_FOLD - Allow the resulting set to be the minimum of
+ * provided index bits. Also, allow the usage of less precise HLL algorithms
+ * when min hash bits of all participatings sets do not match.
+ *
+ * @see {@link HLLPolicy}
+ */
+exports.writeFlags = as.hll.writeFlags
+
+/**
  * Initializes a HLL bin, using the specified index and (optional) min hash
  * counts.
  *

--- a/lib/hll.js
+++ b/lib/hll.js
@@ -22,7 +22,12 @@
  * @description This module defines operations on the HyperLogLog data type.
  * Create HLL operations used by the {@link Client#operate} command.
  *
+ * For more information, please refer to the
+ * <a href="https://www.aerospike.com/docs/guide/hyperloglog.html">&uArr;HyperLogLog</a>
+ * documentation in the Aerospike Feature Guide.
+ *
  * @see {@link Client#operate}
+ * @since v3.16.0
  */
 
 const as = require('bindings')('aerospike.node')

--- a/lib/policies/hll_policy.js
+++ b/lib/policies/hll_policy.js
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright 2020 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+/**
+ * A policy affecting the behavior of {@link module:aerospike/hll|HLL} operations.
+ *
+ * @since v3.16.0
+ */
+class HLLPolicy {
+  /**
+   * Initializes a new HLLPolicy from the provided policy values.
+   *
+   * @param {Object} [props] - Policy values
+   */
+  constructor (props) {
+    props = props || {}
+
+    /**
+     * Specifies the behavior when writing byte values.
+     *
+     * @type number
+     * @default Aerospike.hll.writeFlags.DEFAULT
+     * @see {@link module:aerospike/hll.writeFlags} for supported policy values.
+     */
+    this.writeFlags = props.writeFlags
+  }
+}
+
+module.exports = HLLPolicy

--- a/src/include/enums.h
+++ b/src/include/enums.h
@@ -25,6 +25,7 @@
 v8::Local<v8::Object> auth_mode_enum_values();
 v8::Local<v8::Object> bitwise_enum_values();
 v8::Local<v8::Object> generation_policy_values();
+v8::Local<v8::Object> hll_enum_values();
 v8::Local<v8::Object> indexDataType();
 v8::Local<v8::Object> indexType();
 v8::Local<v8::Object> jobStatus();

--- a/src/include/operations.h
+++ b/src/include/operations.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2018 Aerospike, Inc.
+ * Copyright 2013-2020 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,15 +29,18 @@ int add_scalar_op(as_operations* ops, uint32_t opcode, v8::Local<v8::Object> op,
 int add_list_op(as_operations* ops, uint32_t opcode, v8::Local<v8::Object> op, LogInfo* log);
 int add_map_op(as_operations* ops, uint32_t opcode, v8::Local<v8::Object> op, LogInfo* log);
 int add_bit_op(as_operations* ops, uint32_t opcode, v8::Local<v8::Object> op, LogInfo* log);
+int add_hll_op(as_operations* ops, uint32_t opcode, v8::Local<v8::Object> op, LogInfo* log);
 int get_optional_cdt_context(as_cdt_ctx* context, bool* has_context, v8::Local<v8::Object> obj, LogInfo* log);
 
 v8::Local<v8::Object> scalar_opcode_values();
 v8::Local<v8::Object> list_opcode_values();
 v8::Local<v8::Object> map_opcode_values();
 v8::Local<v8::Object> bit_opcode_values();
+v8::Local<v8::Object> hll_opcode_values();
 
 const uint32_t OPS_MASK = 0xFF00;
 const uint32_t SCALAR_OPS_OFFSET = 0x0000;
 const uint32_t LIST_OPS_OFFSET = 0x0100;
 const uint32_t MAP_OPS_OFFSET = 0x0200;
 const uint32_t BIT_OPS_OFFSET = 0x0300;
+const uint32_t HLL_OPS_OFFSET = 0x0400;

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -127,6 +127,7 @@ NAN_MODULE_INIT(Aerospike)
 	export("listOperations", list_opcode_values());
 	export("mapOperations", map_opcode_values());
 	export("bitOperations", bit_opcode_values());
+	export("hllOperations", hll_opcode_values());
 	export("policy", policy());
 	export("status", status());
 	export("ttl", ttl_enum_values());

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -113,6 +113,7 @@ NAN_MODULE_INIT(Aerospike)
 
 	// enumerations
 	export("bitwise", bitwise_enum_values());
+	export("hll", hll_enum_values());
 	export("indexDataType", indexDataType());
 	export("indexType", indexType());
 	export("jobStatus", jobStatus());

--- a/src/main/enums/hll_enum.cc
+++ b/src/main/enums/hll_enum.cc
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2020 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include <node.h>
+#include <nan.h>
+
+extern "C" {
+#include <aerospike/as_hll_operations.h>
+}
+
+using namespace v8;
+
+#define set(__obj, __name, __value) Nan::Set(__obj, Nan::New(__name).ToLocalChecked(), Nan::New(__value))
+
+Local<Object> hll_enum_values()
+{
+	Nan::EscapableHandleScope scope;
+
+	// as_hll_write_flags
+	Local<Object> write_flags = Nan::New<Object>();
+	set(write_flags, "DEFAULT", AS_HLL_WRITE_DEFAULT);
+	set(write_flags, "CREATE_ONLY", AS_HLL_WRITE_CREATE_ONLY);
+	set(write_flags, "UPDATE_ONLY", AS_HLL_WRITE_UPDATE_ONLY);
+	set(write_flags, "NO_FAIL", AS_HLL_WRITE_NO_FAIL);
+	set(write_flags, "ALLOW_FOLD", AS_HLL_WRITE_ALLOW_FOLD);
+
+	Local<Object> enums = Nan::New<Object>();
+	Nan::Set(enums, Nan::New("writeFlags").ToLocalChecked(), write_flags);
+	return scope.Escape(enums);
+}

--- a/src/main/hll_operations.cc
+++ b/src/main/hll_operations.cc
@@ -130,6 +130,12 @@ add_hll_get_count_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<O
 	return as_operations_hll_get_count(ops, bin, context);
 }
 
+bool
+add_hll_describe_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	return as_operations_hll_describe(ops, bin, context);
+}
+
 typedef bool (*HLLOperation) (as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log);
 
 typedef struct {
@@ -142,7 +148,8 @@ const ops_table_entry ops_table[] = {
 	{ "ADD", add_hll_add_op },
 	{ "REFRESH_COUNT", add_hll_refresh_count_op },
 	{ "FOLD", add_hll_fold_op },
-	{ "GET_COUNT", add_hll_get_count_op }
+	{ "GET_COUNT", add_hll_get_count_op },
+	{ "DESCRIBE", add_hll_describe_op }
 };
 
 int

--- a/src/main/hll_operations.cc
+++ b/src/main/hll_operations.cc
@@ -49,7 +49,7 @@ get_optional_hll_policy(as_hll_policy* policy, bool* has_policy, Local<Object> o
 }
 
 bool
-add_hll_init_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_init_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	int index_bit_count;
 	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
@@ -69,11 +69,11 @@ add_hll_init_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object
 
 	as_v8_debug(log, "bin=%s, index_bit_count=%i, mh_bit_count=%i, has_policy=%s",
 			bin, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
-	return as_operations_hll_init_mh(ops, bin, context, &policy, index_bit_count, mh_bit_count);
+	return as_operations_hll_init_mh(ops, bin, NULL, &policy, index_bit_count, mh_bit_count);
 }
 
 bool
-add_hll_add_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_add_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	int index_bit_count;
 	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
@@ -103,14 +103,14 @@ add_hll_add_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object>
 				bin, list_str, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
 		cf_free(list_str);
 	}
-	bool success = as_operations_hll_add_mh(ops, bin, context, &policy, list, index_bit_count, mh_bit_count);
+	bool success = as_operations_hll_add_mh(ops, bin, NULL, &policy, list, index_bit_count, mh_bit_count);
 
 	if (list) as_list_destroy(list);
 	return success;
 }
 
 bool
-add_hll_set_union_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_set_union_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	bool has_policy = false;
 	as_hll_policy policy;
@@ -130,20 +130,20 @@ add_hll_set_union_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<O
 				bin, list_str, has_policy ?  "true" : "false");
 		cf_free(list_str);
 	}
-	bool success = as_operations_hll_set_union(ops, bin, context, &policy, list);
+	bool success = as_operations_hll_set_union(ops, bin, NULL, &policy, list);
 
 	if (list) as_list_destroy(list);
 	return success;
 }
 
 bool
-add_hll_refresh_count_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_refresh_count_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
-	return as_operations_hll_refresh_count(ops, bin, context);
+	return as_operations_hll_refresh_count(ops, bin, NULL);
 }
 
 bool
-add_hll_fold_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_fold_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	int index_bit_count;
 	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
@@ -151,17 +151,17 @@ add_hll_fold_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object
 	}
 
 	as_v8_debug(log, "bin=%s, index_bit_count=%i", bin, index_bit_count);
-	return as_operations_hll_fold(ops, bin, context, index_bit_count);
+	return as_operations_hll_fold(ops, bin, NULL, index_bit_count);
 }
 
 bool
-add_hll_get_count_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_get_count_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
-	return as_operations_hll_get_count(ops, bin, context);
+	return as_operations_hll_get_count(ops, bin, NULL);
 }
 
 bool
-add_hll_read_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_read_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	uint32_t command;
 	if (get_uint32_property(&command, op, "command", log) != AS_NODE_PARAM_OK) {
@@ -169,11 +169,11 @@ add_hll_read_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object
 	}
 
 	as_v8_debug(log, "bin=%s, read_command=%i", bin, command);
-	return as_operations_hll_read(ops, bin, context, (uint16_t)command);
+	return as_operations_hll_read(ops, bin, NULL, (uint16_t)command);
 }
 
 bool
-add_hll_read_list_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+add_hll_read_list_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
 	uint32_t command;
 	if (get_uint32_property(&command, op, "command", log) != AS_NODE_PARAM_OK) {
@@ -192,13 +192,13 @@ add_hll_read_list_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<O
 				bin, command, list_str);
 		cf_free(list_str);
 	}
-	bool success =  as_operations_hll_read_list(ops, bin, context, (uint16_t)command, list);
+	bool success =  as_operations_hll_read_list(ops, bin, NULL, (uint16_t)command, list);
 
 	if (list) as_list_destroy(list);
 	return success;
 }
 
-typedef bool (*HLLOperation) (as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log);
+typedef bool (*HLLOperation) (as_operations* ops, char* bin, Local<Object> op, LogInfo* log);
 
 typedef struct {
 	const char* op_name;
@@ -229,16 +229,9 @@ add_hll_op(as_operations* ops, uint32_t opcode, Local<Object> op, LogInfo* log)
 		return AS_NODE_PARAM_ERR;
 	}
 
-	bool with_context;
-	as_cdt_ctx context;
-	if (get_optional_cdt_context(&context, &with_context, op, log) != AS_NODE_PARAM_OK) {
-		free(bin);
-		return AS_NODE_PARAM_ERR;
-	}
-
-	as_v8_debug(log, "Adding HyperLogLog operation %s (opcode %i) on bin %s to operations list, %s CDT context",
-			entry->op_name, opcode, bin, with_context ? "with" : "without");
-	bool success = (entry->op_function)(ops, bin, with_context ? &context : NULL, op, log);
+	as_v8_debug(log, "Adding HyperLogLog operation %s (opcode %i) on bin %s to operations list",
+			entry->op_name, opcode, bin);
+	bool success = (entry->op_function)(ops, bin, op, log);
 
 	free(bin);
 

--- a/src/main/hll_operations.cc
+++ b/src/main/hll_operations.cc
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright 2020 Aerospike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include <node.h>
+
+#include "conversions.h"
+#include "log.h"
+#include "operations.h"
+
+extern "C" {
+#include <aerospike/as_hll_operations.h>
+}
+
+using namespace v8;
+
+bool
+get_optional_hll_policy(as_hll_policy* policy, bool* has_policy, Local<Object> obj, LogInfo* log)
+{
+	Nan::HandleScope scope;
+	as_hll_policy_init(policy);
+
+	Local<Value> maybe_policy_obj = Nan::Get(obj, Nan::New("policy").ToLocalChecked()).ToLocalChecked();
+	if (maybe_policy_obj->IsUndefined()) {
+		if (has_policy != NULL) (*has_policy) = false;
+		as_v8_detail(log, "No list policy set - using default policy");
+		return true;
+	} else if (!maybe_policy_obj->IsObject()) {
+		as_v8_error(log, "Type error: policy should be an Object");
+		return false;
+	}
+	if (has_policy != NULL) (*has_policy) = true;
+	Local<Object> policy_obj = maybe_policy_obj.As<Object>();
+
+	as_v8_detail(log, "Setting HLL policy");
+	return true;
+}
+
+bool
+add_hll_init_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	int index_bit_count;
+	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	int mh_bit_count;
+	if (get_int_property(&mh_bit_count, op, "mhBitCount", log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	bool has_policy = false;
+	as_hll_policy policy;
+	if (!get_optional_hll_policy(&policy, &has_policy, op, log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	as_v8_debug(log, "bin=%s, index_bit_count=%i, mh_bit_count=%i, has_policy=%s",
+			bin, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
+	return as_operations_hll_init_mh(ops, bin, context, &policy, index_bit_count, mh_bit_count);
+}
+
+bool
+add_hll_add_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	int index_bit_count;
+	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	int mh_bit_count;
+	if (get_int_property(&mh_bit_count, op, "mhBitCount", log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	bool has_policy = false;
+	as_hll_policy policy;
+	if (!get_optional_hll_policy(&policy, &has_policy, op, log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	as_list* list = NULL;
+	if (get_list_property(&list, op, "list", log) != AS_NODE_PARAM_OK) {
+		if (list) as_list_destroy(list);
+		return false;
+	}
+
+	if (as_v8_debug_enabled(log)) {
+		char* list_str = as_val_tostring(list);
+		as_v8_debug(log, "bin=%s, list=%s, index_bit_count=%i, mh_bit_count=%i, has_policy=%s",
+				bin, list_str, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
+		cf_free(list_str);
+	}
+	return as_operations_hll_add_mh(ops, bin, context, &policy, list, index_bit_count, mh_bit_count);
+}
+
+bool
+add_hll_refresh_count_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	return as_operations_hll_refresh_count(ops, bin, context);
+}
+
+bool
+add_hll_fold_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	int index_bit_count;
+	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+		return false;
+	}
+
+	as_v8_debug(log, "bin=%s, index_bit_count=%i", bin, index_bit_count);
+	return as_operations_hll_fold(ops, bin, context, index_bit_count);
+}
+
+bool
+add_hll_get_count_op(as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log)
+{
+	return as_operations_hll_get_count(ops, bin, context);
+}
+
+typedef bool (*HLLOperation) (as_operations* ops, char* bin, as_cdt_ctx* context, Local<Object> op, LogInfo* log);
+
+typedef struct {
+	const char* op_name;
+	HLLOperation op_function;
+} ops_table_entry;
+
+const ops_table_entry ops_table[] = {
+	{ "INIT", add_hll_init_op },
+	{ "ADD", add_hll_add_op },
+	{ "REFRESH_COUNT", add_hll_refresh_count_op },
+	{ "FOLD", add_hll_fold_op },
+	{ "GET_COUNT", add_hll_get_count_op }
+};
+
+int
+add_hll_op(as_operations* ops, uint32_t opcode, Local<Object> op, LogInfo* log)
+{
+	opcode = opcode ^ HLL_OPS_OFFSET;
+	const ops_table_entry *entry = &ops_table[opcode];
+	if (!entry) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	char* bin = NULL;
+	if (get_string_property(&bin, op, "bin", log) != AS_NODE_PARAM_OK) {
+		return AS_NODE_PARAM_ERR;
+	}
+
+	bool with_context;
+	as_cdt_ctx context;
+	if (get_optional_cdt_context(&context, &with_context, op, log) != AS_NODE_PARAM_OK) {
+		free(bin);
+		return AS_NODE_PARAM_ERR;
+	}
+
+	as_v8_debug(log, "Adding HyperLogLog operation %s (opcode %i) on bin %s to operations list, %s CDT context",
+			entry->op_name, opcode, bin, with_context ? "with" : "without");
+	bool success = (entry->op_function)(ops, bin, with_context ? &context : NULL, op, log);
+
+	free(bin);
+
+	return success ? AS_NODE_PARAM_OK : AS_NODE_PARAM_ERR;
+}
+
+Local<Object>
+hll_opcode_values()
+{
+	Nan::EscapableHandleScope scope;
+	Local<Object> obj = Nan::New<Object>();
+
+	uint32_t entries = sizeof(ops_table) / sizeof(ops_table_entry);
+	for (uint32_t i = 0; i < entries; i++) {
+		ops_table_entry entry = ops_table[i];
+		Nan::Set(obj, Nan::New(entry.op_name).ToLocalChecked(), Nan::New(HLL_OPS_OFFSET | i));
+	}
+
+	return scope.Escape(obj);
+}

--- a/src/main/hll_operations.cc
+++ b/src/main/hll_operations.cc
@@ -63,13 +63,13 @@ get_optional_hll_policy(as_hll_policy* policy, bool* has_policy, Local<Object> o
 bool
 add_hll_init_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
-	int index_bit_count;
-	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+	int index_bits;
+	if (get_int_property(&index_bits, op, "indexBits", log) != AS_NODE_PARAM_OK) {
 		return false;
 	}
 
-	int mh_bit_count;
-	if (get_int_property(&mh_bit_count, op, "mhBitCount", log) != AS_NODE_PARAM_OK) {
+	int minhash_bits;
+	if (get_int_property(&minhash_bits, op, "minhashBits", log) != AS_NODE_PARAM_OK) {
 		return false;
 	}
 
@@ -79,21 +79,21 @@ add_hll_init_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 		return false;
 	}
 
-	as_v8_debug(log, "bin=%s, index_bit_count=%i, mh_bit_count=%i, has_policy=%s",
-			bin, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
-	return as_operations_hll_init_mh(ops, bin, NULL, has_policy ? &policy : NULL, index_bit_count, mh_bit_count);
+	as_v8_debug(log, "bin=%s, index_bits=%i, minhash_bits=%i, has_policy=%s",
+			bin, index_bits, minhash_bits, has_policy ?  "true" : "false");
+	return as_operations_hll_init_mh(ops, bin, NULL, has_policy ? &policy : NULL, index_bits, minhash_bits);
 }
 
 bool
 add_hll_add_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
-	int index_bit_count;
-	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+	int index_bits;
+	if (get_int_property(&index_bits, op, "indexBits", log) != AS_NODE_PARAM_OK) {
 		return false;
 	}
 
-	int mh_bit_count;
-	if (get_int_property(&mh_bit_count, op, "mhBitCount", log) != AS_NODE_PARAM_OK) {
+	int minhash_bits;
+	if (get_int_property(&minhash_bits, op, "minhashBits", log) != AS_NODE_PARAM_OK) {
 		return false;
 	}
 
@@ -111,11 +111,11 @@ add_hll_add_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 
 	if (as_v8_debug_enabled(log)) {
 		char* list_str = as_val_tostring(list);
-		as_v8_debug(log, "bin=%s, list=%s, index_bit_count=%i, mh_bit_count=%i, has_policy=%s",
-				bin, list_str, index_bit_count, mh_bit_count, has_policy ?  "true" : "false");
+		as_v8_debug(log, "bin=%s, list=%s, index_bits=%i, minhash_bits=%i, has_policy=%s",
+				bin, list_str, index_bits, minhash_bits, has_policy ?  "true" : "false");
 		cf_free(list_str);
 	}
-	bool success = as_operations_hll_add_mh(ops, bin, NULL, has_policy ? &policy : NULL, list, index_bit_count, mh_bit_count);
+	bool success = as_operations_hll_add_mh(ops, bin, NULL, has_policy ? &policy : NULL, list, index_bits, minhash_bits);
 
 	if (list) as_list_destroy(list);
 	return success;
@@ -157,13 +157,13 @@ add_hll_refresh_count_op(as_operations* ops, char* bin, Local<Object> op, LogInf
 bool
 add_hll_fold_op(as_operations* ops, char* bin, Local<Object> op, LogInfo* log)
 {
-	int index_bit_count;
-	if (get_int_property(&index_bit_count, op, "indexBitCount", log) != AS_NODE_PARAM_OK) {
+	int index_bits;
+	if (get_int_property(&index_bits, op, "indexBits", log) != AS_NODE_PARAM_OK) {
 		return false;
 	}
 
-	as_v8_debug(log, "bin=%s, index_bit_count=%i", bin, index_bit_count);
-	return as_operations_hll_fold(ops, bin, NULL, index_bit_count);
+	as_v8_debug(log, "bin=%s, index_bits=%i", bin, index_bits);
+	return as_operations_hll_fold(ops, bin, NULL, index_bits);
 }
 
 bool

--- a/src/main/operations.cc
+++ b/src/main/operations.cc
@@ -35,6 +35,8 @@ add_operation(as_operations* ops, uint32_t opcode, Local<Object> params, LogInfo
 			return add_map_op(ops, opcode, params, log);
 		case BIT_OPS_OFFSET:
 			return add_bit_op(ops, opcode, params, log);
+		case HLL_OPS_OFFSET:
+			return add_hll_op(ops, opcode, params, log);
 		default:
 			return AS_NODE_PARAM_ERR;
 	}

--- a/test/hll.js
+++ b/test/hll.js
@@ -214,29 +214,6 @@ describe('client.operate() - HyperLogLog operations', function () {
     })
   })
 
-  describe('hll.update', function () {
-    it('updates an existing HLL value', function () {
-      return initState()
-        .then(createRecord({ foo: 'bar' }))
-        .then(operate([
-          hll.add('hll', ['tiger', 'lion'], 8),
-          hll.update('hll', ['leopard', 'tiger', 'tiger', 'jaguar'])
-        ]))
-        .then(assertResultEql({ hll: 2 }))
-        .then(assertRecordEql({ hll: hllCats, foo: 'bar' }))
-        .then(cleanup())
-    })
-
-    it('returns an error if the HLL bin does not yet exist', function () {
-      return initState()
-        .then(createRecord({ foo: 'bar' }))
-        .then(expectError())
-        .then(operate(hll.update('hll', ['leopard', 'tiger', 'tiger', 'jaguar'])))
-        .then(assertError(status.ERR_OP_NOT_APPLICABLE))
-        .then(cleanup())
-    })
-  })
-
   describe('hll.setUnion', function () {
     it('sets a union of the HLL objects with the HLL bin', function () {
       return initState()
@@ -358,7 +335,7 @@ describe('client.operate() - HyperLogLog operations', function () {
         .then(createRecord({ foo: 'bar' }))
         .then(operate([
           hll.add('hll', ['tiger', 'lynx', 'cheetah', 'tiger'], 8),
-          hll.update('hll', ['lion', 'tiger', 'puma', 'puma']),
+          hll.add('hll', ['lion', 'tiger', 'puma', 'puma']),
           hll.fold('hll', 6),
           hll.refreshCount('hll')
         ]))

--- a/test/hll.js
+++ b/test/hll.js
@@ -135,7 +135,7 @@ describe('client.operate() - HyperLogLog operations', function () {
             .then(createRecord({ foo: 'bar' }))
             .then(expectError())
             .then(operate(
-              hll.init('hll', 10, 6).withPolicy(policy),
+              hll.init('hll', 10, 6).withPolicy(policy)
             ))
             .then(assertError(status.ERR_BIN_NOT_FOUND))
             .then(cleanup())
@@ -150,7 +150,7 @@ describe('client.operate() - HyperLogLog operations', function () {
             return initState()
               .then(createRecord({ foo: 'bar' }))
               .then(operate(
-                hll.init('hll', 10, 6).withPolicy(policy),
+                hll.init('hll', 10, 6).withPolicy(policy)
               ))
               .then(assertRecordEql({ foo: 'bar' }))
               .then(cleanup())
@@ -256,7 +256,7 @@ describe('client.operate() - HyperLogLog operations', function () {
         .then(expectError())
         .then(operate([
           hll.add('hll', ['tiger', 'lynx', 'cheetah', 'tiger'], 12),
-          hll.setUnion('hll', [hllCats]), // index bit size = 8
+          hll.setUnion('hll', [hllCats]) // index bit size = 8
         ]))
         .then(assertError(status.ERR_OP_NOT_APPLICABLE))
         .then(cleanup())
@@ -274,7 +274,7 @@ describe('client.operate() - HyperLogLog operations', function () {
             .then(expectError())
             .then(operate([
               hll.add('hll', ['tiger', 'lynx', 'cheetah', 'tiger'], 8),
-              hll.setUnion('hll', [hllCats]).withPolicy(policy),
+              hll.setUnion('hll', [hllCats]).withPolicy(policy)
             ]))
             .then(assertError(status.ERR_BIN_EXISTS))
             .then(cleanup())
@@ -291,7 +291,7 @@ describe('client.operate() - HyperLogLog operations', function () {
               .then(operate([
                 hll.add('hll', ['tiger'], 8),
                 hll.setUnion('hll', [hllCats]).withPolicy(policy),
-                hll.getCount('hll'),
+                hll.getCount('hll')
               ]))
               .then(assertResultEql({ hll: 1 }))
               .then(cleanup())

--- a/test/hll.js
+++ b/test/hll.js
@@ -102,6 +102,32 @@ describe('client.operate() - HyperLogLog operations', function () {
     })
   })
 
+  describe('hll.fold', function () {
+    it('folds the index bit count to the specified value', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate([
+          hll.init('hll', 16),
+          hll.fold('hll', 8),
+          hll.describe('hll')
+        ]))
+        .then(assertResultEql({ hll: [8, 0] }))
+        .then(cleanup())
+    })
+
+    it('returns an error if the min hash count is not zero', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(expectError())
+        .then(operate([
+          hll.init('hll', 16, 8),
+          hll.fold('hll', 8),
+        ]))
+        .then(assertError(status.ERR_OP_NOT_APPLICABLE))
+        .then(cleanup())
+    })
+  })
+
   describe('hll.describe', function () {
     it('returns the index and min hash bit counts', function () {
       return initState()

--- a/test/hll.js
+++ b/test/hll.js
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright 2020 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+/* eslint-env mocha */
+/* global expect */
+
+const Aerospike = require('../lib/aerospike')
+const helper = require('./test_helper')
+
+const hll = Aerospike.hll
+const ops = Aerospike.operations
+
+const {
+  assertError,
+  assertRecordEql,
+  assertResultEql,
+  assertResultSatisfy,
+  cleanup,
+  createRecord,
+  expectError,
+  initState,
+  operate
+} = require('./util/statefulAsyncTest')
+
+describe('client.operate() - HyperLogLog operations', function () {
+  helper.skipUnlessVersion('>= 4.9.0', this)
+
+  describe('hll.init', function () {
+    it('initializes a HLL bin value', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate(hll.init('hll', 10)))
+        .then(cleanup())
+    })
+  })
+
+  describe('hll.add', function () {
+    it('initializes a new HLL value if it does not exist', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate(hll.add('hll', ['cat', 'dog', 'tiger', 'dog', 'lion', 'dog'], 8)))
+        .then(assertResultEql({ hll: 4 }))
+        .then(cleanup())
+    })
+  })
+})

--- a/test/hll.js
+++ b/test/hll.js
@@ -17,19 +17,17 @@
 'use strict'
 
 /* eslint-env mocha */
-/* global expect */
 
 const Aerospike = require('../lib/aerospike')
 const helper = require('./test_helper')
 
 const hll = Aerospike.hll
-const ops = Aerospike.operations
+const status = Aerospike.status
 
 const {
   assertError,
   assertRecordEql,
   assertResultEql,
-  assertResultSatisfy,
   cleanup,
   createRecord,
   expectError,
@@ -39,6 +37,18 @@ const {
 
 describe('client.operate() - HyperLogLog operations', function () {
   helper.skipUnlessVersion('>= 4.9.0', this)
+
+  // HLL bin value representing the set ('jaguar', 'leopard', 'lion', 'tiger')
+  // with an index bit size of 8.
+  const hllCats = Buffer.from([0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0,
+    0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 65, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
   describe('hll.init', function () {
     it('initializes a HLL bin value', function () {
@@ -53,8 +63,54 @@ describe('client.operate() - HyperLogLog operations', function () {
     it('initializes a new HLL value if it does not exist', function () {
       return initState()
         .then(createRecord({ foo: 'bar' }))
-        .then(operate(hll.add('hll', ['cat', 'dog', 'tiger', 'dog', 'lion', 'dog'], 8)))
+        .then(operate(hll.add('hll', ['jaguar', 'tiger', 'tiger', 'leopard', 'lion', 'jaguar'], 8)))
         .then(assertResultEql({ hll: 4 }))
+        .then(assertRecordEql({ hll: hllCats, foo: 'bar' }))
+        .then(cleanup())
+    })
+
+    it('returns an error if the bin is of wrong type', function () {
+      return initState()
+        .then(createRecord({ hll: 'not a HLL set' }))
+        .then(expectError())
+        .then(operate(hll.add('hll', ['jaguar', 'tiger', 'tiger', 'leopard', 'lion', 'jaguar'], 8)))
+        .then(assertError(status.ERR_BIN_INCOMPATIBLE_TYPE))
+        .then(cleanup())
+    })
+  })
+
+  describe('hll.update', function () {
+    it('updates an existing HLL value', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate([
+          hll.add('hll', ['tiger', 'lion'], 8),
+          hll.update('hll', ['leopard', 'tiger', 'tiger', 'jaguar'])
+        ]))
+        .then(assertResultEql({ hll: 2 }))
+        .then(assertRecordEql({ hll: hllCats, foo: 'bar' }))
+        .then(cleanup())
+    })
+
+    it('returns an error if the HLL bin does not yet exist', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(expectError())
+        .then(operate(hll.update('hll', ['leopard', 'tiger', 'tiger', 'jaguar'])))
+        .then(assertError(status.ERR_OP_NOT_APPLICABLE))
+        .then(cleanup())
+    })
+  })
+
+  describe('hll.describe', function () {
+    it('returns the index and min hash bit counts', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate([
+          hll.init('hll', 16, 5),
+          hll.describe('hll')
+        ]))
+        .then(assertResultEql({ hll: [16, 5] }))
         .then(cleanup())
     })
   })

--- a/test/hll.js
+++ b/test/hll.js
@@ -128,6 +128,19 @@ describe('client.operate() - HyperLogLog operations', function () {
     })
   })
 
+  describe('hll.getCount', function () {
+    it('returns the estimated number of elements in the bin', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate([
+          hll.add('hll', ['leopard', 'tiger', 'tiger', 'jaguar'], 8),
+          hll.getCount('hll')
+        ]))
+        .then(assertResultEql({ hll: 3 }))
+        .then(cleanup())
+    })
+  })
+
   describe('hll.describe', function () {
     it('returns the index and min hash bit counts', function () {
       return initState()
@@ -137,6 +150,17 @@ describe('client.operate() - HyperLogLog operations', function () {
           hll.describe('hll')
         ]))
         .then(assertResultEql({ hll: [16, 5] }))
+        .then(cleanup())
+    })
+
+    it('returns the index count, with min hash zero', function () {
+      return initState()
+        .then(createRecord({ foo: 'bar' }))
+        .then(operate([
+          hll.init('hll', 16),
+          hll.describe('hll')
+        ]))
+        .then(assertResultEql({ hll: [16, 0] }))
         .then(cleanup())
     })
   })

--- a/test/util/statefulAsyncTest.js
+++ b/test/util/statefulAsyncTest.js
@@ -56,8 +56,9 @@ exports.createRecord = (bins) => (state) => {
   return state.set('key', helper.client.put(key, bins, meta, policy))
 }
 
-exports.operate = (ops) => (state) =>
-  state.set('result', helper.client.operate(state.key, Array.isArray(ops) ? ops : [ops]))
+exports.operate = (ops) => (state) => {
+  return state.set('result', helper.client.operate(state.key, Array.isArray(ops) ? ops : [ops]))
+}
 
 exports.assertResultEql = (expected) => (state) => {
   expect(state.result.bins).to.eql(expected, 'result of operation does not match expectation')


### PR DESCRIPTION
Add support for new HyperLogLog data type and operations introduced in server version 4.9:
* [x] Implement new HLL operations for use with `Client#operate` command.
* [x] Add tests for new HLL operations.
* [x] ~Extend tests to cover the use of CDT context with HLL operations.~ (HLL operations don't support context at the moment.)
* [x] Implement support for HLL operation policies.
* [x] Extend test to cover the use of HLL operation policies.
* [x] Add examples for new HLL operations (with policy ~and context~).
* [x] Complete documentation for new HLL operations (with policy ~and context~).
