### PR TITLE
Document string ops missing-bin behavior, writeFlags, and error-detail guidance

### DIFF
--- a/lib/aerospike.d.ts
+++ b/lib/aerospike.d.ts
@@ -12890,17 +12890,57 @@ export namespace bitwise {
 
 /**
  * String bin operations for {@link Client#operate} (server 8.1.3+).
+ *
+ * @remarks Requires Aerospike Server 8.1.3 or later. See {@link exp.string} for
+ * filter/write expressions.
+ *
+ * **Missing bin:** additive modifies ({@link strings.append}, {@link strings.prepend},
+ * {@link strings.concat}, {@link strings.concatList}, {@link strings.insert},
+ * {@link strings.overwrite}, {@link strings.padStart}, {@link strings.padEnd},
+ * {@link strings.repeat}) create the bin; in-place modifies ({@link strings.snip},
+ * {@link strings.replace}, {@link strings.replaceAll}, {@link strings.upper},
+ * {@link strings.lower}, {@link strings.caseFold}, {@link strings.normalizeNfc},
+ * {@link strings.trimStart}, {@link strings.trimEnd}, {@link strings.trim},
+ * {@link strings.regexReplace}, {@link strings.toString}) no-op. Read ops require
+ * an applicable bin/value.
+ *
+ * **Errors:** {@link strings.writeFlags.NO_FAIL} suppresses in-operation failure
+ * with the bin unchanged; it does not suppress wrong-type errors. Use
+ * {@link OperatePolicy#errorDetailVerbosity} and {@link AerospikeError#subcode}
+ * for server 8.1.3+ detail. For raw blob append/prepend use
+ * {@link operations.append} / {@link operations.prepend}; for Unicode string bins
+ * use {@link strings.append} / {@link strings.prepend}.
  */
 export namespace strings {
+    /**
+     * String operation policy passed to {@link StringOperation.withPolicy}.
+     */
     export interface StringPolicy {
+        /**
+         * {@link writeFlags} bit flags for supported modify operations.
+         * @default {@link writeFlags.DEFAULT}
+         */
         writeFlags?: number;
     }
 
+    /**
+     * String operation policy write bit flags. Use bitwise OR to combine flags.
+     */
     export enum writeFlags {
+        /**
+         * Default. Does not suppress an in-operation execution failure.
+         */
         DEFAULT = 0,
+        /**
+         * Suppress an operation failure with the bin unchanged. Does not suppress
+         * wrong-type or invalid-bin-type errors.
+         */
         NO_FAIL = 4
     }
 
+    /**
+     * Regex flags for {@link regexCompareFlags} and {@link regexReplace}.
+     */
     export enum regexFlags {
         NONE = 0,
         CASE_INSENSITIVE = 1,
@@ -12910,6 +12950,9 @@ export namespace strings {
         GLOBAL = 16
     }
 
+    /**
+     * Numeric type filter for {@link isNumericType}.
+     */
     export enum numericType {
         ANY = 0,
         INT = 1,
@@ -12921,58 +12964,118 @@ export namespace strings {
 
     export class StringOperation extends operations.Operation {
         withContext(contextOrFunction: cdt.Context | ((ctx: cdt.Context) => void)): StringOperation;
+        /**
+         * Attach `{ writeFlags }` for supported modify ops. Not used by
+         * {@link regexReplace} (regex flags are a separate argument).
+         */
         withPolicy(policy: StringPolicy): StringOperation;
     }
 
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function strlen(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function substr(bin: string, start: number): StringOperation;
-    /** Half-open codepoint range `[start, end)` (exclusive `end`). */
+    /**
+     * Half-open codepoint range `[start, end)` (exclusive `end`). Read-only.
+     * @remarks Requires applicable string bin; errors if missing or wrong type.
+     */
     export function substrRange(bin: string, start: number, end: number): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function charAt(bin: string, index: number): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function find(bin: string, needle: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function findOccurrence(bin: string, needle: string, occurrence: number): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function contains(bin: string, needle: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function startsWith(bin: string, prefix: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function endsWith(bin: string, suffix: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function toInteger(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function toDouble(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function byteLength(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function isNumeric(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function isNumericType(bin: string, numericType: numericType): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function isUpper(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function isLower(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function toBlob(bin: string): StringOperation;
-    /** Splits by Unicode codepoint (one list element per codepoint). Use {@link splitSeparator} for a delimiter. */
+    /**
+     * Splits by Unicode codepoint (one list element per codepoint). Use {@link splitSeparator} for a delimiter.
+     * @remarks Requires applicable string bin; errors if missing or wrong type.
+     */
     export function split(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function splitSeparator(bin: string, separator: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function b64Decode(bin: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function regexCompare(bin: string, pattern: string): StringOperation;
+    /** @remarks Requires applicable string bin; errors if missing or wrong type. */
     export function regexCompareFlags(bin: string, pattern: string, flags: number): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function insert(bin: string, index: number, value: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function overwrite(bin: string, index: number, value: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function concat(bin: string, value: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function concatList(bin: string, values: any[]): StringOperation;
-    /** Unicode-aware append (`AS_STRING_OP_APPEND`). */
+    /**
+     * Unicode-aware append (`AS_STRING_OP_APPEND`).
+     * @remarks If the bin is missing, creates a new bin.
+     */
     export function append(bin: string, value: string): StringOperation;
-    /** Unicode-aware prepend (`AS_STRING_OP_PREPEND`). */
+    /**
+     * Unicode-aware prepend (`AS_STRING_OP_PREPEND`).
+     * @remarks If the bin is missing, creates a new bin.
+     */
     export function prepend(bin: string, value: string): StringOperation;
-    /** Removes half-open codepoint range `[start, end)`. */
+    /**
+     * Removes half-open codepoint range `[start, end)`.
+     * @remarks If the bin is missing, no-op (record unchanged).
+     */
     export function snip(bin: string, start: number, end: number): StringOperation;
     /** @deprecated Use {@link snip} (same wire). */
     export function snipRange(bin: string, start: number, end: number): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function replace(bin: string, needle: string, replacement: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function replaceAll(bin: string, needle: string, replacement: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function upper(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function lower(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function caseFold(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function normalizeNfc(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function trimStart(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function trimEnd(bin: string): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function trim(bin: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function padStart(bin: string, targetLength: number, padString: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function padEnd(bin: string, targetLength: number, padString: string): StringOperation;
+    /** @remarks If the bin is missing, creates a new bin. */
     export function repeat(bin: string, count: number): StringOperation;
+    /**
+     * Regex replace; uses {@link regexFlags}, not {@link writeFlags}.
+     * @remarks If the bin is missing, no-op (record unchanged).
+     */
     export function regexReplace(bin: string, pattern: string, replacement: string, flags: number): StringOperation;
+    /** @remarks If the bin is missing, no-op (record unchanged). */
     export function toString(bin: string): StringOperation;
 }
 /**

--- a/lib/exp_string.js
+++ b/lib/exp_string.js
@@ -114,9 +114,29 @@ const _policyFlags = (policy) =>
  * @summary String read/modify expressions (Aerospike Server 8.1.3+)
  *
  * @description Mirrors the C client's `as_exp_string_*` macros (`CALL` +
- * `CALL_STRING`). For `operate()` string bin operations, see
+ * `CALL_STRING`). For `operate()` string bin operation helpers, see
  * {@link module:aerospike/strings|aerospike/strings}.
  *
+ * #### Write expressions and missing bins
+ *
+ * Modify expressions that map to the same server string ops follow the same
+ * rules as {@link module:aerospike/strings|aerospike/strings}: additive writes
+ * (for example append/prepend/insert-style paths) may create a bin when it is
+ * missing; in-place transforms (upper, trim, replace, and similar) no-op when
+ * the target string is absent. Policy flags on write expressions use
+ * `{ flags }` with the same semantics as
+ * {@link module:aerospike/strings.writeFlags|strings.writeFlags} where the
+ * server accepts them. Wrong-type errors are not suppressed by
+ * {@link module:aerospike/strings.writeFlags.NO_FAIL|NO_FAIL}.
+ *
+ * #### Errors
+ *
+ * Expression write failures surfaced through {@link Client#operate} respect
+ * {@link BasePolicy#errorDetailVerbosity} on {@link OperatePolicy}; inspect
+ * {@link AerospikeError#subcode} and the message per
+ * {@link module:aerospike/subcode|subcode}.
+ *
+ * Nested string targets use a flat ctx envelope, not CDT nested-array layout.
  * Multi-op `operate()` on the same bin may return an ordered list of per-op
  * results when the server sets RESPOND_ALL_OPS (same family as MAP/BIT/HLL).
  */

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -12,14 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// CTX vs CDT: nested string targets use a flat string-op ctx envelope; see
-// server docs / C `as_string_pack_header` with 0xFF sentinel — not CDT nested
-// array layout.
-//
-// Multi-op `operate()` on the same bin may return an ordered list of per-op
-// results when the server sets RESPOND_ALL_OPS (STRING_READ / STRING_MODIFY /
-// TO_STRING participate like MAP/BIT/HLL in the C client).
 // *****************************************************************************
 
 'use strict'
@@ -36,6 +28,16 @@ const Context = require('./cdt_context')
  */
 class StringOperation extends Operation {}
 
+/**
+ * @summary Target a nested string via context instead of the top-level bin value.
+ * @description Nested string targets use a flat string-op ctx envelope (C
+ * `as_string_pack_header` with `0xFF` sentinel), not CDT nested-array layout.
+ *
+ * @param {module:aerospike/cdt~Context|function} contextOrFunction - A
+ * {@link module:aerospike/cdt~Context} instance, or a function that receives a
+ * new context to configure.
+ * @returns {module:aerospike/strings~StringOperation} This operation.
+ */
 StringOperation.prototype.withContext = function (contextOrFunction) {
   if (typeof contextOrFunction === 'object') {
     this.context = contextOrFunction
@@ -47,7 +49,14 @@ StringOperation.prototype.withContext = function (contextOrFunction) {
 }
 
 /**
- * @param {object} policy `{ writeFlags }` — see {@link module:aerospike/strings.writeFlags}
+ * @summary Attach string policy flags to a modify operation.
+ * @description Pass `{ writeFlags }` using {@link module:aerospike/strings.writeFlags}.
+ * Applies to string modify operations that support policy on the wire. Does not
+ * apply to {@link module:aerospike/strings.regexReplace|regexReplace}, which
+ * accepts regex flags as a separate argument instead of string policy flags.
+ *
+ * @param {object} policy - `{ writeFlags }` bit flags.
+ * @returns {module:aerospike/strings~StringOperation} This operation.
  */
 StringOperation.prototype.withPolicy = function (policy) {
   this.policy = policy
@@ -67,65 +76,537 @@ function op (name, bin, props) {
  * For raw byte append/prepend on **blob** bins, use {@link module:aerospike/operations}
  * `append` / `prepend`. Use {@link module:aerospike/strings.append} /
  * {@link module:aerospike/strings.prepend} for Unicode-aware string bins.
+ *
+ * #### When the target bin is missing
+ *
+ * Modify operations fall into two groups. Missing-bin behavior is defined by the
+ * operation, not by {@link module:aerospike/strings.writeFlags.NO_FAIL|NO_FAIL}.
+ *
+ * * **Creates the bin** (additive; may start from an empty string):
+ *   {@link append}, {@link prepend}, {@link concat}, {@link concatList},
+ *   {@link insert}, {@link overwrite}, {@link padStart}, {@link padEnd},
+ *   {@link repeat} (on a missing bin, {@link repeat} yields an empty string when
+ *   the server applies the op).
+ * * **No-op** (record unchanged; a following `read` may return `undefined` for
+ *   that bin in the record's `bins` map):
+ *   {@link snip}, {@link replace}, {@link replaceAll}, {@link upper},
+ *   {@link lower}, {@link caseFold}, {@link normalizeNfc}, {@link trimStart},
+ *   {@link trimEnd}, {@link trim}, {@link regexReplace}, {@link toString}.
+ *
+ * **Read operations** ({@link strlen}, {@link find}, and the rest of the read
+ * helpers) require an applicable bin/value; the server returns an error if the
+ * bin is missing or the type is wrong.
+ *
+ * #### Policy and errors
+ *
+ * Use {@link module:aerospike/strings~StringOperation#withPolicy|withPolicy} with
+ * {@link module:aerospike/strings.writeFlags|writeFlags} on supported modify ops.
+ * {@link module:aerospike/strings.writeFlags.NO_FAIL|NO_FAIL} suppresses an
+ * in-operation execution failure and leaves the bin unchanged. It does **not**
+ * suppress wrong-type or invalid-bin-type errors; those still fail
+ * {@link Client#operate} with an {@link AerospikeError}.
+ *
+ * For richer failure data on server 8.1.3+, set
+ * {@link BasePolicy#errorDetailVerbosity} on {@link OperatePolicy} using
+ * {@link module:aerospike/errorDetailVerbosity|errorDetailVerbosity}, then read
+ * {@link AerospikeError#subcode} and the error message. Subcodes are paired with
+ * parent {@link module:aerospike/status|status} codes; see
+ * {@link module:aerospike/subcode|subcode}.
+ *
+ * @remarks Some server 8.1.3 builds may ignore {@link writeFlags.NO_FAIL} on
+ * modify paths that do not pass a context argument. Prefer
+ * {@link module:aerospike/strings~StringOperation#withContext|withContext} when
+ * relying on `NO_FAIL` until your server version includes the fix.
+ *
+ * #### Multi-op results
+ *
+ * Chaining multiple string ops on the same bin in one `operate()` call may return
+ * an ordered list of per-op results when the server sets RESPOND_ALL_OPS
+ * (STRING_READ / STRING_MODIFY / TO_STRING behave like MAP/BIT/HLL in the C client).
+ *
+ * @see {@link Client#operate}
+ *
+ * @example <caption>Append creates a missing bin; upper is a no-op on a missing bin</caption>
+ *
+ * const Aerospike = require('aerospike')
+ * const strings = Aerospike.strings
+ * const op = Aerospike.operations
+ * const key = new Aerospike.Key('test', 'demo', 'stringsMissingBin')
+ *
+ * // INSERT HOSTNAME AND PORT NUMBER OF AEROSPIKE SERVER NODE HERE!
+ * const config = {
+ *   hosts: '192.168.33.10:3000',
+ *   policies: {
+ *     operate: new Aerospike.OperatePolicy({ socketTimeout: 0, totalTimeout: 0 })
+ *   }
+ * }
+ * Aerospike.connect(config).then(async client => {
+ *   await client.put(key, {}) // no "msg" bin yet
+ *   await client.operate(key, [
+ *     strings.append('msg', 'hi'),
+ *     op.read('msg')
+ *   ])
+ *   let record = await client.get(key)
+ *   console.log(record.bins.msg) // => 'hi'
+ *
+ *   await client.remove(key)
+ *   await client.put(key, {})
+ *   await client.operate(key, [
+ *     strings.upper('msg'),
+ *     op.read('msg')
+ *   ])
+ *   record = await client.get(key)
+ *   console.log(record.bins.msg) // => undefined (bin was never created)
+ *   client.close()
+ * })
  */
 
+/**
+ * @summary String operation policy write bit flags.
+ *
+ * @type Object
+ * @property {number} DEFAULT - Default. Does not suppress an in-operation
+ * execution failure.
+ * @property {number} NO_FAIL - Suppress an operation failure with the bin
+ * unchanged. Does not suppress wrong-type or invalid-bin-type errors.
+ *
+ * @see {@link module:aerospike/strings~StringOperation#withPolicy}
+ */
+exports.writeFlags = as.string.writeFlags
+
+/**
+ * @summary Regex flags for {@link regexCompareFlags} and {@link regexReplace}.
+ *
+ * @type Object
+ * @property {number} NONE - No flags.
+ * @property {number} CASE_INSENSITIVE - Case-insensitive matching.
+ * @property {number} MULTILINE - `^` and `$` match line boundaries.
+ * @property {number} DOTALL - `.` matches line terminators.
+ * @property {number} UNIX_LINES - Only `\n` is a line terminator.
+ * @property {number} GLOBAL - Replace all matches ({@link regexReplace} only).
+ */
+exports.regexFlags = as.string.regexFlags
+
+/**
+ * @summary Numeric type filter for {@link isNumericType}.
+ *
+ * @type Object
+ * @property {number} ANY - Integer or floating-point.
+ * @property {number} INT - Integer only.
+ * @property {number} FLOAT - Floating-point only.
+ */
+exports.numericType = as.string.numericType
+
+/**
+ * @summary Create string length read operation.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.strlen = (bin) => op('STRLEN', bin, {})
+
+/**
+ * @summary Create substring read from codepoint index to end.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {number} start - Codepoint index (negative indexes count from the end).
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.substr = (bin, start) => op('SUBSTR', bin, { start })
-/** Half-open codepoint range `[start, end)` (exclusive `end`). */
+
+/**
+ * @summary Create substring read for half-open codepoint range `[start, end)`.
+ * @description Read-only; does not change the stored bin. Requires an applicable
+ * string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {number} start - Start codepoint index.
+ * @param {number} end - Exclusive end codepoint index.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.substrRange = (bin, start, end) => op('SUBSTR_RANGE', bin, { start, end })
+
+/**
+ * @summary Read one codepoint at index.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {number} index - Codepoint index.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.charAt = (bin, index) => op('CHAR_AT', bin, { index })
+
+/**
+ * @summary Find first occurrence of needle; returns index or -1.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} needle - Substring to find.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.find = (bin, needle) => op('FIND', bin, { needle })
+
+/**
+ * @summary Find nth occurrence of needle.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} needle - Substring to find.
+ * @param {number} occurrence - Occurrence number (1-based).
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.findOccurrence = (bin, needle, occurrence) =>
   op('FIND_OCCURRENCE', bin, { needle, occurrence })
+
+/**
+ * @summary Test whether the bin contains needle.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} needle - Substring to test.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.contains = (bin, needle) => op('CONTAINS', bin, { needle })
+
+/**
+ * @summary Test whether the bin starts with prefix.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} prefix - Prefix to test.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.startsWith = (bin, prefix) => op('STARTS_WITH', bin, { prefix })
+
+/**
+ * @summary Test whether the bin ends with suffix.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} suffix - Suffix to test.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.endsWith = (bin, suffix) => op('ENDS_WITH', bin, { suffix })
+
+/**
+ * @summary Parse bin contents as integer.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.toInteger = (bin) => op('TO_INTEGER', bin, {})
+
+/**
+ * @summary Parse bin contents as double.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.toDouble = (bin) => op('TO_DOUBLE', bin, {})
+
+/**
+ * @summary Return UTF-8 byte length of the string bin.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.byteLength = (bin) => op('BYTE_LENGTH', bin, {})
+
+/**
+ * @summary Test whether the bin is numeric.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.isNumeric = (bin) => op('IS_NUMERIC', bin, {})
+
+/**
+ * @summary Test whether the bin matches a numeric type filter.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {number} numericType - {@link numericType} filter value.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.isNumericType = (bin, numericType) => op('IS_NUMERIC_TYPE', bin, { numericType })
+
+/**
+ * @summary Test whether all letters in the bin are uppercase.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.isUpper = (bin) => op('IS_UPPER', bin, {})
+
+/**
+ * @summary Test whether all letters in the bin are lowercase.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.isLower = (bin) => op('IS_LOWER', bin, {})
+
+/**
+ * @summary Convert string bin to blob bytes.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.toBlob = (bin) => op('TO_BLOB', bin, {})
-/** Splits by Unicode codepoint (one list element per codepoint). Use {@link splitSeparator} to split on a delimiter. */
+
+/**
+ * @summary Split string into a list of codepoint strings.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * Use {@link splitSeparator} to split on a delimiter.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.split = (bin) => op('SPLIT', bin, {})
+
+/**
+ * @summary Split string on separator into a list.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} separator - Delimiter string.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.splitSeparator = (bin, separator) => op('SPLIT_SEPARATOR', bin, { separator })
+
+/**
+ * @summary Base64-decode string bin to blob.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.b64Decode = (bin) => op('B64_DECODE', bin, {})
+
+/**
+ * @summary Regex match test.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} pattern - Regex pattern.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.regexCompare = (bin, pattern) => op('REGEX_COMPARE', bin, { pattern })
+
+/**
+ * @summary Regex match test with flags.
+ * @description Requires an applicable string bin; errors if the bin is missing or not a string.
+ * @param {string} bin - Bin name.
+ * @param {string} pattern - Regex pattern.
+ * @param {number} flags - {@link regexFlags} bit flags.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.regexCompareFlags = (bin, pattern, flags) =>
   op('REGEX_COMPARE_FLAGS', bin, { pattern, flags })
 
+/**
+ * @summary Insert value at codepoint index.
+ * @description Splices `value` into the bin at `index`. Negative indexes count
+ * from the end. If the bin is missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {number} index - Codepoint index.
+ * @param {string} value - String to insert.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.insert = (bin, index, value) => op('INSERT', bin, { index, value })
+
+/**
+ * @summary Overwrite codepoints starting at index.
+ * @description Result may grow when `value` extends past the end. If the bin is
+ * missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {number} index - Codepoint index.
+ * @param {string} value - Replacement string.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.overwrite = (bin, index, value) => op('OVERWRITE', bin, { index, value })
-/** `AS_STRING_OP_CONCAT` with a single-element list on the wire (see C client). */
+
+/**
+ * @summary Append one string to the bin (`AS_STRING_OP_CONCAT` with one value).
+ * @description If the bin is missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {string} value - String to append.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.concat = (bin, value) => op('CONCAT', bin, { value })
+
+/**
+ * @summary Append each list element to the bin in order.
+ * @description If the bin is missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {string[]} values - Strings to append.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.concatList = (bin, values) => op('CONCAT_LIST', bin, { values })
-/** Unicode-aware append (`AS_STRING_OP_APPEND`). */
+
+/**
+ * @summary Unicode-aware append to end of string bin.
+ * @description Unlike {@link module:aerospike/operations.append}, uses codepoint
+ * semantics and supports policy/ctx. If the bin is missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {string} value - String to append.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.append = (bin, value) => op('APPEND', bin, { value })
-/** Unicode-aware prepend (`AS_STRING_OP_PREPEND`). */
+
+/**
+ * @summary Unicode-aware prepend to start of string bin.
+ * @description Unlike {@link module:aerospike/operations.prepend}, uses codepoint
+ * semantics and supports policy/ctx. If the bin is missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {string} value - String to prepend.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.prepend = (bin, value) => op('PREPEND', bin, { value })
-/** Removes half-open codepoint range `[start, end)`. */
+
+/**
+ * @summary Remove half-open codepoint range `[start, end)`.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @param {number} start - Start codepoint index.
+ * @param {number} end - Exclusive end codepoint index.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.snip = (bin, start, end) => op('SNIP', bin, { start, end })
-/** @deprecated Use {@link #snip} (same wire; opcode alias). */
+
+/**
+ * @summary Remove half-open codepoint range `[start, end)`.
+ * @deprecated Use {@link snip} (same wire opcode).
+ * @param {string} bin - Bin name.
+ * @param {number} start - Start codepoint index.
+ * @param {number} end - Exclusive end codepoint index.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.snipRange = (bin, start, end) => op('SNIP_RANGE', bin, { start, end })
+
+/**
+ * @summary Replace first occurrence of needle with replacement.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @param {string} needle - Substring to find.
+ * @param {string} replacement - Replacement string.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.replace = (bin, needle, replacement) => op('REPLACE', bin, { needle, replacement })
+
+/**
+ * @summary Replace every occurrence of needle with replacement.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @param {string} needle - Substring to find.
+ * @param {string} replacement - Replacement string.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.replaceAll = (bin, needle, replacement) =>
   op('REPLACE_ALL', bin, { needle, replacement })
+
+/**
+ * @summary Uppercase string bin in place.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.upper = (bin) => op('UPPER', bin, {})
+
+/**
+ * @summary Lowercase string bin in place.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.lower = (bin) => op('LOWER', bin, {})
+
+/**
+ * @summary Apply locale-independent case folding (lowercase) in place.
+ * @description Useful for normalized comparison keys. If the bin is missing,
+ * no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.caseFold = (bin) => op('CASE_FOLD', bin, {})
+
+/**
+ * @summary Normalize string bin to Unicode NFC in place.
+ * @description Already-normalized strings are unchanged. If the bin is missing,
+ * no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.normalizeNfc = (bin) => op('NORMALIZE_NFC', bin, {})
+
+/**
+ * @summary Trim leading whitespace in place.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.trimStart = (bin) => op('TRIM_START', bin, {})
+
+/**
+ * @summary Trim trailing whitespace in place.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.trimEnd = (bin) => op('TRIM_END', bin, {})
+
+/**
+ * @summary Trim leading and trailing whitespace in place.
+ * @description If the bin is missing, no-op (record unchanged).
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.trim = (bin) => op('TRIM', bin, {})
+
+/**
+ * @summary Pad start until bin reaches target codepoint length.
+ * @description No-op when already at or above target length. If the bin is
+ * missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {number} targetLength - Target length in codepoints.
+ * @param {string} padString - Pad string (must not be empty).
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.padStart = (bin, targetLength, padString) =>
   op('PAD_START', bin, { targetLength, padString })
+
+/**
+ * @summary Pad end until bin reaches target codepoint length.
+ * @description No-op when already at or above target length. If the bin is
+ * missing, creates a new bin.
+ * @param {string} bin - Bin name.
+ * @param {number} targetLength - Target length in codepoints.
+ * @param {string} padString - Pad string (must not be empty).
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.padEnd = (bin, targetLength, padString) =>
   op('PAD_END', bin, { targetLength, padString })
+
+/**
+ * @summary Repeat bin contents `count` times in place.
+ * @description If the bin is missing, creates a new bin (empty string when the
+ * server applies the op). Invalid `count` may fail unless
+ * {@link writeFlags.NO_FAIL} is set on a supported policy path.
+ * @param {string} bin - Bin name.
+ * @param {number} count - Repeat count.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.repeat = (bin, count) => op('REPEAT', bin, { count })
+
+/**
+ * @summary Replace regex matches in the bin.
+ * @description Accepts {@link regexFlags} (e.g. GLOBAL for all matches). Does
+ * not use {@link writeFlags} string policy flags. If the bin is missing, no-op
+ * (record unchanged).
+ * @param {string} bin - Bin name.
+ * @param {string} pattern - Regex pattern.
+ * @param {string} replacement - Replacement string.
+ * @param {number} flags - {@link regexFlags} bit flags.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.regexReplace = (bin, pattern, replacement, flags) =>
   op('REGEX_REPLACE', bin, { pattern, replacement, flags })
+
+/**
+ * @summary Coerce bin value to string in place.
+ * @description If the bin is missing, no-op (record unchanged). Wrong-type bins
+ * may error even when other ops use {@link writeFlags.NO_FAIL}.
+ * @param {string} bin - Bin name.
+ * @returns {module:aerospike/strings~StringOperation} Operation for {@link Client#operate}.
+ */
 exports.toString = (bin) => op('TO_STRING', bin, {})
 
 exports.StringOperation = StringOperation


### PR DESCRIPTION
## Summary

- Document Aerospike string bin operate helpers (`lib/strings.js`) with Node-style JSDoc: module-level rules for when a missing bin is **created** vs **no-op**, read-op requirements, `writeFlags` / `NO_FAIL` (including wrong-type not suppressed), `errorDetailVerbosity` / `subcode`, ctx vs CDT, and an `@example` operate flow.
- Re-export and document `writeFlags`, `regexFlags`, and `numericType` on the strings module (same objects as today via native merge; enables JSDoc like other CDT modules).
- Mirror semantics in TypeDoc remarks on the `strings` namespace in `lib/aerospike.d.ts`.
- Extend `lib/exp_string.js` module docs with cross-links and the same write-path / error rules for expressions.

Docs-only change; no string operation wire or runtime logic changes.

## Test plan

- [x] Smoke: `require('aerospike')` — `strings.writeFlags`, re-exports, `withPolicy` chain
- [x] `npx mocha --no-config --require tsx test/strings_operate.ts` (4 tests)
- [x] `npx standard lib/strings.js lib/exp_string.js`
- [x] `npm run build-docs` (TypeDoc, 0 errors)
- [ ] `npm run apidocs` (optional; needs `docs/overview.md` in repo)