### PR TITLE
[CLIENT-4114] Fix stage test workflow gaps for Option B bundle

### DIFF
--- a/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
+++ b/.github/workflows/reupload-gh-artifacts-as-jfrog-release-bundle.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: Pack npm tarball
       run: |
+        node scripts/verify-prebuild-manifest.js
         npm pack
         ls -la aerospike-*.tgz
 

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -190,13 +190,16 @@ jobs:
 
     - name: Install test dependencies
       if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_arm64') }}
-      run: npm ci --ignore-scripts
+      run: |
+        npm ci --ignore-scripts
+        node scripts/verify-prebuild-smoke.js
 
     - name: Run tests
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_')}}
       run: |
         cat .mocharc.yml
-        OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm run test
+        node scripts/verify-prebuild-smoke.js
+        PREBUILDS_ONLY=1 OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm run test-ci
 
     - if: ${{ always() }}
       run: docker logs aerospike
@@ -249,34 +252,14 @@ jobs:
       if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
       uses: ./.github/actions/setup-docker-on-macos
 
-    - name: 'macOS x86: run Aerospike server in Docker container and connect via localhost'
-      if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
+    - name: Run CE Aerospike server for package manager smoke test
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
+      run: docker run --ulimit nofile=15000:15000 -d --name aerospike -e DEFAULT_TTL=2592000 -p 3000-3002:3000-3002 aerospike/aerospike-server:8.1.1.0
+
+    - uses: ./.github/actions/wait-for-as-server-to-start
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
       with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
