### PR TITLE
Allows client.batchWrite to return results through a promise rather t…

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -24,14 +24,6 @@ const as = require('bindings')('aerospike.node')
  * @description Database operation error codes.
  */
 
-// ========================================================================
-// Constants
-// ========================================================================
-/**
- * One or more keys failed in a batch.
- * @const {number}
- */
-exports.BATCH_FAILED = exports.AEROSPIKE_BATCH_FAILED = as.status.AEROSPIKE_BATCH_FAILED
 /**
  * Async command delay queue is full.
  * @const {number}

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -50,9 +50,7 @@ class AerospikeCommand : public Nan::AsyncResource {
 
 	v8::Local<v8::Value> Callback(const int argc, v8::Local<v8::Value> argv[]);
 	v8::Local<v8::Value> ErrorCallback();
-	v8::Local<v8::Value> ErrorCallback(v8::Local<v8::Value> arg);
 	v8::Local<v8::Value> ErrorCallback(as_error *err);
-	v8::Local<v8::Value> ErrorCallback(as_error *err, v8::Local<v8::Value> arg);
 	v8::Local<v8::Value> ErrorCallback(as_status code, const char *func,
 									   const char *file, uint32_t line,
 									   const char *fmt, ...);

--- a/src/main/command.cc
+++ b/src/main/command.cc
@@ -92,25 +92,6 @@ Local<Value> AerospikeCommand::ErrorCallback()
 	return scope.Escape(Callback(1, args));
 }
 
-Local<Value> AerospikeCommand::ErrorCallback(Local<Value> arg)
-{
-	Nan::EscapableHandleScope scope;
-
-	if (err.code <= AEROSPIKE_ERR_CLIENT) {
-		as_v8_error(log, "Client error in %s command: %s [%d]", cmd.c_str(),
-					err.message, err.code);
-		Local<Value> args[] = {error_to_jsobject(&err, log), arg};
-		return scope.Escape(Callback(2, args));
-	}
-	else {
-		as_v8_debug(log, "Server error in %s command: %s [%d]", cmd.c_str(),
-					err.message, err.code);
-	}
-
-	Local<Value> args[] = {error_to_jsobject(&err, log)};
-	return scope.Escape(Callback(1, args));
-}
-
 Local<Value> AerospikeCommand::ErrorCallback(as_error *error)
 {
 	Nan::EscapableHandleScope scope;
@@ -118,15 +99,6 @@ Local<Value> AerospikeCommand::ErrorCallback(as_error *error)
 	as_error_copy(&err, error);
 
 	return scope.Escape(ErrorCallback());
-}
-
-Local<Value> AerospikeCommand::ErrorCallback(as_error *error, Local<Value> arg)
-{
-	Nan::EscapableHandleScope scope;
-
-	as_error_copy(&err, error);
-
-	return scope.Escape(ErrorCallback(arg));
 }
 
 Local<Value> AerospikeCommand::ErrorCallback(as_status code, const char *func,

--- a/src/main/enums/status.cc
+++ b/src/main/enums/status.cc
@@ -30,7 +30,6 @@ Local<Object> status()
 {
 	Nan::EscapableHandleScope scope;
 	Local<Object> obj = Nan::New<Object>();
-	set(obj, "AEROSPIKE_BATCH_FAILED", AEROSPIKE_BATCH_FAILED);
 	set(obj, "AEROSPIKE_NO_RESPONSE", AEROSPIKE_NO_RESPONSE);
 	set(obj, "AEROSPIKE_MAX_ERROR_RATE", AEROSPIKE_MAX_ERROR_RATE);
 	set(obj, "AEROSPIKE_USE_NORMAL_RETRY", AEROSPIKE_USE_NORMAL_RETRY);


### PR DESCRIPTION
…han return an error when results have non-zero status values.

CLIENT-2195
Changed batch write to return  only results when the error is AEROSPIKE_BATCH_FAILED (-16) rather than return results an error.  This allows non-zero status values to be seen in promise results. Removed AEROSPIKE_BATCH_FAILED from status.js and status.cc. Added tests for policy.exists using promises.
Removed code from previous batch write workaround centered around callbacks.