### PR TITLE
Updated the C Client submodule.

### DIFF
--- a/ts-test/tests/batch_write.ts
+++ b/ts-test/tests/batch_write.ts
@@ -574,4 +574,38 @@ describe('client.batchWrite()', function () {
         })
     })
   })
+
+  it('Runs BATCH_WRITE with a single batch record an a command in a transaction', async function () {
+    const key: any = new Key(helper.namespace, helper.set, 'test/batch_write/20')
+
+    const batchRecords: BatchWriteRecord[] = [
+      {
+        type: Aerospike.batchType.BATCH_WRITE,
+        key: key,
+        ops: [Aerospike.operations.write('exampleBin', 1)],
+        policy: new Aerospike.BatchWritePolicy({
+          onLockingOnly: true,
+        })
+      },
+    ]
+
+    let mrt: any = new Aerospike.Transaction()
+
+    const policy: BatchPolicyOptions = new Aerospike.BatchPolicy({
+        txn: mrt,
+    })
+
+    try{
+      let result = await client.batchWrite(batchRecords, policy)
+      expect(result[0].status).to.eql(status.OK)
+    }
+    catch(error: any){
+      assert.fail('An error should not have been caught')
+    }
+    finally {
+      await client.abort(mrt)
+    }
+    
+  })
+
 })


### PR DESCRIPTION
CLIENT-3391

Fixes segmentation fault when using batchWrite with a single record as a command in a transaction.