### PR TITLE
typings: fix Nodejs internal types resolving

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import * as Buffer from "buffer";
+/// <reference types="node" />
 import { EventEmitter, Stream } from "stream";
 
 /**


### PR DESCRIPTION
Since this project is not written on TS and don't have tsconfig file, which describes that this project can use Nodejs types - there are only abstract types available for `.d.ts` files, so no `Buffer`, `EventEmitter` and other Nodejs-only types.

Because of this limited list of types, there are some errors with typings - `Client` class extends `any` instead of `EventEmitter`, same with `RecordStream` and `Stream`; `PartialAerospikeBinValue` unions with `Buffer`, which is only available on Nodejs, this results in `type AerospikeBinValue = any` or even can cause an error with typescript-eslint.

It can be fixed with `reference` tag in `.d.ts` file and without tsconfig file.