### PR TITLE
Support for Node.js 14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ image:
 platform: x64
 environment:
   matrix:
+    - nodejs_version: "14"
     - nodejs_version: "12"
     - nodejs_version: "10"
     - nodejs_version: "8"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,6 @@ environment:
     - nodejs_version: "14"
     - nodejs_version: "12"
     - nodejs_version: "10"
-    - nodejs_version: "8"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 'node'
+- '14'
 - '12'
 - '10'
 - '8'

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -12,7 +12,7 @@ and suitable for application prototyping and development.
 * Windows 7 or later
 * Windows 8.1 SDK
 * Visual C++ 2015 Build Tools
-* Node.js v8.x (LTS) or later
+* Node.js v10.x (LTS) or later
 
 The package includes a native add-on. To compile the add-on, Microsoft's Visual
 C++ Build Tools 2015 are required. The easiest way to install the build tools,
@@ -38,5 +38,5 @@ for further information.
 PowerShell's execution policy prevents you from running the client's installation script. You can temporarily lift the restrictions for the current PowerShell session by running the following command:
 
     Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
-    
+
 For further information, please refer to the PowerShell documentation [About Execution Policies](https://docs.microsoft.com/en-sg/powershell/module/microsoft.powershell.core/about/about_execution_policies).


### PR DESCRIPTION
Make any changes necessary (if any) to support building and running the client with Node.js 14, which was announced on 2020-04-22: https://nodejs.org/en/blog/release/v14.0.0/.