### PR TITLE
Fix remaining Windows execute-build failures

### DIFF
--- a/.github/workflows/pr-build-prebuilds.yml
+++ b/.github/workflows/pr-build-prebuilds.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'scripts/ci/**'
+      - 'scripts/build-native.js'
       - 'scripts/relocate-prebuilds.js'
       - 'lib/native.js'
       - 'package.json'

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/aerospike/aerospike-client-nodejs/issues"
   },
   "scripts": {
-    "build": "node-gyp rebuild --addon_version=$(node -p \"require('./package.json').version\") && node scripts/relocate-prebuilds.js",
+    "build": "node scripts/build-native.js",
     "test": "mocha test/${npm_config_testfile:-}",
     "test-dry-run": "mocha --dry-run",
     "test-noserver": "GLOBAL_CLIENT=false mocha -g '#noserver'",

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+'use strict'
+
+const { execSync } = require('child_process')
+const { version } = require('../package.json')
+
+execSync(`node-gyp rebuild --addon_version=${version}`, { stdio: 'inherit' })
+execSync('node scripts/relocate-prebuilds.js', { stdio: 'inherit' })

--- a/scripts/ci/build-node-prebuild.sh
+++ b/scripts/ci/build-node-prebuild.sh
@@ -4,13 +4,61 @@ set -euo pipefail
 PLATFORM_TAG="${PLATFORM_TAG:?PLATFORM_TAG is required}"
 NODE_VERSION="${NODE_VERSION:?NODE_VERSION is required}"
 
+setup_node_windows() {
+  local node_dir="" candidate major toolcache
+
+  toolcache="${RUNNER_TOOL_CACHE:-/c/hostedtoolcache/windows}"
+  shopt -s nullglob
+  for candidate in "${toolcache}/Node/${NODE_VERSION}."*/x64; do
+    if [[ -x "${candidate}/node.exe" ]]; then
+      node_dir="${candidate}"
+      break
+    fi
+  done
+  shopt -u nullglob
+
+  if [[ -n "${node_dir}" ]]; then
+    export PATH="${node_dir}:${PATH}"
+    return
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    major="$(node -p "process.version.split('.')[0].slice(1)")"
+    if [[ "${major}" == "${NODE_VERSION}" ]]; then
+      return
+    fi
+  fi
+
+  # Fallback: download latest patch for the requested major from nodejs.org.
+  node_dir="$(pwsh -NoProfile -Command "
+    \$major = '${NODE_VERSION}'
+    \$dest = Join-Path \$env:RUNNER_TEMP \"node-\$major\"
+    if (Test-Path (Join-Path \$dest 'node.exe')) {
+      \$unix = '/' + \$dest.Substring(0,1).ToLower() + \$dest.Substring(2).Replace('\\', '/')
+      Write-Output \$unix
+      exit 0
+    }
+    \$index = Invoke-RestMethod 'https://nodejs.org/dist/index.json'
+    \$match = \$index | Where-Object { \$_.version -match \"^v\$major\\.\" } | Select-Object -First 1
+    if (-not \$match) { exit 1 }
+    \$ver = \$match.version.TrimStart('v')
+    \$zip = Join-Path \$env:RUNNER_TEMP \"node-v\$ver-win-x64.zip\"
+    Invoke-WebRequest -Uri \"https://nodejs.org/dist/v\$ver/node-v\$ver-win-x64.zip\" -OutFile \$zip
+    Expand-Archive -Path \$zip -DestinationPath \$dest -Force
+    Move-Item -Path (Join-Path \$dest \"node-v\$ver-win-x64\\*\") -Destination \$dest -Force
+    \$unix = '/' + \$dest.Substring(0,1).ToLower() + \$dest.Substring(2).Replace('\\', '/')
+    Write-Output \$unix
+  ")" || {
+    echo "ERROR: could not provision Node.js ${NODE_VERSION} on Windows" >&2
+    exit 1
+  }
+
+  export PATH="${node_dir}:${PATH}"
+}
+
 setup_node() {
   if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-    if ! command -v node >/dev/null 2>&1 \
-      || [[ "$(node -p "process.version.split('.')[0].slice(1)")" != "${NODE_VERSION}" ]]; then
-      choco install nodejs --version="${NODE_VERSION}.18.0" -y --no-progress
-      export PATH="/c/Program Files/nodejs:$PATH"
-    fi
+    setup_node_windows
     return
   fi
 


### PR DESCRIPTION
## Summary

Fixes Windows `win32_x64` failures in `dev-build-node-cpp-bindings` / `reusable_execute-build` after merging the Option B + shared-workflows work to `dev`.

Three separate issues were causing the matrix jobs (`v115`, `v127`, `v137`, `v141`) to fail:

1. **`patch_windows_props()` pwsh quoting** — `'''` + `--working-directory` was parsed inside the PowerShell `-Command` block (`ParserError: Missing expression after unary operator '--'`).
2. **Node version setup via choco** — MSI install failures for Node 20 (exit 1603) and Node 25 not found on Chocolatey (`25.18.0` doesn't exist).
3. **`npm run build` on Windows** — `$(node -p ...)` in `package.json` is bash syntax; Windows npm/cmd doesn't expand it, so `node-gyp` received a broken `--addon_version` argument.

Also removes the legacy post-build OpenSSL `.lib` copy from `cleanup_windows_artifacts()` (per review with Julian) and skips Linux-only `build-c-client.sh` on Windows (C client is built via `build-c-client.ps1` during `node-gyp rebuild`).

## Changes

### `scripts/ci/build-node-prebuild.sh`
- Fix `patch_windows_props()` to use `pwsh -WorkingDirectory aerospike-client-c/vs -Command '...'`
- Replace choco Node install with GHA toolcache lookup (`$RUNNER_TOOL_CACHE/Node/{major}.*/x64`), with nodejs.org zip fallback
- Run `nuget restore` from `aerospike-client-c/vs` (matches master workflow)
- Skip `./scripts/build-c-client.sh` on `win32_x64`
- Align `%(AdditionalIncludeDirectories)` escaping with master workflow
- Drop redundant OpenSSL `.lib` copy; keep pdb/obj cleanup only

### `scripts/build-native.js` + `package.json`
- Add cross-platform build wrapper: `node-gyp rebuild --addon_version={version}` + `relocate-prebuilds.js`
- Does **not** change Option B — still publishes `prebuilds/*.node`; consumers still use `node-gyp-build` with `--ignore-scripts`

### `.github/workflows/pr-build-prebuilds.yml`
- Add `scripts/build-native.js` to PR path filters

## Test plan

- [ ] Re-run **Dev workflow** (or dispatch `dev-build-node-cpp-bindings` for `win32_x64` only)
- [ ] Confirm all 4 Windows matrix jobs pass: `v115`, `v127`, `v137`, `v141`
- [ ] Verify `prebuilds/win32-x64/aerospike.{abi}.node` is uploaded as GH artifact
- [ ] Smoke: `npm install --ignore-scripts` + `require('aerospike')` on Windows (`test-prebuilds-ignore-scripts` when available)