### PR TITLE
Skip client#info() tests when using authentication

### DIFF
--- a/test/info.js
+++ b/test/info.js
@@ -29,7 +29,7 @@ context('Info commands', function () {
   const client = helper.client
 
   describe('Client#info()', function () {
-    helper.skipIf(this, !!helper.config.password && helper.cluster.isVersionInRange('>= 5.5'),
+    helper.skipIf(this, () => !!helper.config.password && helper.cluster.isVersionInRange('>= 5.5'),
       'client#info does not support authenticated connections on server 5.5 or later')
 
     let node = null

--- a/test/info.js
+++ b/test/info.js
@@ -29,6 +29,9 @@ context('Info commands', function () {
   const client = helper.client
 
   describe('Client#info()', function () {
+    helper.skipIf(this, !!helper.config.password && helper.cluster.isVersionInRange('>= 5.5'),
+      'client#info does not support authenticated connections on server 5.5 or later')
+
     let node = null
     let host = null
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -178,17 +178,25 @@ exports.skip = function (ctx, message) {
   })
 }
 
-function skipUnless (ctx, condition, message) {
+function skipIf (ctx, condition, message) {
   ctx.beforeEach(function () {
-    let dontSkip = condition
+    let skip = condition
     if (typeof condition === 'function') {
-      dontSkip = condition()
+      skip = condition()
     }
-    const shouldSkip = !dontSkip
-    if (shouldSkip) {
+    if (skip) {
       this.skip(message)
     }
   })
+}
+exports.skipIf = skipIf
+
+function skipUnless (ctx, condition, message) {
+  if (typeof condition === 'function') {
+    skipIf(ctx, () => !condition(), message)
+  } else {
+    skipIf(ctx, !condition, message)
+  }
 }
 exports.skipUnless = skipUnless
 


### PR DESCRIPTION
The `client#info()` command stopped working on the latest server version when using client authentication. The `client#info()` command has been deprecated since Node.js client 3.11 and will be removed in the next (major) client version. For now, just skip the tests if client authentication is used.