### PR TITLE
CLIENT-1428: Clarify info command docs when no query is specified (maint/3.x)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright 2013-2019 Aerospike, Inc.
+// Copyright 2013-2021 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -986,8 +986,8 @@ Client.prototype.indexRemove = function (namespace, index, policy, callback) {
  * @summary Sends an info query to a specific cluster node.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If <code>null</code>, the result will include default info
- * values.
+ * info request. If it is not specified, a default set of info values will be
+ * returned.
  *
  * Please refer to the
  * <a href="http://www.aerospike.com/docs/reference/info">Info Command Reference</a>
@@ -1034,8 +1034,8 @@ Client.prototype.info = function (request, host, policy, callback) {
  * @summary Sends an info query to a single, randomly selected cluster node.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If it is not specified, the response will include default
- * info values.
+ * info request. If it is not specified, a default set of info values will be
+ * returned.
  *
  * @param {string} [request] - The info request to send.
  * @param {InfoPolicy} [policy] - The Info Policy to use for this operation.
@@ -1078,8 +1078,8 @@ Client.prototype.infoAny = function (request, policy, callback) {
  * results.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If it is not specified, the response will include default
- * info values.
+ * info request. If it is not specified, a default set of info values will be
+ * returned.
  *
  * @param {string} [request] - The info request to send.
  * @param {InfoPolicy} [policy] - The Info Policy to use for this operation.
@@ -1123,8 +1123,8 @@ Client.prototype.infoAll = function (request, policy, callback) {
  * @summary Sends an info query to a single node in the cluster.
  *
  * @description The <code>request</code> parameter is a string representing an
- * info request. If it is not specified, the cluster host(s) will send all
- * available info.
+ * info request. If it is not specified, a default set of info values will be
+ * returned.
  *
  * @param {?string} request - The info request to send.
  * @param {object} node - The node to send the request to.


### PR DESCRIPTION
Resolves CLIENT-1428