### PR TITLE
Fix memory leaks when running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+* **Bug Fixes**
+  * Fix memory leaks when running secondary index queries with string filter predicates. [#370](https://github.com/aerospike/aerospike-client-nodejs/issues/370)
+
 ## [3.16.0] - 2020-05-18
 
 * **New Features**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3502,6 +3502,12 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-throttle": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-3.1.0.tgz",
+      "integrity": "sha512-rLo81NXBihs3GJQhq89IXa0Egj/sbW1zW8/qnyadOwUhIUrZSUvyGdQ46ISRKELFBkVvmMJ4JUqWki4oAh30Qw==",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mocha": "^7.1.2",
     "mocha-clean": "^1.0.0",
     "nyc": "^15.0.0",
+    "p-throttle": "^3.1.0",
     "semver": "^7.1.1",
     "standard": "^14.3.1",
     "tmp": "^0.1",

--- a/src/include/conversions.h
+++ b/src/include/conversions.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2018 Aerospike, Inc.
+ * Copyright 2013-2020 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,6 @@ extern "C" {
 /****************************************************************************
  * MACROS
  ****************************************************************************/
-
-#define COPY_ERR_MESSAGE(__err,__message) \
-    strcpy(__err.message, #__message); \
-__err.code = __message;\
-__err.line = __LINE__; \
-__err.file = __FILE__; \
-__err.func = __func__;
 
 #define AS_NODE_PARAM_ERR -1
 #define AS_NODE_PARAM_OK   0

--- a/src/include/query.h
+++ b/src/include/query.h
@@ -25,3 +25,4 @@ extern "C" {
 #include "log.h"
 
 void setup_query(as_query* query, v8::Local<v8::Value> ns, v8::Local<v8::Value> set, v8::Local<v8::Value> maybe_options, LogInfo* log);
+void free_query(as_query* query, as_policy_query* policy);

--- a/src/main/commands/query_apply.cc
+++ b/src/main/commands/query_apply.cc
@@ -38,9 +38,9 @@ class QueryApplyCommand : public AerospikeCommand {
 			: AerospikeCommand("QueryApply", client, callback_) {}
 
 		~QueryApplyCommand() {
+			free_query(&query, policy);
 			if (policy != NULL) cf_free(policy);
 			if (val != NULL) cf_free(val);
-			as_query_destroy(&query);
 		}
 
 		as_policy_query* policy = NULL;

--- a/src/main/commands/query_async.cc
+++ b/src/main/commands/query_async.cc
@@ -69,6 +69,5 @@ NAN_METHOD(AerospikeClient::QueryAsync)
 
 Cleanup:
 	delete cmd;
-	as_query_destroy(&query);
-	if (p_policy && policy.base.predexp) as_predexp_list_destroy(policy.base.predexp);
+	free_query(&query, p_policy);
 }

--- a/src/main/commands/query_background.cc
+++ b/src/main/commands/query_background.cc
@@ -38,8 +38,8 @@ class QueryBackgroundCommand : public AerospikeCommand {
 			: AerospikeCommand("QueryBackground", client, callback_) {}
 
 		~QueryBackgroundCommand() {
+			free_query(&query, NULL);
 			if (policy != NULL) cf_free(policy);
-			as_query_destroy(&query);
 		}
 
 		as_policy_write* policy = NULL;

--- a/src/main/commands/query_foreach.cc
+++ b/src/main/commands/query_foreach.cc
@@ -45,12 +45,12 @@ class QueryForeachCommand : public AerospikeCommand {
 			}
 
 		~QueryForeachCommand() {
+			free_query(&query, policy);
 			if (policy != NULL) cf_free(policy);
 			if (results != NULL) {
 				as_queue_mt_destroy(results);
 				results = NULL;
 			}
-			as_query_destroy(&query);
 		}
 
 		as_policy_query* policy = NULL;

--- a/src/main/query.cc
+++ b/src/main/query.cc
@@ -127,6 +127,7 @@ void setup_query(as_query* query, Local<Value> ns, Local<Value> set, Local<Value
 						break;
 					}
 			}
+			free((void*) bin_name);
 		}
 	}
 
@@ -194,6 +195,25 @@ void setup_query(as_query* query, Local<Value> ns, Local<Value> set, Local<Value
 		if (operations_from_jsarray(query->ops, ops, log) != AS_NODE_PARAM_OK) {
 			as_v8_error(log, "Parsing ops arguments for query object failed");
 			Nan::ThrowTypeError("Error in parsing the operations");
+		}
+	}
+}
+
+void free_query(as_query* query, as_policy_query* policy)
+{
+	if (query) {
+		for (int i = 0; i < query->where.size; i++) {
+			as_predicate entry = query->where.entries[i];
+			if (entry.dtype == AS_INDEX_STRING || entry.dtype == AS_INDEX_GEO2DSPHERE) {
+				free(entry.value.string);
+			}
+		}
+		as_query_destroy(query);
+	}
+
+	if (policy) {
+		if (policy->base.predexp) {
+			as_predexp_list_destroy(policy->base.predexp);
 		}
 	}
 }

--- a/src/main/util/conversions.cc
+++ b/src/main/util/conversions.cc
@@ -568,40 +568,6 @@ Local<Object> error_to_jsobject(as_error* error, const LogInfo* log)
         return scope.Escape(err);
     }
 
