### PR TITLE
[CLIENT-4964] Docs: clarify client config "batch_parent_write" and "batch" policy behavior

### DIFF
--- a/lib/aerospike.d.ts
+++ b/lib/aerospike.d.ts
@@ -4170,7 +4170,7 @@ export class Client extends EventEmitter {
     *   hosts: '192.168.33.10:3000',
     *   // Timeouts disabled, latency dependent on server location. Configure as needed.
     *   policies: {
-    *     batch : new Aerospike.BatchPolicy({socketTimeout : 0, totalTimeout : 0}),
+    *     batchParentWrite : new Aerospike.BatchPolicy({socketTimeout : 0, totalTimeout : 0}),
     *   }
     * }
     *

--- a/lib/aerospike.d.ts
+++ b/lib/aerospike.d.ts
@@ -10622,7 +10622,7 @@ export interface ConfigPolicies {
      */
     apply?: policy.ApplyPolicy;
     /**
-     * Batch policy. For more information, see {@link policy.BasePolicy | BasePolicy}
+     * Batch policy used in batch read commands. For more information, see {@link policy.BasePolicy | BasePolicy}
      */
     batch?: policy.BasePolicy;
     /**
@@ -10630,7 +10630,7 @@ export interface ConfigPolicies {
      */
     batchApply?: policy.BatchApplyPolicy;
     /**
-     * Batch parent write policy. For more information, see {@link policy.BatchPolicy | BatchPolicy}
+     * Batch policy used in batch write commands. For more information, see {@link policy.BatchPolicy | BatchPolicy}
      */
     batchParentWrite?: policy.BatchPolicy;
     /**


### PR DESCRIPTION
This documentation now matches the C client's `as_config` docs more