### PR TITLE
fix(install): NODE_ENV=production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,20 +19,20 @@
         "win32"
       ],
       "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.3",
         "bindings": "^1.5.0",
+        "husky": "^9.0.11",
         "minimatch": "^10.1.1",
         "nan": "^2.22.0",
         "node-gyp": "^12.1.0",
         "npm-run-all": "^4.1.5"
       },
       "devDependencies": {
-        "@mapbox/node-pre-gyp": "^2.0.3",
         "@types/node": "^24.7.0",
         "chai": "^6.2.0",
         "choma": "^1.2.1",
         "eslint": "^9.39.1",
         "globals": "^16.5.0",
-        "husky": "^9.0.11",
         "mocha": "^11.7.5",
         "mocha-clean": "^1.0.0",
         "standard": "^17.1.0",
@@ -471,7 +471,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
       "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "consola": "^3.2.3",
@@ -938,7 +937,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
       "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -1441,7 +1439,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -1588,7 +1585,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2961,7 +2957,6 @@
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "husky": "bin.js"
@@ -4210,7 +4205,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -4303,7 +4297,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
       "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "abbrev": "^3.0.0"
@@ -6314,7 +6307,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -6631,14 +6623,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -58,20 +58,20 @@
     "removeExtraBinaries": "node ./scripts/prebuiltBinding.js"
   },
   "dependencies": {
+    "@mapbox/node-pre-gyp": "^2.0.3",
     "bindings": "^1.5.0",
+    "husky": "^9.0.11",
     "minimatch": "^10.1.1",
     "nan": "^2.22.0",
     "node-gyp": "^12.1.0",
     "npm-run-all": "^4.1.5"
   },
   "devDependencies": {
-    "@mapbox/node-pre-gyp": "^2.0.3",
     "@types/node": "^24.7.0",
     "chai": "^6.2.0",
     "choma": "^1.2.1",
     "eslint": "^9.39.1",
     "globals": "^16.5.0",
-    "husky": "^9.0.11",
     "mocha": "^11.7.5",
     "mocha-clean": "^1.0.0",
     "standard": "^17.1.0",


### PR DESCRIPTION
When installing with NODE_ENV=production, yarn hiccups on the node-pre-gyp installation, since it is considered a devDependency. This also happens with npm and husky, for the same reason.

Fix [#886](https://github.com/aerospike/aerospike-client-nodejs/issues/886)