### PR TITLE
Update test matrix according to the Readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-- '15'
+- '18'
+- '16'
 - '14'
 - '12'
 - '10'
-- '8'
 env:
   global:
     - AEROSPIKE_HOSTS=127.0.0.1:3000,127.0.0.1:3100


### PR DESCRIPTION
Update test matrix according to the Readme
>The client is compatible with Node.js 10, 12 (LTS), 14 (LTS), 16 (LTS) and 18 (LTS).
https://github.com/aerospike/aerospike-client-nodejs/blob/master/README.md#prerequisites