### PR TITLE
[CLIENT-4114] Use actions/setup-node for dev prebuild matrix jobs

### DIFF
--- a/.github/workflows/dev-build-node-cpp-bindings.yml
+++ b/.github/workflows/dev-build-node-cpp-bindings.yml
@@ -146,7 +146,7 @@ jobs:
       matrix:
         nodejs-tag: ${{ fromJSON(needs.get-runner-os.outputs.nodejs-matrix) }}
       fail-fast: false
-    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@1004088a1b5122b9b71a39b40f619f6b50e78d16
+    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@a341c9f258175f2dded37ae4c3037962fc31fd1a
     with:
       runs-on: ${{ needs.get-runner-os.outputs.runner-os }}
       gh-source-ref: ${{ inputs.version }}
@@ -158,7 +158,8 @@ jobs:
       jf-url: https://aerospike.jfrog.io
       gh-artifact-name: ${{ matrix.nodejs-tag[0] }}-${{ inputs.platform-tag }}.build
       gh-artifact-directory: prebuilds
-      gh-workflows-ref: 1004088a1b5122b9b71a39b40f619f6b50e78d16
+      gh-workflows-ref: a341c9f258175f2dded37ae4c3037962fc31fd1a
+      setup-node-version: ${{ matrix.nodejs-tag[1] }}
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
       publish-build-info: ${{ inputs.publish-build-info }}

--- a/scripts/ci/build-node-prebuild.sh
+++ b/scripts/ci/build-node-prebuild.sh
@@ -31,102 +31,6 @@ assert_active_node() {
   fi
 }
 
-run_npm() {
-  if [[ "${RUNNER_OS:-}" == "Windows" && -n "${NODE_DIR:-}" ]]; then
-    # Use npm.cmd from the selected Node install; do not cd away from the repo.
-    "${NODE_DIR}/npm.cmd" "$@"
-  else
-    npm "$@"
-  fi
-}
-
-export_windows_node_dir() {
-  local node_bin node_dir
-  node_bin="$(command -v node)"
-  node_dir="$(dirname "${node_bin}")"
-  if [[ ! -x "${node_dir}/node.exe" || ! -f "${node_dir}/npm.cmd" ]]; then
-    echo "ERROR: node/npm not paired under ${node_dir}" >&2
-    exit 1
-  fi
-  export NODE_DIR="${node_dir}"
-  export PATH="${NODE_DIR}:${PATH}"
-}
-
-setup_node_windows() {
-  local node_dir="" candidate major toolcache
-
-  toolcache="${RUNNER_TOOL_CACHE:-/c/hostedtoolcache/windows}"
-  shopt -s nullglob
-  for candidate in "${toolcache}/Node/${NODE_VERSION}."*/x64; do
-    if [[ -x "${candidate}/node.exe" && -f "${candidate}/npm.cmd" ]]; then
-      node_dir="${candidate}"
-      break
-    fi
-  done
-  shopt -u nullglob
-
-  if [[ -n "${node_dir}" ]]; then
-    export NODE_DIR="${node_dir}"
-    export PATH="${node_dir}:${PATH}"
-    assert_active_node
-    return
-  fi
-
-  if command -v node >/dev/null 2>&1; then
-    major="$(node -p "process.version.split('.')[0].slice(1)")"
-    if [[ "${major}" == "${NODE_VERSION}" ]]; then
-      export_windows_node_dir
-      assert_active_node
-      return
-    fi
-  fi
-
-  # Fallback: download latest patch for the requested major from nodejs.org.
-  node_dir="$(pwsh -NoProfile -Command "
-    \$major = '${NODE_VERSION}'
-    \$dest = Join-Path \$env:RUNNER_TEMP \"node-\$major\"
-    if (Test-Path (Join-Path \$dest 'node.exe')) {
-      \$unix = '/' + \$dest.Substring(0,1).ToLower() + \$dest.Substring(2).Replace('\\', '/')
-      Write-Output \$unix
-      exit 0
-    }
-    \$index = Invoke-RestMethod 'https://nodejs.org/dist/index.json'
-    \$match = \$index | Where-Object { \$_.version -match \"^v\$major\\.\" } | Select-Object -First 1
-    if (-not \$match) { exit 1 }
-    \$ver = \$match.version.TrimStart('v')
-    \$zip = Join-Path \$env:RUNNER_TEMP \"node-v\$ver-win-x64.zip\"
-    Invoke-WebRequest -Uri \"https://nodejs.org/dist/v\$ver/node-v\$ver-win-x64.zip\" -OutFile \$zip
-    Expand-Archive -Path \$zip -DestinationPath \$dest -Force
-    Move-Item -Path (Join-Path \$dest \"node-v\$ver-win-x64\\*\") -Destination \$dest -Force
-    \$unix = '/' + \$dest.Substring(0,1).ToLower() + \$dest.Substring(2).Replace('\\', '/')
-    Write-Output \$unix
-  ")" || {
-    echo "ERROR: could not provision Node.js ${NODE_VERSION} on Windows" >&2
-    exit 1
-  }
-
-  export NODE_DIR="${node_dir}"
-  export PATH="${node_dir}:${PATH}"
-  assert_active_node
-}
-
-setup_node() {
-  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-    setup_node_windows
-    return
-  fi
-
-  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-  if [[ ! -s "$NVM_DIR/nvm.sh" ]]; then
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-  fi
-  # shellcheck disable=SC1091
-  source "$NVM_DIR/nvm.sh"
-  nvm install "${NODE_VERSION}"
-  nvm use "${NODE_VERSION}"
-  assert_active_node
-}
-
 assert_prebuild_output() {
   node -e "
     const fs = require('fs');
@@ -172,9 +76,10 @@ cleanup_windows_artifacts() {
   '
 }
 
-setup_node
+# Node is provisioned by actions/setup-node in reusable_execute-build (setup-node-version input).
+assert_active_node
 node --version
-run_npm --version
+npm --version
 
 case "${PLATFORM_TAG}" in
   win32_x64)
@@ -198,8 +103,8 @@ if [[ "${PLATFORM_TAG}" != "win32_x64" ]]; then
   ./scripts/build-c-client.sh
 fi
 
-run_npm ci --ignore-scripts
-run_npm run build
+npm ci --ignore-scripts
+npm run build
 assert_prebuild_output
 ls -R prebuilds
 


### PR DESCRIPTION
Provision Node via reusable_execute-build setup-node-version so Windows v137 builds node.abi137.node with matching node/npm. Drop custom Windows node toolcache/download logic from build-node-prebuild.sh.