### PR TITLE
Fixed segmentation fault occuring exp.maps.removeBy* and exp.lists.re…

### DIFF
--- a/lib/exp_lists.js
+++ b/lib/exp_lists.js
@@ -450,9 +450,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByValue: (bin, value, ctx = null) => [
+  removeByValue: (bin, value, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_ALL_BY_VALUE, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...value,
     ...bin
   ],
@@ -465,9 +465,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByValueList: (bin, values, ctx = null) => [
+  removeByValueList: (bin, values, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_VALUE_LIST, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...values,
     ...bin
   ],
@@ -483,9 +483,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByValueRange: (bin, end, begin, ctx = null) => [
+  removeByValueRange: (bin, end, begin, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_VALUE_INTERVAL, 3, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...begin,
     ...end,
     ...bin
@@ -500,9 +500,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByRelRankRangeToEnd: (bin, rank, value, ctx = null) => [
+  removeByRelRankRangeToEnd: (bin, rank, value, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_VALUE_REL_RANK_RANGE, 3, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...value,
     ...rank,
     ...bin
@@ -519,9 +519,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByRelRankRange: (bin, count, rank, value, ctx = null) => [
+  removeByRelRankRange: (bin, count, rank, value, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_VALUE_REL_RANK_RANGE, 4, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...value,
     ...rank,
     ...count,
@@ -536,9 +536,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByIndex: (bin, idx, ctx = null) => [
+  removeByIndex: (bin, idx, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_INDEX, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...idx,
     ...bin
   ],
@@ -551,9 +551,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByIndexRangeToEnd: (bin, idx, ctx = null) => [
+  removeByIndexRangeToEnd: (bin, idx, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_INDEX_RANGE, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...idx,
     ...bin
   ],
@@ -567,9 +567,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByIndexRange: (bin, count, idx, ctx = null) => [
+  removeByIndexRange: (bin, count, idx, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_INDEX_RANGE, 3, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...idx,
     ...count,
     ...bin
@@ -583,9 +583,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByRank: (bin, rank, ctx = null) => [
+  removeByRank: (bin, rank, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_RANK, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...rank,
     ...bin
   ],
@@ -598,9 +598,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByRankRangeToEnd: (bin, rank, ctx = null) => [
+  removeByRankRangeToEnd: (bin, rank, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_RANK_RANGE, 2, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...rank,
     ...bin
   ],
@@ -614,9 +614,9 @@ module.exports = {
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
  * @return {AerospikeExp} (list expression)
  */
-  removeByRankRange: (bin, count, rank, ctx = null) => [
+  removeByRankRange: (bin, count, rank, ctx = null, returnType = lists.returnType.NONE) => [
     ..._listModify(ctx, null, lists.opcodes.REMOVE_BY_RANK_RANGE, 3, 0),
-    ..._int(lists.RETURN_NONE),
+    ..._int(lists.returnType.NONE),
     ...rank,
     ...count,
     ...bin

--- a/lib/exp_maps.js
+++ b/lib/exp_maps.js
@@ -145,12 +145,13 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} key Key expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
 
  * @return {AerospikeExp} (map expression)
  */
-  removeByKey: (bin, key, ctx = null) => [
+  removeByKey: (bin, key, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_KEY, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...key,
     ...bin
   ],
@@ -161,12 +162,13 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} keys List expression of keys to remove.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  *
  */
-  removeByKeyList: (bin, keys, ctx = null) => [
+  removeByKeyList: (bin, keys, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_KEY_LIST, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...keys,
     ...bin
   ],
@@ -180,11 +182,12 @@ module.exports = {
  * @param {AerospikeExp} end End value expression.
  * @param {AerospikeExp} begin Begin value expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByKeyRange: (bin, end, begin, ctx = null) => [
+  removeByKeyRange: (bin, end, begin, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_KEY_INTERVAL, 3, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...begin,
     ...end,
     ...bin
@@ -197,11 +200,12 @@ module.exports = {
  * @param {AerospikeExp} idx Index integer expression.
  * @param {AerospikeExp} key Key expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByKeyRelIndexRangeToEnd: (bin, idx, key, ctx = null) => [
+  removeByKeyRelIndexRangeToEnd: (bin, idx, key, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_KEY_REL_INDEX_RANGE, 3, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...key,
     ...idx,
     ...bin
@@ -215,11 +219,12 @@ module.exports = {
  * @param {AerospikeExp} idx Index integer expression.
  * @param {AerospikeExp} key Key expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByKeyRelIndexRange: (bin, count, idx, key, ctx = null) => [
+  removeByKeyRelIndexRange: (bin, count, idx, key, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_KEY_REL_INDEX_RANGE, 4, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...key,
     ...idx,
     ...count,
@@ -232,11 +237,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} value Value expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByValue: (bin, value, ctx = null) => [
+  removeByValue: (bin, value, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_ALL_BY_VALUE, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...value,
     ...bin
   ],
@@ -247,11 +253,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} values Values list expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByValueList: (bin, values, ctx = null) => [
+  removeByValueList: (bin, values, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_VALUE_LIST, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...values,
     ...bin
   ],
@@ -265,11 +272,12 @@ module.exports = {
  * @param {AerospikeExp} end End value expression.
  * @param {AerospikeExp} begin Begin value expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByValueRange: (bin, end, begin, ctx = null) => [
+  removeByValueRange: (bin, end, begin, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_VALUE_INTERVAL, 3, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...begin,
     ...end,
     ...bin
@@ -282,11 +290,12 @@ module.exports = {
  * @param {AerospikeExp} rank Rank integer expression.
  * @param {AerospikeExp} value Value expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByValueRelRankRangeToEnd: (bin, rank, value, ctx = null) => [
+  removeByValueRelRankRangeToEnd: (bin, rank, value, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_VALUE_REL_RANK_RANGE, 3, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...value,
     ...rank,
     ...bin
@@ -301,11 +310,12 @@ module.exports = {
  * @param {AerospikeExp} rank Rank integer expression.
  * @param {AerospikeExp} value Value expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByValueRelRankRange: (bin, count, rank, value, ctx = null) => [
+  removeByValueRelRankRange: (bin, count, rank, value, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_VALUE_REL_RANK_RANGE, 4, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...value,
     ...rank,
     ...count,
@@ -318,11 +328,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} idx Index integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByIndex: (bin, idx, ctx = null) => [
+  removeByIndex: (bin, idx, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_INDEX, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...idx,
     ...bin
   ],
@@ -333,11 +344,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} idx Index integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByIndexRangeToEnd: (bin, idx, ctx = null) => [
+  removeByIndexRangeToEnd: (bin, idx, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_INDEX_RANGE, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...idx,
     ...bin
   ],
@@ -349,11 +361,12 @@ module.exports = {
  * @param {AerospikeExp} count Count integer expression.
  * @param {AerospikeExp} idx Index integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByIndexRange: (bin, count, idx, ctx = null) => [
-    ..._mapModify(ctx, null, maps.opcodes.PUT, 3, 0),
-    ..._int(maps.RETURN_NONE),
+  removeByIndexRange: (bin, count, idx, ctx = null, returnType = maps.returnType.NONE) => [
+    ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_INDEX_RANGE, 3, 0),
+    ..._int(returnType),
     ...idx,
     ...count,
     ...bin
@@ -365,11 +378,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} rank Rank integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByRank: (bin, rank, ctx = null) => [
+  removeByRank: (bin, rank, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_RANK, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...rank,
     ...bin
   ],
@@ -380,11 +394,12 @@ module.exports = {
  * @param {AerospikeExp} bin Map bin or map value expression.
  * @param {AerospikeExp} rank Rank integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByRankRangeToEnd: (bin, rank, ctx = null) => [
+  removeByRankRangeToEnd: (bin, rank, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_RANK_RANGE, 2, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...rank,
     ...bin
   ],
@@ -396,11 +411,12 @@ module.exports = {
  * @param {AerospikeExp} count Count integer expression.
  * @param {AerospikeExp} rank Rank integer expression.
  * @param {AerospikeExp} ctx Optional context path for nested CDT.
+ * @param {AerospikeExp} returnType Optional Return type. Valid values are returnType.NONE or returnType.INVERTED.
  * @return {AerospikeExp} (map expression)
  */
-  removeByRankRange: (bin, count, rank, ctx = null) => [
+  removeByRankRange: (bin, count, rank, ctx = null, returnType = maps.returnType.NONE) => [
     ..._mapModify(ctx, null, maps.opcodes.REMOVE_BY_RANK_RANGE, 3, 0),
-    ..._int(maps.RETURN_NONE),
+    ..._int(returnType),
     ...rank,
     ...count,
     ...bin
@@ -476,7 +492,7 @@ module.exports = {
  */
   getByKeyList: (bin, keys, returnType, ctx = null) => [
     ..._mapRead(exp.type.AUTO, returnType, true),
-    ..._mapStart(ctx, maps.opcodes.GET_BY_KEY_INTERVAL, 2),
+    ..._mapStart(ctx, maps.opcodes.GET_BY_KEY_LIST, 2),
     ..._int(returnType),
     ...keys,
     ...bin
@@ -495,7 +511,7 @@ module.exports = {
  */
   getByKeyRelIndexRangeToEnd: (bin, idx, key, returnType, ctx = null) => [
     ..._mapRead(exp.type.AUTO, returnType, true),
-    ..._mapStart(ctx, maps.opcodes.GET_BY_KEY_INTERVAL, 3),
+    ..._mapStart(ctx, maps.opcodes.GET_BY_KEY_REL_INDEX_RANGE, 3),
     ..._int(returnType),
     ...key,
     ...idx,
@@ -577,7 +593,7 @@ module.exports = {
  */
   getByValueList: (bin, values, returnType, ctx = null) => [
     ..._mapRead(exp.type.AUTO, returnType, true),
-    ..._mapStart(ctx, maps.opcodes.GET_BY_VALUE_INTERVAL, 2),
+    ..._mapStart(ctx, maps.opcodes.GET_BY_VALUE_LIST, 2),
     ..._int(returnType),
     ...values,
     ...bin

--- a/test/exp_list.js
+++ b/test/exp_list.js
@@ -84,6 +84,434 @@ describe('Aerospike.exp_operations', function () {
       })
     })
 
+    describe('clear', function () {
+      it('removes all items in a map', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.clear(
+              exp.binList('tags')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: [] })
+      })
+
+      it('selects item identified by index inside nested map', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.clear(
+              exp.binList('tags'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', []] })
+      })
+    })
+
+    describe('removeByValue', function () {
+      it('removes list item by value', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValue(
+              exp.binList('tags'),
+              exp.str('green')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'yellow'] })
+      })
+
+      it('removes list item by value in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValue(
+              exp.binList('tags'),
+              exp.str('white'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['orange', 'pink', 'black']] })
+      })
+    })
+
+    describe('removeByValueList', function () {
+      it('removes list item by value list', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValueList(
+              exp.binList('tags'),
+              exp.list(['green', 'yellow'])),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue'] })
+      })
+
+      it('removes list item by value list in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValueList(
+              exp.binList('tags'),
+              exp.list(['orange', 'white']),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['pink', 'black']] })
+      })
+    })
+
+    describe('removeByValueRange', function () {
+      it('removes list item by value range', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValueRange(
+              exp.binList('tags'),
+              exp.str('green'),
+              exp.str('blue')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['green', 'yellow'] })
+      })
+
+      it('removes list item by value range in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByValueRange(
+              exp.binList('tags'),
+              exp.str('pink'),
+              exp.str('black'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['pink', 'white']] })
+      })
+    })
+
+    describe('removeByRelRankRangeToEnd', function () {
+      it('removes list item by value relative rank range to end', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRelRankRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1),
+              exp.str('blue')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue'] })
+      })
+
+      it('removes list item by value relative rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRelRankRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1),
+              exp.str('orange'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['orange', 'black']] })
+      })
+    })
+
+    describe('removeByRelRankRange', function () {
+      it('removes list item by value relative rank range', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRelRankRange(
+              exp.binList('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('green')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['green', 'yellow'] })
+      })
+
+      it('removes list item by value relative rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRelRankRange(
+              exp.binList('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('pink'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['pink', 'white', 'black']] })
+      })
+    })
+
+    describe('removeByIndex', function () {
+      it('removes a list item by index', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndex(
+              exp.binList('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+        expect(result.bins).to.eql({ tags: ['blue', 'yellow'] })
+      })
+
+      it('removes a list item by index in a cdt context in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndex(
+              exp.binList('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['orange', 'white', 'black']] })
+      })
+    })
+
+    describe('removeByIndexRangeToEnd', function () {
+      it('removes a list item by index range to end', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndexRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue'] })
+      })
+
+      it('removes a list item by index range to end in a cdt context in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndexRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['orange']] })
+      })
+    })
+
+    describe('removeByIndexRange', function () {
+      it('removes a list item by index range', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', 'yellow'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndexRange(
+              exp.binList('tags'),
+              exp.int(2),
+              exp.int(0)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['yellow'] })
+      })
+
+      it('removes a list item by index range in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByIndexRange(
+              exp.binList('tags'),
+              exp.int(2),
+              exp.int(0),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['white', 'black']] })
+      })
+    })
+
+    describe('removeByRank', function () {
+      it('removes a list item by rank', async function () {
+        const key = await createRecord({ tags: ['yellow', 'green', 'blue'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRank(
+              exp.binList('tags'),
+              exp.int(2)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['green', 'blue'] })
+      })
+
+      it('removes a list item by rank in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRank(
+              exp.binList('tags'),
+              exp.int(2),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['orange', 'white', 'black']] })
+      })
+    })
+
+    describe('removeByRankRangeToEnd', function () {
+      it('removes a list item by rank range to end', async function () {
+        const key = await createRecord({ tags: ['yellow', 'green', 'blue'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRankRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue'] })
+      })
+
+      it('removes a list item by rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRankRangeToEnd(
+              exp.binList('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['black']] })
+      })
+    })
+
+    describe('removeByRankRange', function () {
+      it('removes a list item by rank range', async function () {
+        const key = await createRecord({ tags: ['yellow', 'green', 'blue'] })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRankRange(
+              exp.binList('tags'),
+              exp.int(2),
+              exp.int(0)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['yellow'] })
+      })
+
+      it('removes a list item by rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: ['blue', 'green', ['orange', 'pink', 'white', 'black']] })
+        const context = new Context().addListIndex(2)
+        const ops = [
+          exp.operations.write('tags',
+            exp.lists.removeByRankRange(
+              exp.binList('tags'),
+              exp.int(2),
+              exp.int(0),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: ['blue', 'green', ['pink', 'white']] })
+      })
+    })
+
     describe('getByValue', function () {
       it('matches the count of the matched list values', async function () {
         const key = await createRecord({ tags: ['blue', 'green', 'yellow', 'green'] })
@@ -292,7 +720,7 @@ describe('Aerospike.exp_operations', function () {
           op.read('list')
         ]
         const result = await client.operate(key, ops, {})
-        // console.log(result)
+
         expect(result.bins.list).to.eql([2, 3, 4, 5])
         expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, 6])
       })
@@ -307,7 +735,7 @@ describe('Aerospike.exp_operations', function () {
           op.read('list')
         ]
         const result = await client.operate(key, ops, {})
-        // console.log(result)
+
         expect(result.bins.list).to.eql([2, 3, 4, 5, [4]])
         expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, [4, 6]])
       })
@@ -323,7 +751,7 @@ describe('Aerospike.exp_operations', function () {
           op.read('list')
         ]
         const result = await client.operate(key, ops, {})
-        // console.log(result)
+
         expect(result.bins.list).to.eql([2, 3, 4, 5])
         expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, 2, 3, 4, 5])
       })
@@ -338,7 +766,7 @@ describe('Aerospike.exp_operations', function () {
           op.read('list')
         ]
         const result = await client.operate(key, ops, {})
-        // console.log(result)
+
         expect(result.bins.list).to.eql([2, 3, 4, 5, [80, 90, 100]])
         expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, [80, 90, 100, 2, 3, 4, 5, [80, 90, 100]]])
       })
@@ -354,7 +782,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      // console.log(result)
+
       expect(result.bins.list).to.eql([2, 3, 4, 5])
       expect(result.bins.ExpVar).to.eql([2, 3, 6, 4, 5])
     })
@@ -369,7 +797,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      // console.log(result)
+
       expect(result.bins.list).to.eql([2, 3, 4, 5, [4, 1, 9]])
       expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, [4, 1, 7, 9]])
     })
@@ -384,7 +812,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      // console.log(result)
+
       expect(result.bins.list).to.eql([2, 3, 4, 5])
       expect(result.bins.ExpVar).to.eql([2, 2, 3, 4, 5, 3, 4, 5])
     })
@@ -399,7 +827,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      // console.log(result)
+
       expect(result.bins.list).to.eql([2, 3, [9, 9]])
       expect(result.bins.ExpVar).to.eql([2, 3, [9, 2, 3, [9, 9], 9]])
     })
