### PR TITLE
Fix stage release bundle promote to use dev git tag version.

### DIFF
--- a/.github/workflows/stage-workflow.yml
+++ b/.github/workflows/stage-workflow.yml
@@ -50,8 +50,8 @@ jobs:
     uses: ./.github/workflows/promote-and-optionally-tag-release-bundle.yml
     with:
       release-bundle-name: ${{ vars.RELEASE_BUNDLE_NAME }}
-      release-bundle-version: ${{ needs.stage-get-jfrog-version.outputs.dev_version }}
-      release-bundle-tag: ${{ needs.stage-get-jfrog-version.outputs.dev_version }}
+      release-bundle-version: ${{ needs.stage-get-jfrog-version.outputs.tag_version }}
+      release-bundle-tag: ${{ needs.stage-get-jfrog-version.outputs.tag_version }}
       new-environment: TEST
       jfrog-project: database
     permissions:


### PR DESCRIPTION
Stage promote was passing package.json version (7.0.0) to JFrog, but dev workflow creates bundles under dev git tags (7.0.0-dev.N).