### PR TITLE
CLIENT-4114: Updated the scripts for stage failures

### DIFF
--- a/.github/workflows/pr-build-prebuilds.yml
+++ b/.github/workflows/pr-build-prebuilds.yml
@@ -68,7 +68,7 @@ jobs:
           abi=$(node -p "process.versions.modules")
           platform=$(node -p "process.platform")
           arch=$(node -p "process.arch")
-          prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/aerospike.${abi}.node"
+          prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/node.abi${abi}.node"
           test -f "$prebuild"
           node -e "require('aerospike'); console.log('ok')"
           node -e "

--- a/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
+++ b/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
@@ -58,7 +58,7 @@ jobs:
         abi=$(node -p "process.versions.modules")
         platform=$(node -p "process.platform")
         arch=$(node -p "process.arch")
-        prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/aerospike.${abi}.node"
+        prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/node.abi${abi}.node"
         test -f "$prebuild"
         node -e "require('aerospike'); console.log('ok')"
         node -e "

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -105,7 +105,7 @@ jobs:
         abi=$(node -p "process.versions.modules")
         platform=$(node -p "process.platform")
         arch=$(node -p "process.arch")
-        prebuild="prebuilds/${platform}-${arch}/aerospike.${abi}.node"
+        prebuild="prebuilds/${platform}-${arch}/node.abi${abi}.node"
         test -f "$prebuild"
         node -e "require('aerospike'); console.log('ok')"
       working-directory: node_modules/aerospike

--- a/scripts/relocate-prebuilds.js
+++ b/scripts/relocate-prebuilds.js
@@ -10,7 +10,8 @@ const abi = process.versions.modules
 const platform = process.platform
 const arch = process.arch
 const destDir = path.join(prebuildsDir, `${platform}-${arch}`)
-const dest = path.join(destDir, `aerospike.${abi}.node`)
+// node-gyp-build expects prebuildify-style tags (e.g. node.abi115.node), not aerospike.115.node
+const dest = path.join(destDir, `node.abi${abi}.node`)
 
 function findSource () {
   const releasePath = path.join(root, 'build', 'Release', 'aerospike.node')


### PR DESCRIPTION
Prebuilds were written as aerospike.115.node, but node-gyp-build expects prebuildify-style names like node.abi115.node. With the old names, every Node version loaded the Node 20 binary, so stage CI only passed on Node 20.

Updates relocate-prebuilds.js and CI verify steps to use node.abi${modules}.node.