### PR TITLE
fix(docs): incompatible changes

### DIFF
--- a/incompatible.md
+++ b/incompatible.md
@@ -2,8 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.3.0]
-### Client no longer supports Node.js version 24
+## [6.4.0]
+
+### Client no longer supports for Red Hat Enterprise Linux 8
+### Client no longer supports Debian 11
 
 ## [5.12.1]
 ### Client no longer supports Node.js version 21


### PR DESCRIPTION
Support was added for Node 24 in 6.3 and according to release docs, nothing was dropped.

In 6.4.0, support was removed for RHEL 8 and Debian 11

This takes care of both of those