### PR TITLE
[CLIENT-4114] Fix run_npm to keep project directory on Windows

### DIFF
--- a/scripts/ci/build-node-prebuild.sh
+++ b/scripts/ci/build-node-prebuild.sh
@@ -33,7 +33,8 @@ assert_active_node() {
 
 run_npm() {
   if [[ "${RUNNER_OS:-}" == "Windows" && -n "${NODE_DIR:-}" ]]; then
-    (cd "${NODE_DIR}" && ./npm.cmd "$@")
+    # Use npm.cmd from the selected Node install; do not cd away from the repo.
+    "${NODE_DIR}/npm.cmd" "$@"
   else
     npm "$@"
   fi


### PR DESCRIPTION
run_npm must invoke npm.cmd by full path without cd'ing into NODE_DIR, otherwise npm ci/build runs outside the repo and all win32 jobs fail.