### PR TITLE
CLIENT-1428: Fix docs for empty info commands

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -986,8 +986,8 @@ Client.prototype.indexRemove = function (namespace, index, policy, callback) {
  * @summary Sends an info query to a specific cluster node.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If <code>null</code>, the cluster host will send all available
- * info.
+ * info request. If <code>null</code>, the result will include default info
+ * values.
  *
  * Please refer to the
  * <a href="http://www.aerospike.com/docs/reference/info">Info Command Reference</a>
@@ -1034,8 +1034,8 @@ Client.prototype.info = function (request, host, policy, callback) {
  * @summary Sends an info query to a single, randomly selected cluster node.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If it is not specified, the cluster host(s) will send all
- * available info.
+ * info request. If it is not specified, the response will include default
+ * info values.
  *
  * @param {string} [request] - The info request to send.
  * @param {InfoPolicy} [policy] - The Info Policy to use for this operation.
@@ -1078,8 +1078,8 @@ Client.prototype.infoAny = function (request, policy, callback) {
  * results.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If it is not specified, the cluster hosts will send all
- * available info.
+ * info request. If it is not specified, the response will include default
+ * info values.
  *
  * @param {string} [request] - The info request to send.
  * @param {InfoPolicy} [policy] - The Info Policy to use for this operation.


### PR DESCRIPTION
When sending an empty info command, the server returns a set of default
info values, not *all* info values.