### PR TITLE
Fix ssl_check.sh

### DIFF
--- a/scripts/ssl_check.sh
+++ b/scripts/ssl_check.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
-raw=$(openssl version);
-text=($raw);
-libre=${text[0]};
-osn=${text[1]:0:1};
+
+# Get the version string
+raw=$(openssl version)
+
+# Split the string on spaces
+IFS=' ' read -ra arr <<< "$raw"
+
+# Extract the first word from the array
+libre=${arr[0]}
+
+# Extract the version number from the second element of the array
+version=${arr[1]}
+
+# Split the version number on dots
+IFS='.' read -ra arr <<< "$version"
+
+# Extract the osn version number
+osn=${arr[0]}
+
 echo $osn;
 if [[ ($osn == 3 && $libre != "LibreSSL") ]]; then
         cd lib/binding/openssl@3;


### PR DESCRIPTION
**What does this PR do?**
This PR updates the script to check the OpenSSL version and copy files from the appropriate directory.

**Why is this change necessary?**
The old script used the wrong syntax to extract the first element from the text array, resulting in the incorrect value used in the if statement. This caused the script to execute the else block even when the OpenSSL version was 3.

The new script extracts the first word from the version string and checks whether it starts with "Libre." It also removes the version number from the second element of the array and splits it into dots to extract the major version number. This allows the script to determine the major version number correctly and whether the version is LibreSSL or OpenSSL.

**How does this PR fix the issue?**
The PR fixes the issue by using the correct syntax to extract the first element from the text array and extract the major version number from the version string. This allows the script to determine the major version number correctly and whether the version is LibreSSL or OpenSSL, enabling it to copy the files from the appropriate directory.

**Are there any side effects?**
There should not be any side effects as the changes are limited to the script for checking the OpenSSL version and copying files.

**Other information**
N/A