### PR TITLE
Allow Exit

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -111,6 +111,9 @@
         'src/include',
         "<!(node -e \"require('nan')\")",
       ],
+      'defines': [
+        'AS_USE_LIBUV',
+      ],
       'configurations': {
         'Release': {
             "cflags": [
@@ -148,7 +151,6 @@
             '../aerospike-client-c/lib/pthreadVC2.lib',
           ],
           'defines': [
-            'AS_USE_LIBUV',
             'AS_SHARED_IMPORT',
             '_TIMESPEC_DEFINED',
           ],

--- a/lib/client.js
+++ b/lib/client.js
@@ -451,7 +451,7 @@ Client.prototype.batchSelect = function (keys, bins, policy, callback) {
  *
  * @summary Closes the client connection to the cluster.
  *
- * @param {boolean} [releaseEventLoop=true] - Whether to release the event loop handle after the client is closed.
+ * @param {boolean} [releaseEventLoop=false] - Whether to release the event loop handle after the client is closed.
  *
  * @see module:aerospike.releaseEventLoop
  *
@@ -466,15 +466,19 @@ Client.prototype.batchSelect = function (keys, bins, policy, callback) {
  */
 Client.prototype.close = function (releaseEventLoop) {
   if (typeof releaseEventLoop === 'undefined') {
-    releaseEventLoop = true
+    releaseEventLoop = false
   }
   if (this.isConnected(false)) {
     this.connected = false
     this.as_client.close()
     _connectedClients -= 1
   }
-  if (releaseEventLoop && _connectedClients === 0) {
-    EventLoop.releaseEventLoop()
+  if (_connectedClients === 0) {
+    if (releaseEventLoop) {
+      EventLoop.releaseEventLoop()
+    } else {
+      EventLoop.unreferenceEventLoop()
+    }
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2021 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -464,10 +464,7 @@ Client.prototype.batchSelect = function (keys, bins, policy, callback) {
  *   client.close()
  * })
  */
-Client.prototype.close = function (releaseEventLoop) {
-  if (typeof releaseEventLoop === 'undefined') {
-    releaseEventLoop = false
-  }
+Client.prototype.close = function (releaseEventLoop = false) {
   if (this.isConnected(false)) {
     this.connected = false
     this.as_client.close()

--- a/lib/event_loop.js
+++ b/lib/event_loop.js
@@ -86,10 +86,36 @@ function registerASEventLoop () {
     throw new AerospikeError('Event loop resources have already been released! Call Client#close() with releaseEventLoop set to false to avoid this error.')
   }
 
-  if (!_eventLoopInitialized) {
+  if (_eventLoopInitialized) {
+    referenceEventLoop()
+  } else {
     as.register_as_event_loop(_commandQueuePolicy)
     _eventLoopInitialized = true
   }
+}
+
+/**
+ * @private
+ */
+
+function referenceEventLoop () {
+  if (!_eventLoopInitialized || _eventLoopReleased) {
+    throw new AerospikeError('Event loop is not initialized right now')
+  }
+
+  as.ref_as_event_loop()
+}
+
+/**
+ * @private
+ */
+
+function unreferenceEventLoop () {
+  if (!_eventLoopInitialized || _eventLoopReleased) {
+    throw new AerospikeError('Event loop is not initialized right now')
+  }
+
+  as.unref_as_event_loop()
 }
 
 /**
@@ -105,5 +131,7 @@ function setCommandQueuePolicy (policy) {
 module.exports = {
   releaseEventLoop,
   registerASEventLoop,
+  referenceEventLoop,
+  unreferenceEventLoop,
   setCommandQueuePolicy
 }

--- a/lib/event_loop.js
+++ b/lib/event_loop.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2018 Aerospike, Inc.
+// Copyright 2013-2021 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -97,7 +97,6 @@ function registerASEventLoop () {
 /**
  * @private
  */
-
 function referenceEventLoop () {
   if (!_eventLoopInitialized || _eventLoopReleased) {
     throw new AerospikeError('Event loop is not initialized right now')
@@ -109,7 +108,6 @@ function referenceEventLoop () {
 /**
  * @private
  */
-
 function unreferenceEventLoop () {
   if (!_eventLoopInitialized || _eventLoopReleased) {
     throw new AerospikeError('Event loop is not initialized right now')

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013-2019 Aerospike, Inc.
+ * Copyright 2013-2021 Aerospike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/aerospike.cc
+++ b/src/main/aerospike.cc
@@ -65,6 +65,20 @@ NAN_METHOD(release_as_event_loop)
 	as_event_close_loops();
 }
 
+NAN_METHOD(ref_as_event_loop)
+{
+	Nan::HandleScope();
+	as_event_loop* loop = as_event_loop_find(uv_default_loop());
+	uv_ref((uv_handle_t*) loop->wakeup);
+}
+
+NAN_METHOD(unref_as_event_loop)
+{
+	Nan::HandleScope();
+	as_event_loop* loop = as_event_loop_find(uv_default_loop());
+	uv_unref((uv_handle_t*) loop->wakeup);
+}
+
 NAN_METHOD(get_cluster_count)
 {
 	Nan::HandleScope();
@@ -109,6 +123,8 @@ NAN_MODULE_INIT(Aerospike)
 	NAN_EXPORT(target, get_cluster_count);
 	NAN_EXPORT(target, register_as_event_loop);
 	NAN_EXPORT(target, release_as_event_loop);
+	NAN_EXPORT(target, ref_as_event_loop);
+	NAN_EXPORT(target, unref_as_event_loop);
 	NAN_EXPORT(target, setDefaultLogging);
 
 	// enumerations

--- a/test/client.js
+++ b/test/client.js
@@ -73,6 +73,25 @@ describe('Client', function () {
         done()
       })
     })
+
+    it('should allow exit when all clients are closed', async function () {
+      const test = async function (Aerospike, config) {
+        Object.assign(config, { log: { level: Aerospike.log.OFF } })
+        const client = await Aerospike.connect(config)
+        client.close()
+
+        await new Promise((resolve, reject) => {
+          // beforeExit signals that the process would exit
+          process.on('beforeExit', resolve)
+
+          setTimeout(() => {
+            reject('Process did not exit within 100ms') // eslint-disable-line
+          }, 100).unref()
+        })
+      }
+
+      await helper.runInNewProcess(test, helper.config)
+    })
   })
 
   describe('#isConnected', function () {

--- a/test/client.js
+++ b/test/client.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2021 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
After closing aerospike clients without releasing the event loop the
wakeup trigger in aerospike's event loop is keeping the node.js process
alive. This is problem for test suits running in mocha as mocha does not
call `process.exit()` by default, which has to be worked around.

This patch implements a cleaner behavior by keeping aerospike's event
loop alive while preventing it from keeping node's event loop alive.
Similar to the behavior when calling `process.exit()` the aerospike's
event loop is not released explicitly.

This might be a good default behavior.

I have not tested this beyond opening a connection to aerospike and closing this. So there might be other handles that leak out of a used connection. 