### PR TITLE
Convert remaining legacy test/*.js files to TypeScript.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -199,7 +199,7 @@ jobs:
       run: |
         cat .mocharc.yml
         node scripts/verify-prebuild-smoke.js
-        PREBUILDS_ONLY=1 OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm run test-ci
+        PREBUILDS_ONLY=1 OPTIONS="-t 40000 -h 127.0.0.1 --port 3000 -U superuser -P superuser" npm test --ignore-scripts
 
     - if: ${{ always() }}
       run: docker logs aerospike
@@ -836,7 +836,7 @@ jobs:
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
         node scripts/verify-prebuild-smoke.js
-        PREBUILDS_ONLY=1 OPTIONS="--h localhost --port 3000" npm run test-ci;
+        PREBUILDS_ONLY=1 OPTIONS="--h localhost --port 3000" npm test --ignore-scripts;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -836,7 +836,7 @@ jobs:
       if: ${{ inputs.run_tests && startsWith(inputs.platform-tag, 'linux_') }}
       run: |
         node scripts/verify-prebuild-smoke.js
-        PREBUILDS_ONLY=1 npm run test-ci -- --h localhost --port 3000;
+        PREBUILDS_ONLY=1 OPTIONS="--h localhost --port 3000" npm run test-ci;
 
     # - name: Set final commit status
     #   uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # 2.0.1

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -2,8 +2,7 @@ require:
   - choma
   - mocha-clean
 spec:
-  - "test/*.js" # the positional arguments!
-  - "test/*.ts" # the positional arguments!
+  - "test/*.ts"
 node-option:
   - "import=tsx"
 parallel: false

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "scripts": {
     "build": "node scripts/build-native.js",
     "test": "mocha test/${npm_config_testfile:-}",
-    "test-ci": "mocha test/${npm_config_testfile:-}",
     "test-ci-single": "mocha --no-config --require choma --require mocha-clean --node-option import=tsx",
     "test-dry-run": "mocha --dry-run",
     "test-noserver": "GLOBAL_CLIENT=false mocha -g '#noserver'",

--- a/test/README.md
+++ b/test/README.md
@@ -15,6 +15,11 @@ To run the test cases:
 
     $ npm test
 
+`npm test` runs the full mocha suite and then `posttest` lint. CI uses
+`npm test --ignore-scripts` for the same mocha run without lint. For a single
+test file without loading the full `.mocharc.yml` suite, use
+`npm run test-ci-single -- test/<file>.ts`.
+
 The tests are written and run using [`mocha`](http://visionmedia.github.io/mocha).
 You can choose to use `mocha` directly, but you must first install `mocha`:
 

--- a/test/command.ts
+++ b/test/command.ts
@@ -16,10 +16,12 @@
 
 'use strict'
 
-/* eslint-env mocha */
-/* global expect */
+/* global context */
 
