### PR TITLE
Support setting tlsname using Host object

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -186,32 +186,41 @@ class Config {
      * @description If not specified, the client attempts to read the host list
      * from the <code>AEROSPIKE_HOSTS</code> environment variable or else falls
      * back to use a default value of "localhost".
-     * @type {(Object[] | string)}
+     * @type {(Host[] | string)}
      *
-     * @example <caption>Setting <code>hosts</code> using a String</caption>
-     *
-     * const Aerospike = require('aerospike')
-     *
-     * var hosts = '192.168.0.1:3000,192.168.0.2:3000'
-     * Aerospike.connect({hosts: hosts}, (err, client) => {
-     *   if (err) throw err
-     *   // ...
-     *   client.close()
-     * })
-     *
-     * @example <caption>Setting <code>hosts</code> using an array of hostname/port tuples</caption>
+     * @example <caption>Setting <code>hosts</code> using a string:</caption>
      *
      * const Aerospike = require('aerospike')
      *
-     * var hosts = [
+     * const hosts = '192.168.0.1:3000,192.168.0.2:3000'
+     * const client = await Aerospike.connect({ hosts })
+     *
+     * @example <caption>Setting <code>hosts</code> using an array of hostname/port tuples:</caption>
+     *
+     * const Aerospike = require('aerospike')
+     *
+     * const hosts = [
      *   { addr: '192.168.0.1', port: 3000 },
      *   { addr: '192.168.0.2', port: 3000 }
      * ]
-     * Aerospike.connect({hosts: hosts}, (err, client) => {
-     *   if (err) throw err
-     *   // ...
-     *   client.close()
-     * })
+     * const client = await Aerospike.connect({ hosts })
+     *
+     * @example <caption>Setting <code>hosts</code> with TLS name using a string:</caption>
+     *
+     * const Aerospike = require('aerospike')
+     *
+     * const hosts = '192.168.0.1:example.com:3000,192.168.0.2:example.com:3000'
+     * const client = await Aerospike.connect({ hosts })
+     *
+     * @example <caption>Setting <code>hosts</code> using an array of hostname/port/tlsname tuples:</caption>
+     *
+     * const Aerospike = require('aerospike')
+     *
+     * const hosts = [
+     *   { addr: '192.168.0.1', port: 3000, tlsname: 'example.com' },
+     *   { addr: '192.168.0.2', port: 3000, tlsname: 'example.com' }
+     * ]
+     * const client = await Aerospike.connect({ hosts })
      */
     this.hosts = config.hosts || process.env.AEROSPIKE_HOSTS || `localhost:${this.port}`
 

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -15,6 +15,19 @@
 // *****************************************************************************
 
 /**
+ * @typedef {object} Host
+ *
+ * @summary Address of an Aerospike cluster seed host.
+ *
+ * @property {string} addr - The hostname/IP address of the host.
+ * @property {number} [port] - Optional port number; the default port number will be used if not specified.
+ * @property {string} [tlsname] - Optional name to use when verifying the TLS certificate for TLS encrypted server connections.
+ *
+ * @see Config#hosts
+ * @since v3.17.0
+ */
+
+/**
  * @typedef {Object} ClientStats
  *
  * @summary Runtime stats about a client instance.

--- a/src/main/config.cc
+++ b/src/main/config.cc
@@ -74,6 +74,7 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 			Local<Object> host = Nan::Get(host_list, i).ToLocalChecked().As<Object>();
 			Local<Value> v8_addr = Nan::Get(host, Nan::New("addr").ToLocalChecked()).ToLocalChecked();
 			Local<Value> v8_port = Nan::Get(host, Nan::New("port").ToLocalChecked()).ToLocalChecked();
+			Local<Value> v8_tlsname = Nan::Get(host, Nan::New("tlsname").ToLocalChecked()).ToLocalChecked();
 
 			uint16_t port = default_port;
 			if (v8_port->IsNumber()) {
@@ -88,8 +89,14 @@ int config_from_jsobject(as_config* config, Local<Object> configObj, const LogIn
 
 			if (v8_addr->IsString()) {
 				Nan::Utf8String addr(v8_addr);
-				as_config_add_host(config, *addr, port);
-				as_v8_detail(log,"adding host, addr=\"%s\", port=%d", *addr, port);
+				if (v8_tlsname->IsString()) {
+					Nan::Utf8String tlsname(v8_tlsname);
+					as_config_tls_add_host(config, *addr, *tlsname, port);
+					as_v8_detail(log,"adding TLS host, addr=\"%s\", port=%d, tlsname=\"%s\"", *addr, port, *tlsname);
+				} else {
+					as_config_add_host(config, *addr, port);
+					as_v8_detail(log,"adding host, addr=\"%s\", port=%d", *addr, port);
+				}
 			} else {
 				as_v8_error(log, "host[%d].addr should be a string", i);
 				rc = AS_NODE_PARAM_ERR;


### PR DESCRIPTION
As of v3.16.1, the only way to specify a tlsname when establishing a TLS encrypted server connection is to specify the seed hosts as a single string, e.g. 

```
const hosts = '192.168.0.1:example.com:3000,192.168.0.2:example.com:3000'
const client = await Aerospike.connect({ hosts })
```

This PR adds support for setting the tlsname via the array of `Host` objects instead:

```
const hosts = [
  { addr: '192.168.0.1', port: 3000, tlsname: 'example.com' },
  { addr: '192.168.0.2', port: 3000, tlsname: 'example.com' }
]
const client = await Aerospike.connect({ hosts })
```

It also generally improves the documentation for the `Config#hosts` property by adding more examples, including examples with `tlsname`.

Resolves #377.