-    - name: Remove aerospike docker image
-      if: ${{ inputs.platform-tag == 'linux_aarch64' }}
-      run: |
-        if docker ps -aq | grep -q .; then
-          docker rm -f $(docker ps -aq) || echo "Failed to remove one or more containers."
-        else
-          echo "No containers to remove."
-        fi
-
-    # TODO: combine this composite action and the above into one
-    - name: "Linux: run Aerospike server in Docker container and configure config.conf to connect to the server container's Docker IP address"
-      if: ${{ inputs.platform-tag == 'linux_x86_64' || inputs.platform-tag == 'linux_aarch64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
-      with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
+        container-name: aerospike
 
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
@@ -292,7 +275,7 @@ jobs:
       shell: "bash -ex {0}"
 
     - name: Run tests
-      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_arm64') }}
+      if: ${{ inputs.run_tests }}
       run: |
         npm ci --ignore-scripts;
         npm install -g pnpm@9.15.9 --ignore-scripts;
@@ -302,7 +285,7 @@ jobs:
         mv *.tgz pnpm
         cd pnpm
         echo '{}' > package.json
-        pnpm add ./*.tgz
+        pnpm add file:./aerospike-${{ inputs.version }}.tgz
         node basic_test.js
 
     # - name: Set final commit status
@@ -353,34 +336,14 @@ jobs:
       if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
       uses: ./.github/actions/setup-docker-on-macos
 
-    - name: 'macOS x86: run Aerospike server in Docker container and connect via localhost'
-      if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
+    - name: Run CE Aerospike server for package manager smoke test
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
+      run: docker run --ulimit nofile=15000:15000 -d --name aerospike -e DEFAULT_TTL=2592000 -p 3000-3002:3000-3002 aerospike/aerospike-server:8.1.1.0
+
+    - uses: ./.github/actions/wait-for-as-server-to-start
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
       with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
-    - name: Remove aerospike docker image
-      if: ${{ inputs.platform-tag == 'linux_aarch64' }}
-      run: |
-        if docker ps -aq | grep -q .; then
-          docker rm -f $(docker ps -aq) || echo "Failed to remove one or more containers."
-        else
-          echo "No containers to remove."
-        fi
-
-    # TODO: combine this composite action and the above into one
-    - name: "Linux: run Aerospike server in Docker container and configure config.conf to connect to the server container's Docker IP address"
-      if: ${{ inputs.platform-tag == 'linux_x86_64' || inputs.platform-tag == 'linux_aarch64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
-      with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
+        container-name: aerospike
 
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
@@ -396,6 +359,7 @@ jobs:
       shell: "bash -ex {0}"
 
     - name: Run tests
+      if: ${{ inputs.run_tests }}
       run: |
         npm ci --ignore-scripts;
         curl -fsSL https://bun.sh/install | bash;
@@ -406,7 +370,7 @@ jobs:
         mv *.tgz bun/
         cd bun;
         echo '{}' > package.json;
-        bun add *.tgz
+        bun add ./aerospike-${{ inputs.version }}.tgz
         node basic_test.js;
 
     #- name: Debug server
@@ -463,34 +427,14 @@ jobs:
       if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
       uses: ./.github/actions/setup-docker-on-macos
 
-    - name: 'macOS x86: run Aerospike server in Docker container and connect via localhost'
-      if: ${{ inputs.platform-tag == 'darwin_x86_64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
+    - name: Run CE Aerospike server for package manager smoke test
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
+      run: docker run --ulimit nofile=15000:15000 -d --name aerospike -e DEFAULT_TTL=2592000 -p 3000-3002:3000-3002 aerospike/aerospike-server:8.1.1.0
+
+    - uses: ./.github/actions/wait-for-as-server-to-start
+      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
       with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
-    - name: Remove aerospike docker image
-      if: ${{ inputs.platform-tag == 'linux_aarch64' }}
-      run: |
-        if docker ps -aq | grep -q .; then
-          docker rm -f $(docker ps -aq) || echo "Failed to remove one or more containers."
-        else
-          echo "No containers to remove."
-        fi
-
-    # TODO: combine this composite action and the above into one
-    - name: "Linux: run Aerospike server in Docker container and configure config.conf to connect to the server container's Docker IP address"
-      if: ${{ inputs.platform-tag == 'linux_x86_64' || inputs.platform-tag == 'linux_aarch64' }}
-      uses: ./.github/actions/run-ee-server-for-ext-container
-      with:
-        use-server-rc: false
-        server-tag: ${{ inputs.server-tag }}
-        docker-hub-username: ${{ secrets.soup_hat }}
-        docker-hub-password: ${{ secrets.cell_girl }}
-
+        container-name: aerospike
 
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
@@ -506,7 +450,7 @@ jobs:
       shell: "bash -ex {0}"
 
     - name: Run tests
-      if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_arm64' )}}
+      if: ${{ inputs.run_tests }}
       run: |
         npm ci --ignore-scripts
         npm install -g yarn
@@ -629,12 +573,16 @@ jobs:
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
         npm ci --ignore-scripts
+        node scripts/verify-prebuild-smoke.js
         # tree ./node_modules
         # tree ../node_modules
 
     - name: Install Aerolab
       if: ${{ matrix.description == 'set-xdr-filter' }}
       run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y unzip
         curl -L -o aerolab.zip https://github.com/aerospike/aerolab/releases/download/7.8.0/aerolab-linux-amd64-7.8.0.zip
         unzip aerolab.zip
         chmod +x aerolab
@@ -643,7 +591,8 @@ jobs:
         aerolab config backend -t docker
         aerolab xdr create-clusters -n dc1 -c 3 -N dc2 -C 3 -M test
         aerolab cluster list
-        npm run test --testfile=set_xdr_filter.ts -- --testXDR true --h 172.17.0.2 --port 3100;
+        sleep 30
+        PREBUILDS_ONLY=1 npm run test-ci --testfile=set_xdr_filter.ts -- --testXDR true --h 172.17.0.2 --port 3100;
         # Cleanup steps
         echo y | aerolab cluster destroy --name dc1
         echo y | aerolab cluster destroy --name dc2
@@ -653,7 +602,7 @@ jobs:
       run: |
         sudo apt-get update;
         sudo apt-get install -y valgrind;
-        MOCHA_OPTIONS="--timeout 40000" OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm run valgrind;
+        PREBUILDS_ONLY=1 MOCHA_OPTIONS="--timeout 40000" OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm run valgrind;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1
@@ -770,6 +719,15 @@ jobs:
       with:
         node-version: ${{ matrix.nodejs-tag[1] }}
 
+    - name: Run CE Aerospike server for metrics tests
+      if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
+      run: docker run --ulimit nofile=15000:15000 -d --name aerospike -e DEFAULT_TTL=2592000 -p 3000-3002:3000-3002 aerospike/aerospike-server:8.1.1.0
+
+    - uses: ./.github/actions/wait-for-as-server-to-start
+      if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
+      with:
+        container-name: aerospike
+
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
@@ -796,9 +754,10 @@ jobs:
     - name: Run tests
       if: ${{ inputs.run_tests && (startsWith(inputs.platform-tag, 'linux_') || inputs.platform-tag == 'darwin_x86_64') }}
       run: |
+        node scripts/verify-prebuild-smoke.js
         docker pull aerospike/aerospike-server:latest;
-        npm run test --testfile=metrics_node_close.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
-        npm run test --testfile=metrics_cluster_name.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
+        PREBUILDS_ONLY=1 npm run test-ci --testfile=metrics_node_close.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
+        PREBUILDS_ONLY=1 npm run test-ci --testfile=metrics_cluster_name.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1
@@ -875,7 +834,9 @@ jobs:
 
     - name: Run tests
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
-      run: npm run test -- --h localhost --port 3000;
+      run: |
+        node scripts/verify-prebuild-smoke.js
+        PREBUILDS_ONLY=1 npm run test-ci -- --h localhost --port 3000;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1
@@ -960,7 +921,8 @@ jobs:
     - name: Run tests
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
-        npm run test --testfile=timeout_delay.ts -- --testTimeoutDelay true --h localhost --port 3000;
+        node scripts/verify-prebuild-smoke.js
+        PREBUILDS_ONLY=1 npm run test-ci --testfile=timeout_delay.ts -- --testTimeoutDelay true --h localhost --port 3000;
         sudo tc qdisc del dev lo root netem
 
     # - name: Set final commit status

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "node scripts/build-native.js",
     "test": "mocha test/${npm_config_testfile:-}",
+    "test-ci": "mocha test/${npm_config_testfile:-}",
     "test-dry-run": "mocha --dry-run",
     "test-noserver": "GLOBAL_CLIENT=false mocha -g '#noserver'",
     "lint": "standard --ignore scripts",

--- a/scripts/basic_test.js
+++ b/scripts/basic_test.js
@@ -1,8 +1,19 @@
 const Aerospike = require('aerospike')
 
-// INSERT HOSTNAME AND PORT NUMBER OF AEROSPIKE SERVER NODE HERE!
+const host = process.env.AEROSPIKE_HOST || '127.0.0.1'
+const port = Number(process.env.AEROSPIKE_PORT || 3000)
+const user = process.env.AEROSPIKE_USER
+const password = process.env.AEROSPIKE_PASSWORD
+
 const config = {
-  hosts: '127.0.0.1 :3000'
+  hosts: `${host}:${port}`
+}
+
+if (user) {
+  config.user = user
+}
+if (password) {
+  config.password = password
 }
 
 const key = new Aerospike.Key('test', 'demo', 'demo')
@@ -21,7 +32,6 @@ Aerospike.connect(config)
     const meta = { ttl: 10000 }
     const policy = new Aerospike.WritePolicy({
       exists: Aerospike.policy.exists.CREATE_OR_REPLACE,
-      // Timeouts disabled, latency dependent on server location. Configure as needed.
       socketTimeout: 0,
       totalTimeout: 0
     })
@@ -38,18 +48,12 @@ Aerospike.connect(config)
         return client.operate(key, ops)
       })
       .then(result => {
-        console.log(result.bins) // => { i: 124, l: 4, m: null }
+        console.log(result.bins)
 
         return client.get(key)
       })
       .then(record => {
-        console.log(record.bins) // => { i: 124,
-        //      s: 'hello',
-        //      b: <Buffer 77 6f 72 6c 64>,
-        //      d: 3.1415,
-        //      g: '{"type":"Point","coordinates":[103.913,1.308]}',
-        //      l: [ 1, 'a', { x: 'y' }, 'z' ],
-        //      m: { foo: 4 } }
+        console.log(record.bins)
       })
       .then(() => client.close())
   })
@@ -58,4 +62,5 @@ Aerospike.connect(config)
     if (error.client) {
       error.client.close()
     }
+    process.exit(1)
   })

--- a/scripts/verify-prebuild-manifest.js
+++ b/scripts/verify-prebuild-manifest.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const root = path.join(__dirname, '..')
+const abis = ['115', '127', '137', '141']
+const platforms = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'win32-x64'
+]
+
+let missing = false
+
+for (const platform of platforms) {
+  const prebuildDir = path.join(root, 'prebuilds', platform)
+  for (const abi of abis) {
+    const prebuild = path.join(prebuildDir, `node.abi${abi}.node`)
+    if (!fs.existsSync(prebuild)) {
+      console.error(`missing prebuild: ${prebuild}`)
+      missing = true
+    }
+  }
+
+  if (platform === 'win32-x64') {
+    const dlls = fs.existsSync(prebuildDir)
+      ? fs.readdirSync(prebuildDir).filter((name) => name.toLowerCase().endsWith('.dll'))
+      : []
+    if (dlls.length === 0) {
+      console.error(`missing win32 DLLs in ${prebuildDir}`)
+      missing = true
+    }
+  }
+}
+
+if (missing) {
+  process.exit(1)
+}
+
+console.log('prebuild manifest ok')


### PR DESCRIPTION
- Add test-ci script without posttest lint for stage mocha jobs
- Start CE server for metrics/pnpm/yarn/bun; fix pnpm install path
- Harden basic_test.js (host config, exit code, optional auth env)
- Verify prebuild overlay before server tests; set PREBUILDS_ONLY
- Fail npm pack if any platform/ABI prebuild is missing (incl. win32 DLLs)
- Improve set-xdr-filter aerolab setup (unzip, cluster settle wait)