### PR TITLE
Remove ApplyPolicy#gen

### DIFF
--- a/lib/policies/apply_policy.js
+++ b/lib/policies/apply_policy.js
@@ -35,14 +35,6 @@ class ApplyPolicy extends BasePolicy {
     super(props)
 
     /**
-     * Specifies the behavior for the generation value.
-     *
-     * @type number
-     * @see {@link module:aerospike/policy.gen} for supported policy values.
-     */
-    this.gen = props.gen
-
-    /**
      * Specifies the behavior for the key.
      *
      * @type number

--- a/src/main/policy.cc
+++ b/src/main/policy.cc
@@ -260,9 +260,6 @@ int applypolicy_from_jsobject(as_policy_apply* policy, Local<Object> obj, const 
 	if ((rc = basepolicy_from_jsobject(&policy->base, obj, log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}
-	if ((rc = get_optional_uint32_property((uint32_t*) &policy->gen, NULL, obj, "gen", log)) != AS_NODE_PARAM_OK) {
-		return rc;
-	}
 	if ((rc = get_optional_uint32_property((uint32_t*) &policy->key, NULL, obj, "key", log)) != AS_NODE_PARAM_OK) {
 		return rc;
 	}

--- a/test/policy.js
+++ b/test/policy.js
@@ -49,7 +49,6 @@ context('Client Policies #noserver', function () {
           socketTimeout: 1000,
           totalTimeout: 2000,
           maxRetries: 1,
-          gen: Aerospike.policy.gen.EQ,
           key: Aerospike.policy.key.SEND,
           commitLevel: 2,
           ttl: 3600,
@@ -59,7 +58,6 @@ context('Client Policies #noserver', function () {
         expect(subject.socketTimeout).to.equal(1000)
         expect(subject.totalTimeout).to.equal(2000)
         expect(subject.maxRetries).to.equal(1)
-        expect(subject.gen).to.equal(Aerospike.policy.gen.EQ)
         expect(subject.key).to.equal(Aerospike.policy.key.SEND)
         expect(subject.commitLevel).to.equal(2)
         expect(subject.ttl).to.equal(3600)


### PR DESCRIPTION
The server does not support these fields in UDF calls. The read-modify-write usage model can still be enforced inside the UDF code itself. The `as_policy_apply.gen` property is being dropped in C client v5.