-    // LDT error codes are populated as a string message.
-    // Parse the string and populate the error object appropriately
-    // so that application can look up the error codes and doesn't have
-    // to look at strings.
-    // Check if it's an UDF ERROR and message has string LDT in it
-    // then it implies it is an LDT error, so parse the error
-    // and populate the error object.
-    if(error->code == AEROSPIKE_ERR_UDF && strstr(error->message, "LDT") != NULL) {
-        char err_message[AS_ERROR_MESSAGE_MAX_LEN] = {"\0"};
-        as_strlcpy(err_message, error->message, AS_ERROR_MESSAGE_MAX_LEN);
-        char *ptr;
-        ptr = strtok(err_message, ":");
-        if(ptr != NULL) {
-            error->file = ptr;
-            ptr = strtok(NULL, ":");
-        }
-        if(ptr != NULL) {
-            error->line =  atoi(ptr);
-            ptr = strtok(NULL, ":");
-        }
-        if(ptr != NULL) {
-            error->code =  (as_status) atoi(ptr);
-            ptr = strtok(NULL, ":");
-        }
-
-        if(ptr != NULL) {
-            as_strlcpy(error->message, ptr, AS_ERROR_MESSAGE_MAX_LEN);
-            ptr = strtok(NULL, ":");
-        }
-
-        // LDT error does not populate function name as of now.
-        error->func = NULL;
-
-    }
     Nan::Set(err, Nan::New("code").ToLocalChecked(), Nan::New(error->code));
     Nan::Set(err, Nan::New("message").ToLocalChecked(), error->message[0] != '\0' ? Nan::New(error->message).ToLocalChecked() : Nan::New("\0").ToLocalChecked() );
     Nan::Set(err, Nan::New("func").ToLocalChecked(), error->func ? Nan::New(error->func).ToLocalChecked() : Nan::New("\0").ToLocalChecked() );

