### PR TITLE
[CLIENT-4114] Set NODE_DIR when using runner default Node on Windows

### DIFF
--- a/scripts/ci/build-node-prebuild.sh
+++ b/scripts/ci/build-node-prebuild.sh
@@ -40,6 +40,18 @@ run_npm() {
   fi
 }
 
+export_windows_node_dir() {
+  local node_bin node_dir
+  node_bin="$(command -v node)"
+  node_dir="$(dirname "${node_bin}")"
+  if [[ ! -x "${node_dir}/node.exe" || ! -f "${node_dir}/npm.cmd" ]]; then
+    echo "ERROR: node/npm not paired under ${node_dir}" >&2
+    exit 1
+  fi
+  export NODE_DIR="${node_dir}"
+  export PATH="${NODE_DIR}:${PATH}"
+}
+
 setup_node_windows() {
   local node_dir="" candidate major toolcache
 
@@ -62,7 +74,8 @@ setup_node_windows() {
 
   if command -v node >/dev/null 2>&1; then
     major="$(node -p "process.version.split('.')[0].slice(1)")"
-    if [[ "${major}" == "${NODE_VERSION}" ]] && command -v npm >/dev/null 2>&1; then
+    if [[ "${major}" == "${NODE_VERSION}" ]]; then
+      export_windows_node_dir
       assert_active_node
       return
     fi


### PR DESCRIPTION
Node 24 is often missing from the Windows toolcache but present as the runner default node. Pin NODE_DIR from that node.exe so run_npm uses the matching npm.cmd and produces node.abi137.node.