### PR TITLE
[CLIENT-4114] Fix stage tests: .ts testfiles and win32 prebuild DLLs

### DIFF
--- a/.github/workflows/pr-build-prebuilds.yml
+++ b/.github/workflows/pr-build-prebuilds.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/ci/**'
       - 'scripts/build-native.js'
       - 'scripts/relocate-prebuilds.js'
+      - 'scripts/verify-prebuild-smoke.js'
       - 'lib/native.js'
       - 'package.json'
       - 'package-lock.json'
@@ -65,12 +66,7 @@ jobs:
           npm pack
           PKG_TGZ=(aerospike-*.tgz)
           npm install --no-save --ignore-scripts "${PKG_TGZ[0]}"
-          abi=$(node -p "process.versions.modules")
-          platform=$(node -p "process.platform")
-          arch=$(node -p "process.arch")
-          prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/node.abi${abi}.node"
-          test -f "$prebuild"
-          node -e "require('aerospike'); console.log('ok')"
+          node node_modules/aerospike/scripts/verify-prebuild-smoke.js
           node -e "
             const p = require('./node_modules/aerospike/package.json');
             for (const s of ['preinstall','install','postinstall']) {

--- a/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
+++ b/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
@@ -55,12 +55,7 @@ jobs:
         set -ex
         PKG_TGZ=(aerospike-*.tgz)
         npm install --no-save --ignore-scripts "${PKG_TGZ[0]}"
-        abi=$(node -p "process.versions.modules")
-        platform=$(node -p "process.platform")
-        arch=$(node -p "process.arch")
-        prebuild="node_modules/aerospike/prebuilds/${platform}-${arch}/node.abi${abi}.node"
-        test -f "$prebuild"
-        node -e "require('aerospike'); console.log('ok')"
+        node node_modules/aerospike/scripts/verify-prebuild-smoke.js
         node -e "
           const p = require('./node_modules/aerospike/package.json');
           for (const s of ['preinstall','install','postinstall']) {

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -650,7 +650,7 @@ jobs:
         aerolab config backend -t docker
         aerolab xdr create-clusters -n dc1 -c 3 -N dc2 -C 3 -M test
         aerolab cluster list
-        npm run test --testfile=set_xdr_filter.js -- --testXDR true --h 172.17.0.2 --port 3100;
+        npm run test --testfile=set_xdr_filter.ts -- --testXDR true --h 172.17.0.2 --port 3100;
         # Cleanup steps
         echo y | aerolab cluster destroy --name dc1
         echo y | aerolab cluster destroy --name dc2
@@ -804,8 +804,8 @@ jobs:
       if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
       run: |
         docker pull aerospike/aerospike-server:latest;
-        npm run test --testfile=metrics_node_close.js -- --testMetrics true --h localhost --port 3000  --t 50000;
-        npm run test --testfile=metrics_cluster_name.js -- --testMetrics true --h localhost --port 3000  --t 50000;
+        npm run test --testfile=metrics_node_close.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
+        npm run test --testfile=metrics_cluster_name.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1
@@ -967,7 +967,7 @@ jobs:
     - name: Run tests
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
-        npm run test --testfile=timeout_delay.js -- --testTimeoutDelay true --h localhost --port 3000;
+        npm run test --testfile=timeout_delay.ts -- --testTimeoutDelay true --h localhost --port 3000;
         sudo tc qdisc del dev lo root netem
 
     # - name: Set final commit status

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -100,14 +100,7 @@ jobs:
     - run: npm install --no-save --ignore-scripts *.tgz
       shell: bash
 
-    - run: |
-        set -ex
-        abi=$(node -p "process.versions.modules")
-        platform=$(node -p "process.platform")
-        arch=$(node -p "process.arch")
-        prebuild="prebuilds/${platform}-${arch}/node.abi${abi}.node"
-        test -f "$prebuild"
-        node -e "require('aerospike'); console.log('ok')"
+    - run: node scripts/verify-prebuild-smoke.js
       working-directory: node_modules/aerospike
       shell: bash
 

--- a/scripts/relocate-prebuilds.js
+++ b/scripts/relocate-prebuilds.js
@@ -43,3 +43,17 @@ if (!src) {
 fs.mkdirSync(destDir, { recursive: true })
 fs.copyFileSync(src, dest)
 console.log(`relocate-prebuilds: ${src} -> ${dest}`)
+
+// Windows links aerospike.dll at runtime (AS_SHARED_IMPORT). Linux/macOS are fully static in .node.
+if (platform === 'win32') {
+  const releaseDir = path.dirname(src)
+  for (const name of fs.readdirSync(releaseDir)) {
+    if (!name.toLowerCase().endsWith('.dll')) {
+      continue
+    }
+    const from = path.join(releaseDir, name)
+    const to = path.join(destDir, name)
+    fs.copyFileSync(from, to)
+    console.log(`relocate-prebuilds: ${from} -> ${to}`)
+  }
+}

--- a/scripts/verify-prebuild-smoke.js
+++ b/scripts/verify-prebuild-smoke.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const pkgRoot = path.join(__dirname, '..')
+const abi = process.versions.modules
+const prebuildDir = path.join(
+  pkgRoot,
+  'prebuilds',
+  `${process.platform}-${process.arch}`
+)
+const prebuild = path.join(prebuildDir, `node.abi${abi}.node`)
+
+if (!fs.existsSync(prebuild)) {
+  console.error(`missing prebuild: ${prebuild}`)
+  if (fs.existsSync(prebuildDir)) {
+    console.error('available:', fs.readdirSync(prebuildDir).join(', '))
+  } else {
+    console.error(`missing directory: ${prebuildDir}`)
+  }
+  process.exit(1)
+}
+
+if (process.platform === 'win32') {
+  const dlls = fs.readdirSync(prebuildDir).filter((name) => name.toLowerCase().endsWith('.dll'))
+  if (dlls.length === 0) {
+    console.error(`win32 prebuild dir has no DLLs next to ${path.basename(prebuild)}`)
+    process.exit(1)
+  }
+}
+
+require(path.join(pkgRoot, 'lib', 'aerospike.js'))
+console.log('ok')


### PR DESCRIPTION
**Title:** `[CLIENT-4114] Fix stage tests: .ts testfiles and win32 prebuild DLLs`

**Description:**

## Summary
- Updates stage workflow `--testfile` references from `.js` to `.ts` after CLIENT-4712 stopped emitting compiled test JavaScript.
- Copies Windows runtime DLLs into `prebuilds/win32-x64/` during packaging and adds `verify-prebuild-smoke.js` for prebuild smoke checks in CI.

## Test plan
- [ ] Merge to `dev` and re-run dev workflow to publish a new tarball with win32 DLLs
- [ ] Re-run stage comprehensive tests
- [ ] Confirm set-xdr-filter, test-metrics, test-timeout-delay, and win32 prebuild smoke pass

[CLIENT-4114]: https://aerospike.atlassian.net/browse/CLIENT-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