### PR TITLE
Use object shorthand for properties

### DIFF
--- a/benchmarks/alerts.js
+++ b/benchmarks/alerts.js
@@ -103,8 +103,8 @@ function handleAlert (alertInfo, sev) {
 }
 
 module.exports = {
-  handleAlert: handleAlert,
-  setupAlertSystem: setupAlertSystem,
-  severity: severity,
-  action: action
+  handleAlert,
+  setupAlertSystem,
+  severity,
+  action
 }

--- a/benchmarks/stats.js
+++ b/benchmarks/stats.js
@@ -317,11 +317,11 @@ function reportFinal (argv, print) {
 }
 
 module.exports = {
-  start: start,
-  stop: stop,
-  iteration: iteration,
-  interval: interval,
-  printHistogram: printHistogram,
-  reportFinal: reportFinal,
-  parseTimeToSecs: parseTimeToSecs
+  start,
+  stop,
+  iteration,
+  interval,
+  printHistogram,
+  reportFinal,
+  parseTimeToSecs
 }

--- a/benchmarks/worker.js
+++ b/benchmarks/worker.js
@@ -235,7 +235,7 @@ function run (options) {
     var k = keygen(options.keyRange.min, options.keyRange.max)
     var key = { ns: options.namespace, set: options.set, key: k }
     var record = recordgen(k, options.binSpec)
-    var ops = { key: key, record: record }
+    var ops = { key, record }
     if (writeOps > 0) {
       writeOps--
       if (usePromises) {

--- a/examples/geospatialMonteCarlo.js
+++ b/examples/geospatialMonteCarlo.js
@@ -52,7 +52,7 @@ shared.runner()
 
 async function monteCarlo (client, argv) {
   const game = {
-    client: client,
+    client,
     noDarts: argv.darts, // number of darts to throw
     maxInFlight: argv.maxInFlight,
     maxLatLng: 10, // pick coordinates between (-10, -10) and (10, 10)

--- a/lib/event_loop.js
+++ b/lib/event_loop.js
@@ -103,7 +103,7 @@ function setCommandQueuePolicy (policy) {
 }
 
 module.exports = {
-  releaseEventLoop: releaseEventLoop,
-  registerASEventLoop: registerASEventLoop,
-  setCommandQueuePolicy: setCommandQueuePolicy
+  releaseEventLoop,
+  registerASEventLoop,
+  setCommandQueuePolicy
 }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -76,8 +76,8 @@ class EqualPredicate extends SindexFilterPredicate {
 class RangePredicate extends SindexFilterPredicate {
   constructor (bin, min, max, dataType, indexType) {
     super(as.predicates.RANGE, bin, dataType, indexType, {
-      min: min,
-      max: max
+      min,
+      max
     })
   }
 }

--- a/lib/info.js
+++ b/lib/info.js
@@ -249,12 +249,12 @@ function splitBins (str) {
     }
   })
   return {
-    stats: stats,
-    names: names
+    stats,
+    names
   }
 }
 
 module.exports = {
-  parse: parse,
-  separators: separators
+  parse,
+  separators
 }

--- a/lib/lists.js
+++ b/lib/lists.js
@@ -274,7 +274,7 @@ exports.returnType = as.lists.returnType
  */
 exports.setOrder = function (bin, order) {
   return new ListOperation(opcodes.LIST_SET_ORDER, bin, {
-    order: order
+    order
   })
 }
 
@@ -290,7 +290,7 @@ exports.setOrder = function (bin, order) {
  */
 exports.sort = function (bin, flags) {
   return new ListOperation(opcodes.LIST_SORT, bin, {
-    flags: flags
+    flags
   })
 }
 
@@ -330,8 +330,8 @@ exports.sort = function (bin, flags) {
  */
 exports.append = function (bin, value, policy) {
   return new ListOperation(opcodes.LIST_APPEND, bin, {
-    value: value,
-    policy: policy
+    value,
+    policy
   })
 }
 
@@ -371,8 +371,8 @@ exports.append = function (bin, value, policy) {
  */
 exports.appendItems = function (bin, list, policy) {
   return new ListOperation(opcodes.LIST_APPEND_ITEMS, bin, {
-    list: list,
-    policy: policy
+    list,
+    policy
   })
 }
 
@@ -413,9 +413,9 @@ exports.appendItems = function (bin, list, policy) {
  */
 exports.insert = function (bin, index, value, policy) {
   return new ListOperation(opcodes.LIST_INSERT, bin, {
-    index: index,
-    value: value,
-    policy: policy
+    index,
+    value,
+    policy
   })
 }
 
@@ -455,9 +455,9 @@ exports.insert = function (bin, index, value, policy) {
  */
 exports.insertItems = function (bin, index, list, policy) {
   return new ListOperation(opcodes.LIST_INSERT_ITEMS, bin, {
-    index: index,
-    list: list,
-    policy: policy
+    index,
+    list,
+    policy
   })
 }
 
@@ -663,8 +663,8 @@ exports.removeRange = function (bin, index, count) {
  */
 exports.removeByIndex = function (bin, index, returnType) {
   return new ListOperation(opcodes.LIST_REMOVE_BY_INDEX, bin, {
-    index: index,
-    returnType: returnType
+    index,
+    returnType
   })
 }
 
@@ -691,9 +691,9 @@ exports.removeByIndex = function (bin, index, returnType) {
  */
 exports.removeByIndexRange = function (bin, index, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_INDEX_RANGE, bin, {
-    index: index,
-    count: count,
-    returnType: returnType
+    index,
+    count,
+    returnType
   })
 }
 
@@ -718,8 +718,8 @@ exports.removeByIndexRange = function (bin, index, count, returnType) {
  */
 exports.removeByValue = function (bin, value, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE, bin, {
-    value: value,
-    returnType: returnType
+    value,
+    returnType
   })
 }
 
@@ -744,8 +744,8 @@ exports.removeByValue = function (bin, value, returnType) {
  */
 exports.removeByValueList = function (bin, values, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE_LIST, bin, {
-    values: values,
-    returnType: returnType
+    values,
+    returnType
   })
 }
 
@@ -775,9 +775,9 @@ exports.removeByValueList = function (bin, values, returnType) {
  */
 exports.removeByValueRange = function (bin, begin, end, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE_RANGE, bin, {
-    begin: begin,
-    end: end,
-    returnType: returnType
+    begin,
+    end,
+    returnType
   })
 }
 
@@ -844,10 +844,10 @@ exports.removeByValueRange = function (bin, begin, end, returnType) {
  */
 exports.removeByValueRelRankRange = function (bin, value, rank, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_VALUE_REL_RANK_RANGE, bin, {
-    value: value,
-    rank: rank,
-    count: count,
-    returnType: returnType
+    value,
+    rank,
+    count,
+    returnType
   })
 }
 
@@ -872,8 +872,8 @@ exports.removeByValueRelRankRange = function (bin, value, rank, count, returnTyp
  */
 exports.removeByRank = function (bin, rank, returnType) {
   return new ListOperation(opcodes.LIST_REMOVE_BY_RANK, bin, {
-    rank: rank,
-    returnType: returnType
+    rank,
+    returnType
   })
 }
 
@@ -900,9 +900,9 @@ exports.removeByRank = function (bin, rank, returnType) {
  */
 exports.removeByRankRange = function (bin, rank, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_REMOVE_BY_RANK_RANGE, bin, {
-    rank: rank,
-    count: count,
-    returnType: returnType
+    rank,
+    count,
+    returnType
   })
 }
 
@@ -1138,8 +1138,8 @@ exports.getRange = function (bin, index, count) {
  */
 exports.getByIndex = function (bin, index, returnType) {
   return new ListOperation(opcodes.LIST_GET_BY_INDEX, bin, {
-    index: index,
-    returnType: returnType
+    index,
+    returnType
   })
 }
 
@@ -1166,9 +1166,9 @@ exports.getByIndex = function (bin, index, returnType) {
  */
 exports.getByIndexRange = function (bin, index, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_INDEX_RANGE, bin, {
-    index: index,
-    count: count,
-    returnType: returnType
+    index,
+    count,
+    returnType
   })
 }
 
@@ -1193,8 +1193,8 @@ exports.getByIndexRange = function (bin, index, count, returnType) {
  */
 exports.getByValue = function (bin, value, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE, bin, {
-    value: value,
-    returnType: returnType
+    value,
+    returnType
   })
 }
 
@@ -1219,8 +1219,8 @@ exports.getByValue = function (bin, value, returnType) {
  */
 exports.getByValueList = function (bin, values, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE_LIST, bin, {
-    values: values,
-    returnType: returnType
+    values,
+    returnType
   })
 }
 
@@ -1250,9 +1250,9 @@ exports.getByValueList = function (bin, values, returnType) {
  */
 exports.getByValueRange = function (bin, begin, end, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE_RANGE, bin, {
-    begin: begin,
-    end: end,
-    returnType: returnType
+    begin,
+    end,
+    returnType
   })
 }
 
@@ -1318,10 +1318,10 @@ exports.getByValueRange = function (bin, begin, end, returnType) {
  */
 exports.getByValueRelRankRange = function (bin, value, rank, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_VALUE_REL_RANK_RANGE, bin, {
-    value: value,
-    rank: rank,
-    count: count,
-    returnType: returnType
+    value,
+    rank,
+    count,
+    returnType
   })
 }
 
@@ -1346,8 +1346,8 @@ exports.getByValueRelRankRange = function (bin, value, rank, count, returnType) 
  */
 exports.getByRank = function (bin, rank, returnType) {
   return new ListOperation(opcodes.LIST_GET_BY_RANK, bin, {
-    rank: rank,
-    returnType: returnType
+    rank,
+    returnType
   })
 }
 
@@ -1374,9 +1374,9 @@ exports.getByRank = function (bin, rank, returnType) {
  */
 exports.getByRankRange = function (bin, rank, count, returnType) {
   return new InvertibleListOp(opcodes.LIST_GET_BY_RANK_RANGE, bin, {
-    rank: rank,
-    count: count,
-    returnType: returnType
+    rank,
+    count,
+    returnType
   })
 }
 
@@ -1420,9 +1420,9 @@ exports.getByRankRange = function (bin, rank, count, returnType) {
  */
 exports.increment = function (bin, index, value, policy) {
   return new ListOperation(opcodes.LIST_INCREMENT, bin, {
-    index: index,
-    value: value,
-    policy: policy
+    index,
+    value,
+    policy
   })
 }
 

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -568,10 +568,10 @@ exports.removeByKeyRange = function (bin, begin, end, returnType) {
  */
 exports.removeByKeyRelIndexRange = function (bin, key, index, count, returnType) {
   return new MapOperation(opcodes.MAP_REMOVE_BY_KEY_REL_INDEX_RANGE, bin, {
-    key: key,
-    index: index,
-    count: count,
-    returnType: returnType
+    key,
+    index,
+    count,
+    returnType
   })
 }
 
@@ -706,10 +706,10 @@ exports.removeByValueRange = function (bin, begin, end, returnType) {
  */
 exports.removeByValueRelRankRange = function (bin, value, rank, count, returnType) {
   return new MapOperation(opcodes.MAP_REMOVE_BY_VALUE_REL_RANK_RANGE, bin, {
-    value: value,
-    rank: rank,
-    count: count,
-    returnType: returnType
+    value,
+    rank,
+    count,
+    returnType
   })
 }
 
@@ -935,10 +935,10 @@ exports.getByKeyRange = function (bin, begin, end, returnType) {
  */
 exports.getByKeyRelIndexRange = function (bin, key, index, count, returnType) {
   return new MapOperation(opcodes.MAP_GET_BY_KEY_REL_INDEX_RANGE, bin, {
-    key: key,
-    index: index,
-    count: count,
-    returnType: returnType
+    key,
+    index,
+    count,
+    returnType
   })
 }
 
@@ -1047,10 +1047,10 @@ exports.getByValueRange = function (bin, begin, end, returnType) {
  */
 exports.getByValueRelRankRange = function (bin, value, rank, count, returnType) {
   return new MapOperation(opcodes.MAP_GET_BY_VALUE_REL_RANK_RANGE, bin, {
-    value: value,
-    rank: rank,
-    count: count,
-    returnType: returnType
+    value,
+    rank,
+    count,
+    returnType
   })
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,6 +52,6 @@ function print (err, result) {
 }
 
 module.exports = {
-  parseHostString: parseHostString,
-  print: print
+  parseHostString,
+  print
 }

--- a/test/command_queue.js
+++ b/test/command_queue.js
@@ -29,7 +29,7 @@ describe('Command Queue #slow', function () {
       Aerospike.connect(config)
         .then(client => {
           const cmds = Array.from({ length: 10 }, (_, i) =>
-            client.put(new Aerospike.Key('test', 'test', i), { i: i }))
+            client.put(new Aerospike.Key('test', 'test', i), { i }))
           Promise.all(cmds)
             .then(results => done(results.length))
             .then(() => client.close())
@@ -46,7 +46,7 @@ describe('Command Queue #slow', function () {
       Aerospike.connect(config)
         .then(client => {
           const cmds = Array.from({ length: 10 }, (_, i) =>
-            client.put(new Aerospike.Key('test', 'test', i), { i: i }))
+            client.put(new Aerospike.Key('test', 'test', i), { i }))
           Promise.all(cmds)
             .then(() => done('All commands processed successfully'))
             .catch(error => done(error.message))

--- a/test/generators/key.js
+++ b/test/generators/key.js
@@ -60,8 +60,8 @@ function range (keygen, end, start) {
 }
 
 module.exports = {
-  bytes: bytes,
-  integer: integer,
-  string: string,
-  range: range
+  bytes,
+  integer,
+  string,
+  range
 }

--- a/test/generators/metadata.js
+++ b/test/generators/metadata.js
@@ -26,5 +26,5 @@ function constant (metadata) {
 }
 
 module.exports = {
-  constant: constant
+  constant
 }

--- a/test/generators/put.js
+++ b/test/generators/put.js
@@ -85,5 +85,5 @@ function put (n, keygen, recgen, metagen, policy, callback) {
 }
 
 module.exports = {
-  put: put
+  put
 }

--- a/test/generators/record.js
+++ b/test/generators/record.js
@@ -39,6 +39,6 @@ function record (bins) {
 }
 
 module.exports = {
-  constant: constant,
-  record: record
+  constant,
+  record
 }

--- a/test/generators/util.js
+++ b/test/generators/util.js
@@ -28,5 +28,5 @@ function range (end, start) {
 }
 
 module.exports = {
-  range: range
+  range
 }

--- a/test/generators/value.js
+++ b/test/generators/value.js
@@ -168,11 +168,11 @@ function map () {
 }
 
 module.exports = {
-  bytes: bytes,
-  constant: constant,
-  integer: integer,
-  string: string,
-  double: double,
-  array: array,
-  map: map
+  bytes,
+  constant,
+  integer,
+  string,
+  double,
+  array,
+  map
 }

--- a/test/predexp.js
+++ b/test/predexp.js
@@ -617,7 +617,7 @@ describe('Aerospike.predexp', function () {
         const keys = []
         for (let i = 0; i < 10; i++) {
           const key = batchKeyGen()
-          await client.put(key, { i: i })
+          await client.put(key, { i })
           keys.push(key)
         }
         keys.push(batchKeyGen())
@@ -646,7 +646,7 @@ describe('Aerospike.predexp', function () {
         const batch = []
         for (let i = 0; i < 10; i++) {
           const key = batchKeyGen()
-          await client.put(key, { i: i })
+          await client.put(key, { i })
           batch.push({ key })
         }
         batch.push({ key: batchKeyGen() })

--- a/test/stress/perfdata.js
+++ b/test/stress/perfdata.js
@@ -69,6 +69,6 @@ function generate (ns, set, numberOfRecords, recordSize, done) {
 }
 
 module.exports = {
-  interval: interval,
-  generate: generate
+  interval,
+  generate
 }

--- a/test/util/run_in_new_process.js
+++ b/test/util/run_in_new_process.js
@@ -42,7 +42,7 @@ function createTempFile (fn, data) {
 
 function forkAndRun (fn, env, data) {
   const temp = createTempFile(fn, data)
-  return childProcess.fork(temp, { env: env })
+  return childProcess.fork(temp, { env })
 }
 
 module.exports = function runInNewProcess (fn, env, data) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

-----

This syntax is compatible with Node.js >=4.0, which is the indicated support in your package.json