### PR TITLE
Fix stage yarn/pnpm install and single-file mocha runs.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -285,7 +285,7 @@ jobs:
         mv *.tgz pnpm
         cd pnpm
         echo '{}' > package.json
-        pnpm add file:./aerospike-${{ inputs.version }}.tgz
+        pnpm add file:./aerospike-${{ inputs.version }}.tgz --ignore-scripts
         node basic_test.js
 
     # - name: Set final commit status
@@ -460,7 +460,7 @@ jobs:
         mv *.tgz yarn/
         cd yarn
         echo '{}' > package.json
-        yarn add file:./aerospike-${{ inputs.version }}.tgz
+        yarn add file:./aerospike-${{ inputs.version }}.tgz --ignore-scripts
         node basic_test.js
 
     #- name: Debug server
@@ -592,7 +592,7 @@ jobs:
         aerolab xdr create-clusters -n dc1 -c 3 -N dc2 -C 3 -M test
         aerolab cluster list
         sleep 30
-        PREBUILDS_ONLY=1 npm run test-ci --testfile=set_xdr_filter.ts -- --testXDR true --h 172.17.0.2 --port 3100;
+        PREBUILDS_ONLY=1 npm run test-ci-single -- test/set_xdr_filter.ts --testXDR true --h 172.17.0.2 --port 3100;
         # Cleanup steps
         echo y | aerolab cluster destroy --name dc1
         echo y | aerolab cluster destroy --name dc2
@@ -756,8 +756,8 @@ jobs:
       run: |
         node scripts/verify-prebuild-smoke.js
         docker pull aerospike/aerospike-server:latest;
-        PREBUILDS_ONLY=1 npm run test-ci --testfile=metrics_node_close.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
-        PREBUILDS_ONLY=1 npm run test-ci --testfile=metrics_cluster_name.ts -- --testMetrics true --h localhost --port 3000  --t 50000;
+        PREBUILDS_ONLY=1 npm run test-ci-single -- test/metrics_node_close.ts --testMetrics true --h localhost --port 3000 --t 50000;
+        PREBUILDS_ONLY=1 npm run test-ci-single -- test/metrics_cluster_name.ts --testMetrics true --h localhost --port 3000 --t 50000;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1
@@ -922,7 +922,7 @@ jobs:
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
         node scripts/verify-prebuild-smoke.js
-        PREBUILDS_ONLY=1 npm run test-ci --testfile=timeout_delay.ts -- --testTimeoutDelay true --h localhost --port 3000;
+        PREBUILDS_ONLY=1 npm run test-ci-single -- test/timeout_delay.ts --testTimeoutDelay true --h localhost --port 3000;
         sudo tc qdisc del dev lo root netem
 
     # - name: Set final commit status

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "node scripts/build-native.js",
     "test": "mocha test/${npm_config_testfile:-}",
     "test-ci": "mocha test/${npm_config_testfile:-}",
+    "test-ci-single": "mocha --no-config --require choma --require mocha-clean --node-option import=tsx",
     "test-dry-run": "mocha --dry-run",
     "test-noserver": "GLOBAL_CLIENT=false mocha -g '#noserver'",
     "lint": "standard --ignore scripts",


### PR DESCRIPTION
Use --ignore-scripts when installing the tarball via yarn/pnpm so CI does not rebuild from binding.gyp, and add test-ci-single to run one test file without .mocharc.yml loading the full suite.