--- a/test/batch_exists.js
+++ b/test/batch_exists.js
@@ -31,12 +31,13 @@ describe('client.batchExists()', function () {
   var client = helper.client
 
   it('should successfully find 10 records', function () {
-    var numberOfRecords = 10
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_exists/10/', random: false })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() })
-
-    return putgen.put(numberOfRecords, kgen, rgen, mgen)
+    const numberOfRecords = 10
+    const generators = {
+      keygen: keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_exists/10/', random: false }),
+      recgen: recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() }),
+      metagen: metagen.constant({ ttl: 1000 })
+    }
+    return putgen.put(numberOfRecords, generators)
       .then(records => {
         const keys = records.map(record => record.key)
         return client.batchExists(keys)

--- a/test/batch_get.js
+++ b/test/batch_get.js
@@ -31,12 +31,13 @@ describe('client.batchGet()', function () {
   var client = helper.client
 
   it('should successfully read 10 records', function () {
-    var numberOfRecords = 10
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_get/success', random: false })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() })
-
-    return putgen.put(numberOfRecords, kgen, rgen, mgen)
+    const numberOfRecords = 10
+    const generators = {
+      keygen: keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_get/success', random: false }),
+      recgen: recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() }),
+      metagen: metagen.constant({ ttl: 1000 })
+    }
+    return putgen.put(numberOfRecords, generators)
       .then(records => {
         const keys = records.map(record => record.key)
         return client.batchGet(keys)

--- a/test/batch_read.js
+++ b/test/batch_read.js
@@ -35,15 +35,17 @@ describe('client.batchRead()', function () {
 
   before(function () {
     const nrecords = 10
-    const kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_read/', random: false })
-    const mgen = metagen.constant({ ttl: 1000 })
-    const rgen = recgen.record({
-      i: valgen.integer(),
-      s: valgen.string(),
-      l: () => [1, 2, 3],
-      m: () => { return { a: 1, b: 2, c: 3 } }
-    })
-    return putgen.put(nrecords, kgen, rgen, mgen)
+    const generators = {
+      keygen: keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_read/', random: false }),
+      recgen: recgen.record({
+        i: valgen.integer(),
+        s: valgen.string(),
+        l: () => [1, 2, 3],
+        m: () => { return { a: 1, b: 2, c: 3 } }
+      }),
+      metagen: metagen.constant({ ttl: 1000 })
+    }
+    return putgen.put(nrecords, generators)
   })
 
   it('returns the status whether each key was found or not', function (done) {

--- a/test/batch_select.js
+++ b/test/batch_select.js
@@ -31,12 +31,13 @@ describe('client.batchSelect()', function () {
   var client = helper.client
 
   it('should successfully read bins from 10 records', function () {
-    var numberOfRecords = 10
-    var kgen = keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_get/success', random: false })
-    var mgen = metagen.constant({ ttl: 1000 })
-    var rgen = recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() })
-
-    return putgen.put(numberOfRecords, kgen, rgen, mgen)
+    const numberOfRecords = 10
+    const generators = {
+      keygen: keygen.string(helper.namespace, helper.set, { prefix: 'test/batch_get/success', random: false }),
+      recgen: recgen.record({ i: valgen.integer(), s: valgen.string(), b: valgen.bytes() }),
+      metagen: metagen.constant({ ttl: 1000 })
+    }
+    return putgen.put(numberOfRecords, generators)
       .then(records => {
         const keys = records.map(record => record.key)
         return client.batchSelect(keys, ['i', 's'])

--- a/test/predexp.js
+++ b/test/predexp.js
@@ -110,10 +110,12 @@ describe('Aerospike.predexp', function () {
 
     before(() => {
       const entries = samples.entries()
-      const rgen = () => entries.next().value[1]
-      const kgen = keygen.string(helper.namespace, testSet, { prefix: 'test/predexp/query', random: false })
-      const mgen = metagen.constant({ ttl: 300 })
-      return putgen.put(samples.length, kgen, rgen, mgen)
+      const generators = {
+        keygen: keygen.string(helper.namespace, testSet, { prefix: 'test/predexp/query', random: false }),
+        recgen: () => entries.next().value[1],
+        metagen: metagen.constant({ ttl: 300 })
+      }
+      return putgen.put(samples.length, generators)
     })
 
     function timeNanos (diff) {

--- a/test/query.js
+++ b/test/query.js
@@ -112,11 +112,13 @@ describe('Queries', function () {
   }
 
   before(() => {
-    const sampleGen = () => samples.pop()
-    const kgen = keygen.string(helper.namespace, testSet, { prefix: 'test/query/', random: false })
-    const mgen = metagen.constant({ ttl: 300 })
+    const generators = {
+      keygen: keygen.string(helper.namespace, testSet, { prefix: 'test/query/', random: false }),
+      recgen: () => samples.pop(),
+      metagen: metagen.constant({ ttl: 300 })
+    }
     return Promise.all([
-      putgen.put(numberOfSamples, kgen, sampleGen, mgen)
+      putgen.put(numberOfSamples, generators)
         .then((records) => { keys = records.map((rec) => rec.key) })
         .then(() => Promise.all(indexes.map(idx =>
           helper.index.create(idx[0], testSet, idx[1], idx[2], idx[3])))),

--- a/test/scan.js
+++ b/test/scan.js
@@ -40,15 +40,17 @@ context('Scans', function () {
 
   before(() => helper.udf.register('udf.lua')
     .then(() => {
-      const kgen = keygen.string(helper.namespace, testSet, { prefix: 'test/scan/', random: false })
-      const rgen = recgen.record({ i: valgen.integer(), s: valgen.string() })
-      const mgen = metagen.constant({ ttl: 300 })
-      const policy = new Aerospike.WritePolicy({
-        totalTimeout: 1000,
-        key: Aerospike.policy.key.SEND,
-        exists: Aerospike.policy.exists.CREATE_OR_REPLACE
-      })
-      return putgen.put(numberOfRecords, kgen, rgen, mgen, policy)
+      const config = {
+        keygen: keygen.string(helper.namespace, testSet, { prefix: 'test/scan/', random: false }),
+        recgen: recgen.record({ i: valgen.integer(), s: valgen.string() }),
+        metagen: metagen.constant({ ttl: 300 }),
+        policy: new Aerospike.WritePolicy({
+          totalTimeout: 1000,
+          key: Aerospike.policy.key.SEND,
+          exists: Aerospike.policy.exists.CREATE_OR_REPLACE
+        })
+      }
+      return putgen.put(numberOfRecords, config)
         .then((records) => { keys = records.map((rec) => rec.key) })
     }))
 

--- a/test/stress/perfdata.js
+++ b/test/stress/perfdata.js
@@ -54,7 +54,7 @@ function generate (ns, set, numberOfRecords, recordSize, done) {
   var uniqueKeys = new Set()
   var timer = interval(10 * 1000, function (ms) {
     var throughput = Math.round(1000 * keysCreated / ms)
-    console.info('%s ms: %d records created (%d records / second)', ms, keysCreated, throughput)
+    console.info('%s ms: %d records created (%d records / second) - memory: %s', ms, keysCreated, throughput, JSON.stringify(process.memoryUsage()))
   })
   putgen.put(numberOfRecords, kgen, rgen, mgen, function (key) {
     if (key) {

--- a/test/stress/perfdata.js
+++ b/test/stress/perfdata.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 // *****************************************************************************
 
 'use strict'
+
+const { format } = require('util')
 
 const helper = require('../test_helper')
 
@@ -53,8 +55,8 @@ function generate (ns, set, numberOfRecords, recordSize, done) {
   var keysCreated = 0
   var uniqueKeys = new Set()
   var timer = interval(10 * 1000, function (ms) {
-    var throughput = Math.round(1000 * keysCreated / ms)
-    console.info('%s ms: %d records created (%d records / second) - memory: %s', ms, keysCreated, throughput, JSON.stringify(process.memoryUsage()))
+    const throughput = Math.round(1000 * keysCreated / ms)
+    console.info('%s ms: %d records created (%d records / second) - %s', ms, keysCreated, throughput, memoryUsage())
   })
   putgen.put(numberOfRecords, kgen, rgen, mgen, function (key) {
     if (key) {
@@ -68,7 +70,17 @@ function generate (ns, set, numberOfRecords, recordSize, done) {
   })
 }
 
+const MEGA = 1024 * 1024 // bytes in a MB
+function memoryUsage () {
+  const memUsage = process.memoryUsage()
+  const rss = Math.round(memUsage.rss / MEGA)
+  const heapUsed = Math.round(memUsage.heapUsed / MEGA)
+  const heapTotal = Math.round(memUsage.heapTotal / MEGA)
+  return format('mem: %d MB, heap: %d / %d MB', rss, heapUsed, heapTotal)
+}
+
 module.exports = {
   interval,
-  generate
+  generate,
+  memoryUsage
 }

--- a/test/stress/query.js
+++ b/test/stress/query.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ const perfdata = require('./perfdata')
 
 const fs = require('fs')
 
-const mega = 1024 * 1024 // bytes in a MB
-
 describe('client.query()', function () {
   this.enableTimeouts(false)
   var client = helper.client
@@ -42,13 +40,9 @@ describe('client.query()', function () {
 
     var received = 0
     var timer = perfdata.interval(10000, function (ms) {
-      var throughput = Math.round(1000 * received / ms)
-      var memUsage = process.memoryUsage()
-      var rss = Math.round(memUsage.rss / mega)
-      var heapUsed = Math.round(memUsage.heapUsed / mega)
-      var heapTotal = Math.round(memUsage.heapTotal / mega)
-      console.log('%d ms: %d records received (%d rps; mem: %d MB, heap: %d / %d MB)',
-        ms, received, throughput, rss, heapUsed, heapTotal)
+      const throughput = Math.round(1000 * received / ms)
+      console.log('%d ms: %d records received (%d rps; %s)',
+        ms, received, throughput, perfdata.memoryUsage())
     })
 
     stream.on('error', function (err) { throw err })
@@ -95,8 +89,8 @@ describe('client.query()', function () {
         })
       } else {
         // perf test data already exists
-        numberOfRecords = record.norec
-        testSet = record.set
+        numberOfRecords = record.bins.norec
+        testSet = record.bins.set
         console.info('using performance test data from set %s (%d records)', testSet, numberOfRecords)
         done()
       }

--- a/test/stress/scan.js
+++ b/test/stress/scan.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -45,13 +45,9 @@ describe('client.scan()', function () {
 
     var received = 0
     var timer = perfdata.interval(reportingInterval, function (ms) {
-      var throughput = Math.round(1000 * received / ms)
-      var memUsage = process.memoryUsage()
-      var rss = Math.round(memUsage.rss / mega)
-      var heapUsed = Math.round(memUsage.heapUsed / mega)
-      var heapTotal = Math.round(memUsage.heapTotal / mega)
-      console.log('%d ms: %d records received (%d rps; mem: %d MB, heap: %d / %d MB)',
-        ms, received, throughput, rss, heapUsed, heapTotal)
+      const throughput = Math.round(1000 * received / ms)
+      console.log('%d ms: %d records received (%d rps; %s)',
+        ms, received, throughput, perfdata.memUsage())
     })
 
     stream.on('error', function (err) { throw err })

--- a/test/truncate.js
+++ b/test/truncate.js
@@ -34,16 +34,18 @@ const putgen = helper.putgen
 describe('client.truncate()', function () {
   helper.skipUnlessVersion('>= 3.12.0', this)
 
-  var client = helper.client
+  const client = helper.client
 
   // Generates a number of records; the callback function is called with a list
   // of the record keys.
   function genRecords (kgen, noRecords, done) {
-    var mgen = metagen.constant({ ttl: 300 })
-    var rgen = recgen.constant({ a: 'foo', b: 'bar' })
-    putgen.put(noRecords, kgen, rgen, mgen)
+    const generators = {
+      keygen: kgen,
+      recgen: recgen.constant({ a: 'foo', b: 'bar' }),
+      metagen: metagen.constant({ ttl: 300 })
+    }
+    putgen.put(noRecords, generators)
       .then(done)
-      .catch(err => { throw err })
   }
 
   // Checks to verify that records that are supposed to have been truncated


### PR DESCRIPTION
Prevent memory leak from keeping duplicate copies of the bin name and
string predicate values in memory after the query is finished.

Resolves #370.