### PR TITLE
 Fix duplicate map policy items it the TS

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -119,26 +119,6 @@ declare namespace Aerospike {
         INVERTED
     }
 
-    enum MapsOrder {
-        UNORDERED,
-        KEY_ORDERED,
-        KEY_VALUE_ORDERED = 3
-    }
-
-    enum MapsWriteMode {
-        UPDATE,
-        UPDATE_ONLY,
-        CREATE_ONLY
-    }
-
-    enum MapsWriteFlags {
-        DEFAULT,
-        CREATE_ONLY,
-        UPDATE_ONLY,
-        NO_FAIL,
-        PARTIAL
-    }
-
     enum MapReturnType {
         NONE,
         INDEX,
@@ -1338,11 +1318,10 @@ declare namespace Aerospike {
     }
 
     export interface MapsModule {
-        order: MapsOrder;
-        writeMode: MapsWriteMode;
-        writeFlags: MapsWriteFlags;
+        order: MapOrder;
+        writeMode: MapWriteMode;
+        writeFlags: MapWriteFlags;
         returnType: MapReturnType;
-        MapPolicy: MapPolicy;
         setPolicy(bin: string, policy: MapPolicy): MapOperation;
         put(bin: string, key: string, value: AerospikeRecordValue, policy?: MapPolicy): MapOperation;
         putItems(bin: string, items: AerospikeBins, policy?: MapPolicy): MapOperation;


### PR DESCRIPTION
The items appear twice causing confusion (`MapsOrder` vs. `MapOrder`, etc.)