-// require('./test_helper.mts')
+import { createRequire } from 'module'
+import { expect } from 'chai'
+
+const require = createRequire(import.meta.url)
 const Command = require('../lib/commands/command')
 
 describe('Command', function () {

--- a/test/info.ts
+++ b/test/info.ts
@@ -19,12 +19,12 @@
 /* global expect, describe, it, context, before */
 /* eslint-disable no-unused-expressions */
 
+import type { AerospikeError, Host } from '../lib/aerospike.js'
 import * as Aerospike from '../lib/aerospike.js'
 import * as info from '../lib/info.js'
-import * as helper from './test_helper.js'
+import * as helper from './test_helper.ts'
 import * as utils from '../lib/utils.js'
-
-const AerospikeError = Aerospike.AerospikeError
+import { expect } from 'chai'
 
 context('Info commands', function () {
   const client = helper.client
@@ -33,8 +33,8 @@ context('Info commands', function () {
     helper.skipIf(this, () => !!helper.config.password && helper.cluster.isVersionInRange('>= 5.5'),
       'client#info does not support authenticated connections on server 5.5 or later')
 
-    let node = null
-    let host = null
+    let node: any = null
+    let host: Host | null = null
 
     before(() => {
       node = helper.cluster.randomNode()
@@ -42,7 +42,7 @@ context('Info commands', function () {
     })
 
     it('sends status query to a specific cluster node', function (done) {
-      client.info('status', host, (error, response) => {
+      client.info('status', host, (error: AerospikeError | null, response: string) => {
         if (error) throw error
         expect(response).to.equal('status\tok\n')
         done()
@@ -50,7 +50,7 @@ context('Info commands', function () {
     })
 
     it('accepts a string with the host address', function (done) {
-      client.info('status', node.address, (error, response) => {
+      client.info('status', node.address, (error: AerospikeError | null, response: string) => {
         if (error) throw error
         expect(response).to.equal('status\tok\n')
         done()
@@ -58,7 +58,7 @@ context('Info commands', function () {
     })
 
     it('fetches all info if no request is passed', function (done) {
-      client.info(null, host, (error, response) => {
+      client.info(null, host, (error: AerospikeError | null, response: string) => {
         if (error) throw error
         expect(response).to.contain('\nversion\t')
         expect(response).to.contain('\nedition\t')
@@ -67,15 +67,15 @@ context('Info commands', function () {
     })
 
     it('should return a client error if the client is not connected', function (done) {
-      Aerospike.client(helper.config).info('status', host, error => {
-        expect(error).to.be.instanceof(AerospikeError).with.property('code', Aerospike.status.ERR_CLIENT)
+      Aerospike.client(helper.config).info('status', host, (error: AerospikeError | null) => {
+        expect(error).to.be.instanceof(Aerospike.AerospikeError).with.property('code', Aerospike.status.ERR_CLIENT)
         done()
       })
     })
   })
 
   describe('Client#infoNode()', function () {
-    let node = null
+    let node: any = null
 
     before(() => {
       node = helper.cluster.randomNode()
@@ -95,8 +95,8 @@ context('Info commands', function () {
     })
 
     it('should return a client error if the client is not connected', function (done) {
-      Aerospike.client(helper.config).infoNode('status', node, error => {
-        expect(error).to.be.instanceof(AerospikeError).with.property('code', Aerospike.status.ERR_CLIENT)
+      Aerospike.client(helper.config).infoNode('status', node, (error: AerospikeError | null) => {
+        expect(error).to.be.instanceof(Aerospike.AerospikeError).with.property('code', Aerospike.status.ERR_CLIENT)
         done()
       })
     })
@@ -104,7 +104,7 @@ context('Info commands', function () {
 
   describe('Client#infoAny()', function () {
     it('executes the info command on a single cluster node', function (done) {
-      client.infoAny('status', function (err, result) {
+      client.infoAny('status', function (err: AerospikeError | null, result: string) {
         expect(err).to.not.be.ok
         expect(result).to.equal('status\tok\n')
         done()
@@ -121,7 +121,7 @@ context('Info commands', function () {
 
   describe('client.infoAll()', function () {
     it('executes the info command on all cluster nodes an returns a list of results', function (done) {
-      client.infoAll('status', function (err, results) {
+      client.infoAll('status', function (err: AerospikeError | null, results: Array<{ host: string, info: string }>) {
         expect(err).to.not.be.ok
         expect(Array.isArray(results)).to.be.true
         results.forEach(function (result) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -16,11 +16,8 @@
 
 'use strict'
 
-/* global expect, describe, it */
-
-// require('./test_helper.ts')
+import { expect } from 'chai'
 import * as utils from '../lib/utils.js'
-// const utils = require('../lib/utils')
 
 describe('utils.parseHostString() #noserver', function () {
   it('parses a domain name', function () {


### PR DESCRIPTION
Fix test-ce by passing host/port via OPTIONS instead of mocha CLI flags that conflict with --help.