### PR TITLE
PR: Client-nodejs 5.0.2 patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,8 @@
 [downloads-image]: https://img.shields.io/npm/dm/aerospike.svg
 [downloads-url]: http://npm-stat.com/charts.html?package=aerospike
 
-An Aerospike add-on module for Node.js.
+The Aerospike Node.js client is a Node.js add-on module, written using V8.
 
-The client is compatible with Node.js 10, 12 (LTS), 14 (LTS), and 16 (LTS). It
-supports the following operating systems: CentOS/RHEL 7/8, Debian 8/9/10,
-Ubuntu 18.04/20.04, as well as many Linux distributions compatible with one of
-these OS releases. macOS is also supported. The client port to Windows is a
-community supported project and suitable for application prototyping and
-development.
-
-- [Usage](#Usage)
-- [Prerequisites](#Prerequisites)
-- [Installation](#Installation)
-  - [Primer on Node.js Modules](#Primer-on-Node.js-Modules)
-  - [Installing via npm Registry](#Installing-via-npm-Registry)
-  - [Installing via Git Repository](#Installing-via-Git-Repository)
-- [Documentation](#Documentation)
-- [Tests](#Tests)
-- [Benchmarks](#Benchmarks)
-
-<a name="Usage"></a>
 ## Usage
 
 The following is very simple example how to create, update, read and remove a
@@ -93,8 +75,15 @@ Aerospike.connect(config)
   })
 ```
 
-<a name="Prerequisites"></a>
+
 ## Prerequisites
+
+The client is compatible with Node.js 10, 12 (LTS), 14 (LTS), 16 (LTS) and 18 (LTS). It
+supports the following operating systems: CentOS/RHEL 7/8, Debian 8/9/10,
+Ubuntu 18.04/20.04, as well as many Linux distributions compatible with one of
+these OS releases. macOS is also supported. The client port to Windows is a
+community supported project and suitable for application prototyping and
+development.
 
 The Aerospike Node.js client supports all Node.js [LTS
 releases](https://github.com/nodejs/Release#release-schedule). To download and
@@ -102,36 +91,39 @@ install the latest stable version of Node.js, visit
 [nodejs.org](http://nodejs.org/) or use the version that comes bundled with
 your operating system.
 
-The package includes a native add-on. `gcc`/`g++` v4.8 or newer or
-`clang`/`clang++` v3.4 or newer are required to build the add-on.
+### Libraries
 
-The package has the following compile time/run time dependencies:
+The client library requires the following libraries to be present on the machine for building and running:
 
-| Library Name | Description |
-| --- | --- |
-| libssl | |
-| libcrypto | Required for RIPEMD160 hash function. |
-| libz | Required for (optional) command compression. |
+|Library Name |	.rpm Package | Description
+|--|--|--
+| libssl | openssl |
+|libcrypto | openssl | Required for the `RIPEMD160` hash function.
 
-### CentOS/RHEL
+#### CentOS/RHEL
 
-To install library prerequisites via `yum`:
+To install library prerequisites using `yum`:
 
 ```bash
-sudo yum install gcc-c++ openssl-devel zlib-devel
+sudo yum install openssl-devel
+```
+Some CentOS installation paths do not include required C development tools. These packages may also be required:
+
+```bash
+sudo yum install gcc gcc-c++
 ```
 
-### Debian
+#### Debian
 
-To install library prerequisites via `apt-get`:
+To install library prerequisites using `apt-get`:
 
 ```bash
 sudo apt-get install g++ libssl1.0.0 libssl-dev libz-dev
 ```
 
-### Ubuntu
+#### Ubuntu
 
-To install library prerequisites via `apt-get`:
+To install library prerequisites using `apt-get`:
 
 ```bash
 sudo apt-get install g++ libssl1.0.0 libssl-dev zlib1g-dev
@@ -157,128 +149,83 @@ services:
     platform: linux/amd64
 ```
 
-#### Openssl library installation in Mac OS X.
+**Openssl Library**
 
 ```bash
 $ brew install openssl
 $ brew link openssl --force
 ```
+**LIBUV Library**
 
-### Windows
+```bash
+$ brew install libuv
+$ brew link libuv --force
+```
 
-See [Prerequisites for Aerospike Node.js Client on Windows](https://github.com/aerospike/aerospike-client-nodejs/blob/master/README_WINDOWS.md).
-
-<a name="Installation"></a>
 ## Installation
 
-The Aerospike Node.js client is a Node.js add-on module utilizing the Aerospike
-C client. The installation will attempt to install the pre-built binaries.
+The Aerospike Node.js client is an add-on module that uses the Aerospike C client. The installation will attempt to install the pre-built binaries including dependent C client.
 
-The Aerospike Node.js client can be installed like any other Node.js module, however
-we provided the following information for those not so familiar with Node.js modules.
+You can install the Aerospike Node.js client like any other Node.js module.
 
-<a name="Primer-on-Node.js-Modules"></a>
 ### Primer on Node.js Modules
 
 Node.js modules are containers of JavaScript code and a `package.json`, which defines
 the module, its dependencies and requirements. Modules are usually installed as
-dependencies of others Node.js application or module. The modules are installed in
+dependencies of other Node.js applications or modules. The modules are installed in
 the application's `node_modules` directory, and can be utilized within the program
 by requiring the module by name.
 
-A module may be installed in global location via the `-g` flag. The global location
-is usually reserved for modules that are not directly depended on by an application,
-but may have executables which you want to be able to call regardless of the
-application. This is usually the case for tools like tools like `npm` and `mocha`.
+### npm Registry Installations
 
-<a name="Installing-via-npm-Registry"></a>
-### Installing via npm Registry
+To install `aerospike` as a dependency of your project, in your project directory run:
 
-Installing via npm Registry is pretty simple and most common install method, as
-it only involves a single step.
+```bash
+$ npm install aerospike
+```
 
-Although the module may be installed globally or locally, we recommend performing
-local installs.
+To add `aerospike` as a dependency in _package.json_, run:
 
-To install the module as a dependency of your application, run the following
-from your application's directory:
+```bash
+$ npm install aerospike --save-dev
+```
 
-	$ npm install aerospike
+To require the module in your application:
+```bash
+const Aerospike = require('aerospike')
+```
 
-In most cases, an application should specify `aerospike` as a dependency in
-its `package.json`.
+### Git Repository Installations
 
-Once installed, the module can be required in the application:
-
-	const Aerospike = require('aerospike')
-
-<a name="Installing-via-Git-Repository"></a>
-### Installing via Git Repository
-
-The following is relevant for users who have cloned the repository, and want
-to install it as a dependency of their application.
+When using a cloned repository, install `aerospike` as a dependency of your application. Instead of referencing the module by name, you reference it by path.
 
 To clone the repository use the following command:
 
 	$ git clone --recursive git@github.com:aerospike/aerospike-client-nodejs.git
 
-Installing via Git Repository is slightly different from installing via npm
-registry, in that you will be referencing the module by path, rather than name.
+:::note
+Install the Aerospike Node.js module locally.
+:::
 
-Although the module may be installed globally or locally, we recommend performing
-local installs.
+#### Building dependancy C client
 
-#### Building dependancy c client
-
-Make sure to build c client before doing npm install variants
-Run the following commands to build c-client:
+Make sure to build the C client before doing npm install variants
+Run the following commands to build the C client:
 
 	$ ./scripts/build-c-client.sh
 
-#### Installing Globally
+To install the module as a dependency of your application, run the following in the application directory:
 
-This option required root permissions. This will download the Aerospike C client
-only once, which will improve the experience of using the module for many users.
-However, you will need to first install the package globally using root permissions.
+```bash
+$ npm install --unsafe-perm --build-from-source
+```
 
-Run the following as a user with root permission or using the sudo command:
+To require it in the application:
 
-	$ npm install -g <PATH> --unsafe-perm --build-from-source
+```bash
+const Aerospike = require('aerospike')
+```
 
-Where `<PATH>` is the path to the Aerospike Node.js client's Git respository is
-located. This will install the module in a globally accessible location.
-
-To install the module as a dependency of your application, run the following
-from your application's directory:
-
-	$ npm link aerospike
-
-Linking to the module does not require root permission.
-
-Once linked, the module can be required in the application:
-
-	const Aerospike = require('aerospike')
-
-#### Installing Locally
-
-This option does not require root permissions to install the module as a
-dependency of an application. However, it will require resolving the Aerospike
-C client each time you install the dependency, as it will need to exist local
-to the application.
-
-To install the module as a dependency of your application, run the following
-from your application's directory:
-
-	$ npm install <PATH> --unsafe-perm --build-from-source
-
-Where `<PATH>` is the path to the Aerospike Node.js client's Git respository is
-located.
-
-Once installed, the module can be required in the application:
-
-	const Aerospike = require('aerospike')
-
-<a name="Documentation"></a>
 ## Documentation
 
 Detailed documentation of the client's API can be found at
@@ -306,7 +253,6 @@ the major version number. Minor and patch releases, which increment only the
 second and third version number, will always be backwards compatible.
 
 
-<a name="Tests"></a>
 ## Tests
 
 The client includes a comprehensive test suite using
@@ -325,7 +271,6 @@ To run the tests and also report on test coverage:
 
     $ npm run coverage
 
-<a name="Benchmarks"></a>
 ## Benchmarks
 
 Benchmark utilies are provided in the [`benchmarks`](benchmarks) directory.

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -582,6 +582,14 @@ exports.setupGlobalCommandQueue = function (policy) {
   EventLoop.setCommandQueuePolicy(policy)
 }
 
+/**
+  * The {@link module:aerospike/batch_type|batch_type} module contains a list of the
+  * batch record types.
+  *
+  * @summary {@link module:aerospike/batch_type|aerospike/batch_type} module
+  */
+ exports.batch_type = require('./batch_type')
+ 
 // Set default log level
 as.setDefaultLogging({
   level: as.log.WARN,

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -583,12 +583,11 @@ exports.setupGlobalCommandQueue = function (policy) {
 }
 
 /**
-  * The {@link module:aerospike/batch_type|batch_type} module contains a list of the
-  * batch record types.
+  * @summary This module {@link module:aerospike/batchType|aerospike/batch_type} 
+  * contains a list of batch record types.
   *
-  * @summary {@link module:aerospike/batch_type|aerospike/batch_type} module
   */
-exports.batch_type = require('./batch_type')
+exports.batchType = require('./batch_type')
 
 // Set default log level
 as.setDefaultLogging({

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -583,7 +583,7 @@ exports.setupGlobalCommandQueue = function (policy) {
 }
 
 /**
-  * @summary This module {@link module:aerospike/batchType|aerospike/batch_type} 
+  * @summary This module {@link module:aerospike/batchType|aerospike/batch_type}
   * contains a list of batch record types.
   *
   */

--- a/lib/aerospike.js
+++ b/lib/aerospike.js
@@ -588,8 +588,8 @@ exports.setupGlobalCommandQueue = function (policy) {
   *
   * @summary {@link module:aerospike/batch_type|aerospike/batch_type} module
   */
- exports.batch_type = require('./batch_type')
- 
+exports.batch_type = require('./batch_type')
+
 // Set default log level
 as.setDefaultLogging({
   level: as.log.WARN,

--- a/lib/batch_type.js
+++ b/lib/batch_type.js
@@ -20,7 +20,7 @@ const as = require('bindings')('aerospike.node')
 const batchType = as.batchTypes
 
 /**
- * @module aerospike/batch_type
+ * @module aerospike/batchType
  *
  * @description batch record type.
  */

--- a/lib/batch_type.js
+++ b/lib/batch_type.js
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright 2022 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License')
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// *****************************************************************************
+
+'use strict'
+
+const as = require('bindings')('aerospike.node')
+const batchType = as.batchTypes
+
+/**
+ * @module aerospike/batch_type
+ *
+ * @description batch record type.
+ */
+
+// ========================================================================
+// Constants
+// ========================================================================
+
+/**
+ * Batch Record for read.
+ * @const {number}
+ */
+exports.BATCH_READ = batchType.BATCH_READ
+
+/**
+ * Batch Record for write.
+ * @const {number}
+ */
+exports.BATCH_WRITE = batchType.BATCH_WRITE
+ 
+ /**
+ * Batch Record for apply.
+ * @const {number}
+ */
+exports.BATCH_APPLY = batchType.BATCH_APPLY
+
+/**
+ * Batch Record for remove.
+ * @const {number}
+ */
+ exports.BATCH_REMOVE = batchType.BATCH_REMOVE
+ 

--- a/lib/batch_type.js
+++ b/lib/batch_type.js
@@ -40,8 +40,8 @@ exports.BATCH_READ = batchType.BATCH_READ
  * @const {number}
  */
 exports.BATCH_WRITE = batchType.BATCH_WRITE
- 
- /**
+
+/**
  * Batch Record for apply.
  * @const {number}
  */
@@ -51,5 +51,4 @@ exports.BATCH_APPLY = batchType.BATCH_APPLY
  * Batch Record for remove.
  * @const {number}
  */
- exports.BATCH_REMOVE = batchType.BATCH_REMOVE
- 
+exports.BATCH_REMOVE = batchType.BATCH_REMOVE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aerospike",
-  "version": "5.0.0",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aerospike",
-      "version": "5.0.0",
+      "version": "5.0.2",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aerospike",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Aerospike Client Library",
   "keywords": [
     "aerospike",

--- a/scripts/build-commands.sh
+++ b/scripts/build-commands.sh
@@ -35,15 +35,7 @@ LIBUV_URL=http://dist.libuv.org/dist/v1.8.0/${LIBUV_TAR}
 LIBUV_ABS_DIR=${CWD}/${LIBUV_DIR}
 LIBUV_BUILD=0
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  AEROSPIKE_LIB_HOME=${AEROSPIKE_C_HOME}/target/Linux-x86_64
-  AEROSPIKE_LIBRARY=${AEROSPIKE_LIB_HOME}/lib/libaerospike.a
-  AEROSPIKE_INCLUDE=${AEROSPIKE_LIB_HOME}/include
-  LIBUV_LIBRARY_DIR=${LIBUV_DIR}/.libs
-  LIBUV_INCLUDE_DIR=${CWD}/${LIBUV_DIR}/include
-  LIBUV_LIBRARY=${CWD}/${LIBUV_LIBRARY_DIR}/libuv.a
-  OS_FLAVOR=linux
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
   # Mac OSX
   AEROSPIKE_LIB_HOME=${AEROSPIKE_C_HOME}/target/Darwin-x86_64
   AEROSPIKE_LIBRARY=${AEROSPIKE_LIB_HOME}/lib/libaerospike.a
@@ -55,10 +47,22 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   LIBUV_INCLUDE_DIR=${LIBUV_DIR}/include
   LIBUV_LIBRARY=${LIBUV_LIBRARY_DIR}/libuv.a
   OS_FLAVOR=darwin
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  AEROSPIKE_LIB_HOME=${AEROSPIKE_C_HOME}/target/Linux-x86_64
+  AEROSPIKE_LIBRARY=${AEROSPIKE_LIB_HOME}/lib/libaerospike.a
+  AEROSPIKE_INCLUDE=${AEROSPIKE_LIB_HOME}/include
+  LIBUV_LIBRARY_DIR=${LIBUV_DIR}/.libs
+  LIBUV_INCLUDE_DIR=${CWD}/${LIBUV_DIR}/include
+  LIBUV_LIBRARY=${CWD}/${LIBUV_LIBRARY_DIR}/libuv.a
+  OS_FLAVOR=linux
 else
-    # Unknown.
-    printf "Unsupported OS version:" "$OSTYPE"
-    exit 1
+  AEROSPIKE_LIB_HOME=${AEROSPIKE_C_HOME}/target/Linux-x86_64
+  AEROSPIKE_LIBRARY=${AEROSPIKE_LIB_HOME}/lib/libaerospike.a
+  AEROSPIKE_INCLUDE=${AEROSPIKE_LIB_HOME}/include
+  LIBUV_LIBRARY_DIR=${LIBUV_DIR}/.libs
+  LIBUV_INCLUDE_DIR=${CWD}/${LIBUV_DIR}/include
+  LIBUV_LIBRARY=${CWD}/${LIBUV_LIBRARY_DIR}/libuv.a
+  OS_FLAVOR=linux
 fi
 
 configure_nvm() {

--- a/test/batch_write.js
+++ b/test/batch_write.js
@@ -22,6 +22,7 @@
 const Aerospike = require('../lib/aerospike')
 const helper = require('./test_helper')
 // const util = require('util')
+const batchType = Aerospike.batchType
 
 const op = Aerospike.operations
 const GeoJSON = Aerospike.GeoJSON
@@ -33,9 +34,6 @@ const putgen = helper.putgen
 const valgen = helper.valgen
 
 const Key = Aerospike.Key
-
-const as = require('bindings')('aerospike.node')
-const batchType = as.batchTypes
 
 describe('client.batchWrite()', function () {
   const client = helper.client

--- a/test/batch_write.js
+++ b/test/batch_write.js
@@ -22,7 +22,7 @@
 const Aerospike = require('../lib/aerospike')
 const helper = require('./test_helper')
 // const util = require('util')
-const batchType = Aerospike.batchType
+const batchType = Aerospike.batch_type
 
 const op = Aerospike.operations
 const GeoJSON = Aerospike.GeoJSON

--- a/test/batch_write.js
+++ b/test/batch_write.js
@@ -22,7 +22,7 @@
 const Aerospike = require('../lib/aerospike')
 const helper = require('./test_helper')
 // const util = require('util')
-const batchType = Aerospike.batch_type
+const batchType = Aerospike.batchType
 
 const op = Aerospike.operations
 const GeoJSON = Aerospike.GeoJSON

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -119,26 +119,6 @@ declare namespace Aerospike {
         INVERTED
     }
 
-    enum MapsOrder {
-        UNORDERED,
-        KEY_ORDERED,
-        KEY_VALUE_ORDERED = 3
-    }
-
-    enum MapsWriteMode {
-        UPDATE,
-        UPDATE_ONLY,
-        CREATE_ONLY
-    }
-
-    enum MapsWriteFlags {
-        DEFAULT,
-        CREATE_ONLY,
-        UPDATE_ONLY,
-        NO_FAIL,
-        PARTIAL
-    }
-
     enum MapReturnType {
         NONE,
         INDEX,
@@ -1286,9 +1266,9 @@ declare namespace Aerospike {
     }
 
     export interface MapsModule {
-        order: MapsOrder;
-        writeMode: MapsWriteMode;
-        writeFlags: MapsWriteFlags;
+        order: MapOrder;
+        writeMode: MapWriteMode;
+        writeFlags: MapWriteFlags;
         returnType: MapReturnType;
         MapPolicy: MapPolicy;
         setPolicy(bin: string, policy: MapPolicy): MapOperation;


### PR DESCRIPTION
It fixes the following:

[CLIENT-1745] Running node.js client 5.0.0 on Alpine 3.15 + node 17.9 results with an error
[CLIENT-1746] Node.js batch type js object and documentation incomplete

[CLIENT-1745]: https://aerospike.atlassian.net/browse/CLIENT-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-1746]: https://aerospike.atlassian.net/browse/CLIENT-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