@@ -418,7 +846,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      // console.log(result)
+
       expect(result.bins.ExpVar).to.eql([5, 5, 4, 4, 3, 3, 2, 2])
       expect(result.bins.list).to.eql([2, 2, 3, 4, 5, 3, 4, 5])
     })
@@ -433,8 +861,7 @@ describe('Aerospike.exp_operations', function () {
         op.read('list')
       ]
       const result = await client.operate(key, ops, {})
-      console.log(result.bins.ExpVar)
-      // console.log(result)
+
       expect(result.bins.ExpVar).to.eql([2, 3, 4, 5, [100, 9]])
       expect(result.bins.list).to.eql([2, 3, 4, 5, [9, 100]])
     })

--- a/test/exp_map.js
+++ b/test/exp_map.js
@@ -109,6 +109,967 @@ describe('Aerospike.exp_operations', function () {
       })
     })
 
+    describe('removeByKey', function () {
+      it('removes map item by key', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKey(
+              exp.binMap('tags'),
+              exp.str('a')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { b: 'green', c: 'yellow' } })
+      })
+
+      it('removes map item by key in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKey(
+              exp.binMap('tags'),
+              exp.str('e'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByKeyList', function () {
+      it('removes map item by key list', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyList(
+              exp.binMap('tags'),
+              exp.list(['a', 'b'])),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'yellow' } })
+      })
+
+      it('removes map item by key list in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyList(
+              exp.binMap('tags'),
+              exp.list(['d', 'e']),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByKeyRange', function () {
+      it('removes map item by key range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRange(
+              exp.binMap('tags'),
+              exp.str('c'),
+              exp.str('a')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'yellow' } })
+      })
+
+      it('removes map item by key range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRange(
+              exp.binMap('tags'),
+              exp.str('h'),
+              exp.str('e'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange' } } })
+      })
+
+      it('removes inverted map item by key range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRange(
+              exp.binMap('tags'),
+              exp.str('c'),
+              exp.str('a'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', b: 'green' } })
+      })
+
+      it('removes inverted map item by key range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRange(
+              exp.binMap('tags'),
+              exp.str('h'),
+              exp.str('e'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByKeyRelIndexRangeToEnd', function () {
+      it('removes map item by key relative index range to end', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('b')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', b: 'green' } })
+      })
+
+      it('removes map item by key relative index range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('e'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink' } } })
+      })
+
+      it('removes inverted map item by key relative index range to end', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('b'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'yellow' } })
+      })
+
+      it('removes inverted map item by key relative index range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('e'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByKeyRelIndexRange', function () {
+      it('removes map item by key relative index range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              exp.str('a')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'yellow' } })
+      })
+
+      it('removes map item by key relative index range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              exp.str('d'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { f: 'white', g: 'black' } } })
+      })
+
+      it('removes inverted map item by key relative index range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              exp.str('a'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', b: 'green' } })
+      })
+
+      it('removes inverted map item by key relative index range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByKeyRelIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              exp.str('a'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink' } } })
+      })
+    })
+
+    describe('removeByValue', function () {
+      it('removes map item by value', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValue(
+              exp.binMap('tags'),
+              exp.str('green')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', c: 'yellow' } })
+      })
+
+      it('removes map item by value in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValue(
+              exp.binMap('tags'),
+              exp.str('white'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', g: 'black' } } })
+      })
+    })
+
+    describe('removeByValueList', function () {
+      it('removes map item by value list', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueList(
+              exp.binMap('tags'),
+              exp.list(['green', 'yellow'])),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue' } })
+      })
+
+      it('removes map item by value list in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueList(
+              exp.binMap('tags'),
+              exp.list(['orange', 'white']),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', g: 'black' } } })
+      })
+    })
+
+    describe('removeByValueRange', function () {
+      it('removes map item by value range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRange(
+              exp.binMap('tags'),
+              exp.str('green'),
+              exp.str('blue')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { b: 'green', c: 'yellow' } })
+      })
+
+      it('removes map item by value range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRange(
+              exp.binMap('tags'),
+              exp.str('pink'),
+              exp.str('black'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', f: 'white' } } })
+      })
+
+      it('removes inverted map item by value range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRange(
+              exp.binMap('tags'),
+              exp.str('green'),
+              exp.str('blue'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue' } })
+      })
+
+      it('removes inverted map item by value range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRange(
+              exp.binMap('tags'),
+              exp.str('pink'),
+              exp.str('black'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', g: 'black' } } })
+      })
+    })
+
+    describe('removeByValueRelRankRangeToEnd', function () {
+      it('removes map item by value relative rank range to end', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('blue')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'blue' } })
+      })
+
+      it('removes map item by value relative rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('orange'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', g: 'black' } } })
+      })
+
+      it('removes inverted map item by value relative rank range to end', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('blue'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'yellow', b: 'green' } })
+      })
+
+      it('removes inverted map item by value relative rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.str('black'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white' } } })
+      })
+    })
+
+    describe('removeByValueRelRankRange', function () {
+      it('removes map item by value relative rank range', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRange(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('green')),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'yellow', b: 'green' } })
+      })
+
+      it('removes map item by value relative rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRange(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('pink'),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', f: 'white', g: 'black' } } })
+      })
+
+      it('removes inverted map item by value relative rank range', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRange(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('green'),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'blue' } })
+      })
+
+      it('removes inverted map item by value relative rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByValueRelRankRange(
+              exp.binMap('tags'),
+              exp.int(1),
+              exp.int(-1),
+              exp.str('pink'),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange' } } })
+      })
+    })
+
+    describe('removeByIndex', function () {
+      it('removes a map item by index', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndex(
+              exp.binMap('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        let result = await client.operate(key, ops, {})
+        result = await client.get(key)
+        console.log(result)
+        expect(result.bins).to.eql({ tags: { a: 'blue', c: 'yellow' } })
+      })
+
+      it('removes a map item by index in a cdt context in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndex(
+              exp.binMap('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        let result = await client.operate(key, ops, {})
+        result = await client.get(key)
+        console.log(result)
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByIndexRangeToEnd', function () {
+      it('removes a map item by index range to end', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue' } })
+      })
+
+      it('removes a map item by index range to end in a cdt context in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange' } } })
+      })
+
+      it('removes an inverted map item by index range to end', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { b: 'green', c: 'yellow' } })
+      })
+
+      it('removes an inverted map item by index range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByIndexRange', function () {
+      it('removes a map item by index range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'yellow' } })
+      })
+
+      it('removes a map item by index range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { f: 'white', g: 'black' } } })
+      })
+
+      it('removes a inverted map item by index range', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', b: 'green' } })
+      })
+
+      it('removes a inverted map item by index range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByIndexRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink' } } })
+      })
+    })
+
+    describe('removeByRank', function () {
+      it('removes a map item by rank', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRank(
+              exp.binMap('tags'),
+              exp.int(2)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { b: 'green', c: 'blue' } })
+      })
+
+      it('removes a map item by rank in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRank(
+              exp.binMap('tags'),
+              exp.int(2),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', f: 'white', g: 'black' } } })
+      })
+    })
+
+    describe('removeByRankRangeToEnd', function () {
+      it('removes a map item by rank range to end', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { c: 'blue' } })
+      })
+
+      it('removes a map item by rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { g: 'black' } } })
+      })
+
+      it('removes an inverted map item by rank range to end', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'yellow', b: 'green' } })
+      })
+
+      it('removes an inverted map item by rank range to end in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRangeToEnd(
+              exp.binMap('tags'),
+              exp.int(1),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white' } } })
+      })
+    })
+
+    describe('removeByRankRange', function () {
+      it('removes a map item by rank range', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0)),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'yellow' } })
+      })
+
+      it('removes a map item by rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              context),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { e: 'pink', f: 'white' } } })
+      })
+
+      it('removes an inverted map item by rank range', async function () {
+        const key = await createRecord({ tags: { a: 'yellow', b: 'green', c: 'blue' } })
+
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              null,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { b: 'green', c: 'blue' } })
+      })
+
+      it('removes an inverted map item by rank range in a cdt context', async function () {
+        const key = await createRecord({ tags: { a: 'blue', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        const ops = [
+          exp.operations.write('tags',
+            exp.maps.removeByRankRange(
+              exp.binMap('tags'),
+              exp.int(2),
+              exp.int(0),
+              context,
+              maps.returnType.INVERTED),
+            0),
+          op.read('tags')
+        ]
+        const result = await client.operate(key, ops, {})
+
+        expect(result.bins).to.eql({ tags: { a: 'blue', nested: { d: 'orange', g: 'black' } } })
+      })
+    })
+
     describe('getByIndex', function () {
       it('selects item identified by index', async function () {
         const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
@@ -264,6 +1225,21 @@ describe('Aerospike.exp_operations', function () {
       })
     })
 
+    describe('getByKeyList', function () {
+      it('matches the count of the matched map values', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
+        await testNoMatch(key, exp.eq(exp.maps.getByKeyList(exp.binMap('tags'), exp.list(['a', 'b']), maps.returnType.COUNT), exp.int(1)))
+        await testMatch(key, exp.eq(exp.maps.getByKeyList(exp.binMap('tags'), exp.list(['a', 'b']), maps.returnType.COUNT), exp.int(2)))
+      })
+
+      it('matches the count of the matched map values of a nested map', async function () {
+        const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
+        const context = new Context().addMapKey('nested')
+        await testNoMatch(key, exp.eq(exp.maps.getByKeyList(exp.binMap('tags'), exp.list(['d', 'e']), maps.returnType.COUNT, context), exp.int(1)))
+        await testMatch(key, exp.eq(exp.maps.getByKeyList(exp.binMap('tags'), exp.list(['d', 'e']), maps.returnType.COUNT, context), exp.int(2)))
+      })
+    })
+
     describe('getByKeyRange', function () {
       it('matches the count of the matched map values', async function () {
         const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
@@ -293,7 +1269,7 @@ describe('Aerospike.exp_operations', function () {
         await testMatch(key, exp.eq(exp.maps.getByKeyRelIndexRange(exp.binMap('tags'), exp.int(3), exp.int(0), exp.str('g'), maps.returnType.COUNT, context), exp.int(2)))
       })
     })
-    /*
+
     describe('getByKeyRelIndexRangeToEnd', function () {
       it('matches the count of the matched map values', async function () {
         const key = await createRecord({ tags: { a: 'blue', b: 'green', d: 'yellow' } })
@@ -304,11 +1280,11 @@ describe('Aerospike.exp_operations', function () {
       it('matches the count of the matched map values of a nested map', async function () {
         const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow', nested: { d: 'orange', e: 'pink', g: 'white', h: 'black' } } })
         const context = new Context().addMapKey('nested')
-        await testNoMatch(key, exp.eq(exp.maps.getByKeyRelIndexRangeToEnd(exp.binMap('tags'),  exp.int(0), exp.str('e'), maps.returnType.COUNT, context), exp.int(2)))
-        await testMatch(key, exp.eq(exp.maps.getByKeyRelIndexRangeToEnd(exp.binMap('tags'), exp.int(0), exp.str('e'),  maps.returnType.COUNT, context), exp.int(3)))
+        await testNoMatch(key, exp.eq(exp.maps.getByKeyRelIndexRangeToEnd(exp.binMap('tags'), exp.int(0), exp.str('e'), maps.returnType.COUNT, context), exp.int(2)))
+        await testMatch(key, exp.eq(exp.maps.getByKeyRelIndexRangeToEnd(exp.binMap('tags'), exp.int(0), exp.str('e'), maps.returnType.COUNT, context), exp.int(3)))
       })
     })
-*/
+
     describe('getByRank', function () {
       it('selects map item identified by rank', async function () {
         const key = await createRecord({ tags: { a: 'blue', b: 'green', d: 5, c: 'yellow' } })
@@ -472,24 +1448,22 @@ describe('Aerospike.exp_operations', function () {
     })
   })
 
-  /*
   describe('getByValueList', function () {
     it('matches the count of the matched values', async function () {
       const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow' } })
 
-      await testNoMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list([exp.str('green'), exp.str('yellow')]), maps.returnType.COUNT), exp.int(3)))
-      await testMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list([exp.str('green'), exp.str('yellow')]), maps.returnType.COUNT), exp.int(2)))
+      await testNoMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list(['green', 'yellow']), maps.returnType.COUNT), exp.int(3)))
+      await testMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list(['green', 'yellow']), maps.returnType.COUNT), exp.int(2)))
     })
 
     it('matches the count of the matched values', async function () {
       const key = await createRecord({ tags: { a: 'blue', b: 'green', c: 'yellow', nested: { d: 'orange', e: 'pink', f: 'white', g: 'black' } } })
       const context = new Context().addMapKey('nested')
 
-      await testNoMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list([exp.str('orange'), exp.str('white')]), maps.returnType.COUNT, context), exp.int(3)))
-      await testMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list([exp.str('orange'), exp.str('white')]), maps.returnType.COUNT, context), exp.int(2)))
+      await testNoMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list(['orange', 'white']), maps.returnType.COUNT, context), exp.int(3)))
+      await testMatch(key, exp.eq(exp.maps.getByValueList(exp.binMap('tags'), exp.list(['orange', 'white']), maps.returnType.COUNT, context), exp.int(2)))
     })
   })
-*/
 
   describe('getByValueRange', function () {
     it('matches the count of the matched range of map values', async function () {


### PR DESCRIPTION
…moveBy methods

CLIENT-2488 & CLIENT-2538
Fixed segmentation fault occuring exp.maps.removeBy* and exp.lists.removeBy methods Fixed opcodes in exp.list.getByKeyList, exp.list.getByKeyRelIndexRangeToEnd, exp.getByValueList methods Added testing for all fixed methods.