### PR TITLE
fix(typings): AerospikeRecord

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -295,7 +295,7 @@ export class AerospikeRecord<B extends AerospikeBins = AerospikeBins> {
      *
      * @type {AerospikeBins}
      */
-    public bins: AerospikeRecord<B>;
+    public bins: B;
 
     /**
      * The record's remaining time-to-live in seconds before it expires.


### PR DESCRIPTION
This should be B, as it extends AerospikeBins, not AerospikeRecord<B>, which would lead to a nested record.

(This change reflects the JSDoc comment)

Fixes #801 