### PR TITLE
CLIENT-1425: Fix docs for Query#background policy argument

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -502,7 +502,7 @@ Query.prototype.apply = function (udfModule, udfFunction, udfArgs, policy, callb
  * @param {string} udfModule - UDF module name.
  * @param {string} udfFunction - UDF function name.
  * @param {Array<*>} [udfArgs] - Arguments for the function.
- * @param {QueryPolicy} [policy] - The Query Policy to use for this operation.
+ * @param {WritePolicy} [policy] - The Write Policy to use for this operation.
  * @param {number} [queryID] - Job ID to use for the query; will be assigned
  * randomly if zero or undefined.
  * @param {jobCallback} [callback] - The function to call when the operation completes.


### PR DESCRIPTION
Query#background takes a WritePolicy instead of a QueryPolicy as argument.

Fixes CLIENT-1425.