### PR TITLE
Fix client #noserver test

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -198,7 +198,7 @@ describe('Client', function () {
         checkpoints.push(checkpoint)
         if (checkpoints.length !== 2) return
         expect(checkpoints).to.eql(['after', 'callback'])
-        client.close(false)
+        if (client.isConnected()) client.close(false)
         done()
       }
       var key = keygen.string(helper.namespace, helper.set)()

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -215,10 +215,10 @@ if (process.env.GLOBAL_CLIENT !== 'false') {
       throw error
     })
   )
-}
 
-/* global after */
-after(function (done) {
-  client.close()
-  done()
-})
+  /* global after */
+  after(function (done) {
+    client.close()
+    done()
+  })
+}


### PR DESCRIPTION
Calling client.close() before client.connect() has been called is now an
error, rather than a no-op.

Addresses https://github.com/aerospike/aerospike-client-nodejs/pull/399#issuecomment-781753518.