### PR TITLE
fix: tls and tlsname mismatch

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function parseHostString (hostString) {
 
   const tlsName = parts[2]
   if (tlsName) {
-    host.tls = tlsName
+    host.tlsname = tlsName
   }
 
   const port = parts[3]

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,12 +34,12 @@ describe('utils.parseHostString() #noserver', function () {
 
   it('parses a domain name with TLS name and port', function () {
     var host = utils.parseHostString('aero.local:aero.tls:3333')
-    expect(host).to.eql({ addr: 'aero.local', tls: 'aero.tls', port: 3333 })
+    expect(host).to.eql({ addr: 'aero.local', tlsname: 'aero.tls', port: 3333 })
   })
 
   it('parses a domain name with TLS name', function () {
     var host = utils.parseHostString('aero.local:aero.tls')
-    expect(host).to.eql({ addr: 'aero.local', tls: 'aero.tls', port: 3000 })
+    expect(host).to.eql({ addr: 'aero.local', tlsname: 'aero.tls', port: 3000 })
   })
 
   it('parses an IPv4 address', function () {
@@ -54,12 +54,12 @@ describe('utils.parseHostString() #noserver', function () {
 
   it('parses an IPv4 address with TLS name and port', function () {
     var host = utils.parseHostString('192.168.33.10:aero.tls:3333')
-    expect(host).to.eql({ addr: '192.168.33.10', tls: 'aero.tls', port: 3333 })
+    expect(host).to.eql({ addr: '192.168.33.10', tlsname: 'aero.tls', port: 3333 })
   })
 
   it('parses an IPv4 address with TLS name', function () {
     var host = utils.parseHostString('192.168.33.10:aero.tls')
-    expect(host).to.eql({ addr: '192.168.33.10', tls: 'aero.tls', port: 3000 })
+    expect(host).to.eql({ addr: '192.168.33.10', tlsname: 'aero.tls', port: 3000 })
   })
 
   it('parses an IPv6 address', function () {
@@ -74,12 +74,12 @@ describe('utils.parseHostString() #noserver', function () {
 
   it('parses an IPv6 address with TLS name and port', function () {
     var host = utils.parseHostString('[fde4:8dba:82e1::c4]:aero.tls:3333')
-    expect(host).to.eql({ addr: 'fde4:8dba:82e1::c4', tls: 'aero.tls', port: 3333 })
+    expect(host).to.eql({ addr: 'fde4:8dba:82e1::c4', tlsname: 'aero.tls', port: 3333 })
   })
 
   it('parses an IPv6 address with TLS name', function () {
     var host = utils.parseHostString('[fde4:8dba:82e1::c4]:aero.tls')
-    expect(host).to.eql({ addr: 'fde4:8dba:82e1::c4', tls: 'aero.tls', port: 3000 })
+    expect(host).to.eql({ addr: 'fde4:8dba:82e1::c4', tlsname: 'aero.tls', port: 3000 })
   })
 
   it('throws an error if it cannot parse the string', function () {


### PR DESCRIPTION
As stated in this TLS PR here #382, the attribute is called `tlsname`. The current version of the `config.cc` also makes use of `tlsname` like e.g. here in [src/main/config.cc](https://github.com/aerospike/aerospike-client-nodejs/blob/master/src/main/config.cc#L77).

However, in `lib/utils.js` [here](https://github.com/aerospike/aerospike-client-nodejs/blob/719b259c81a613a13424d4f133b5d9a8adc53d41/lib/utils.js#L37), the attribute is `tls` and not `tlsname`.