### PR TITLE
Align exp.string.toString with C CLIENT-5164 TO_STRING opcode.

### DIFF
--- a/lib/exp_string.js
+++ b/lib/exp_string.js
@@ -506,13 +506,9 @@ const regexReplace = (policy, pattern, replacement, _flags, bin) => [
   ...bin
 ]
 
-/** @param {import('./exp').AerospikeExp} bin */
+/** Matches `as_exp_to_string` in as_exp.h (opcode TO_STRING, count 2). */
 const toString = (bin) => [
-  { op: exp.ops.CALL, count: 5 },
-  ..._rtype(exp.type.STR),
-  ..._int(exp.sys.CALL_REPR),
-  { op: exp.ops.CALL_VOP_START, count: 1 },
-  ..._int(0),
+  { op: exp.ops.TO_STRING, count: 2 },
   ...bin
 ]
 

--- a/src/main/enums/exp_enum.cc
+++ b/src/main/enums/exp_enum.cc
@@ -70,6 +70,7 @@ Local<Object> exp_opcode_values()
 	set(exp_ops, "KEY", as_exp_ops::_AS_EXP_CODE_KEY);
 	set(exp_ops, "BIN", as_exp_ops::_AS_EXP_CODE_BIN);
 	set(exp_ops, "BIN_TYPE", as_exp_ops::_AS_EXP_CODE_BIN_TYPE);
+	set(exp_ops, "TO_STRING", as_exp_ops::_AS_EXP_CODE_TO_STRING);
 
 	set(exp_ops, "REMOVE_RESULT", as_exp_ops::_AS_EXP_CODE_REMOVE_RESULT);
 	set(exp_ops, "MAP_KEYS_IN", as_exp_ops::_AS_EXP_CODE_MAP_KEYS_IN);
@@ -145,7 +146,6 @@ Local<Object> exp_opcode_values()
 	set(exp_sys, "CALL_BITS", as_exp_call_system_type::_AS_EXP_SYS_CALL_BITS);
 	set(exp_sys, "CALL_HLL", as_exp_call_system_type::_AS_EXP_SYS_CALL_HLL);
 	set(exp_sys, "CALL_STRING", as_exp_call_system_type::_AS_EXP_SYS_CALL_STRING);
-	set(exp_sys, "CALL_REPR", as_exp_call_system_type::_AS_EXP_SYS_CALL_REPR);
 	set(exp_sys, "FLAG_MODIFY_LOCAL",
 		as_exp_call_system_type::_AS_EXP_SYS_FLAG_MODIFY_LOCAL);
 

--- a/test/exp.ts
+++ b/test/exp.ts
@@ -645,7 +645,7 @@ describe('Aerospike.exp', function () {
         expect(result.bins.ExpVar).to.eql(true)
       })
 
-      it('toString repr on string bin', async function () {
+      it('toString on string bin', async function () {
         const key = await createRecord({ text: 'quoted' })
         const ops = [
           exp.operations.read(tempBin,


### PR DESCRIPTION
Bump aerospike-client-c to stage; encode expression toString as EXP_TO_STRING (99) and drop removed CALL_REPR from exp enums.