### PR TITLE
Fix stage comprehensive tests for slim prebuild layout.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -83,6 +83,8 @@ jobs:
       with:
         egress-policy: audit
 
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
@@ -91,19 +93,17 @@ jobs:
         oidc-provider-name: database-gh-aerospike
         oidc-audience: database-gh-aerospike
 
-    - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-      shell: "bash -ex {0}"
-
     - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: ${{ matrix.nodejs-tag[1] }}
 
-    - run: npm install --no-save --ignore-scripts *.tgz
+    - run: |
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh install
       shell: bash
 
     - run: node scripts/verify-prebuild-smoke.js
-      working-directory: node_modules/aerospike
+      working-directory: .slim-install/node_modules/aerospike
       shell: bash
 
   test-ee:
@@ -183,9 +183,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        # npm install *.tgz --no-save
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # macOS x86 doesn't have tree by default
         # tree .
       shell: "bash -ex {0}"
@@ -288,7 +287,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
 
@@ -300,10 +300,12 @@ jobs:
         pnpm --version
         mkdir pnpm
         cp ./scripts/basic_test.js pnpm/basic_test.js
-        mv *.tgz pnpm
+        mv aerospike-*.tgz @aerospike-prebuild-*.tgz pnpm/
         cd pnpm
         echo '{}' > package.json
-        pnpm add file:./aerospike-${{ inputs.version }}.tgz --ignore-scripts
+        MAIN_TGZ=(aerospike-*.tgz)
+        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
+        pnpm add "file:./${MAIN_TGZ[0]}" "file:./${PREBUILD_TGZ[0]}" --ignore-scripts
         node basic_test.js
 
     # - name: Set final commit status
@@ -372,7 +374,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
 
@@ -385,10 +388,12 @@ jobs:
         bun --version;
         mkdir bun;
         cp ./scripts/basic_test.js bun/basic_test.js;
-        mv *.tgz bun/
+        mv aerospike-*.tgz @aerospike-prebuild-*.tgz bun/
         cd bun;
         echo '{}' > package.json;
-        bun add ./aerospike-${{ inputs.version }}.tgz
+        MAIN_TGZ=(aerospike-*.tgz)
+        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
+        bun add "./${MAIN_TGZ[0]}" "./${PREBUILD_TGZ[0]}"
         node basic_test.js;
 
     #- name: Debug server
@@ -463,7 +468,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
 
@@ -475,10 +481,12 @@ jobs:
         yarn --version
         mkdir yarn
         cp ./scripts/basic_test.js yarn/basic_test.js
-        mv *.tgz yarn/
+        mv aerospike-*.tgz @aerospike-prebuild-*.tgz yarn/
         cd yarn
         echo '{}' > package.json
-        yarn add file:./aerospike-${{ inputs.version }}.tgz --ignore-scripts
+        MAIN_TGZ=(aerospike-*.tgz)
+        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
+        yarn add "file:./${MAIN_TGZ[0]}" "file:./${PREBUILD_TGZ[0]}" --ignore-scripts
         node basic_test.js
 
     #- name: Debug server
@@ -582,8 +590,8 @@ jobs:
         node-version: ${{ matrix.nodejs-tag[1] }}
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 
@@ -678,8 +686,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 
@@ -755,8 +763,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 
@@ -840,8 +848,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 
@@ -924,8 +932,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 
@@ -994,8 +1002,8 @@ jobs:
           oidc-audience: database-gh-aerospike
 
       - run: |
-          jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-          tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+          PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+            scripts/ci/jfrog-fetch-slim-packages.sh extract
           # tree .
         shell: "bash -ex {0}"
 
@@ -1081,8 +1089,8 @@ jobs:
         oidc-audience: database-gh-aerospike
 
     - run: |
-        jf rt dl --flat --fail-no-op "database-npm-dev-local/aerospike/-/aerospike-${{ inputs.version }}.tgz" .
-        tar xvf aerospike-${{ inputs.version }}.tgz --strip-components 1 'package/prebuilds'
+        PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
 

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch slim-layout npm artifacts from JFrog and either:
+#   download - fetch main + platform prebuild .tgz files only
+#   extract  - unpack platform prebuilds into ./prebuilds/ (repo checkout jobs)
+#   install  - npm install main + platform prebuild tarballs (smoke / pm tests)
+#
+# Required env:
+#   PKG_VERSION     npm package version (e.g. 7.0.0) used in .tgz filenames
+#   PLATFORM_TAG    CI platform tag (e.g. linux_x86_64)
+# Optional env:
+#   JF_REPO         default database-npm-dev-local
+
+usage () {
+  echo "usage: $0 download|extract|install" >&2
+  exit 1
+}
+
+map_prebuild_tag () {
+  case "$1" in
+    linux_x86_64) echo linux-x64 ;;
+    linux_aarch64) echo linux-arm64 ;;
+    win32_x64) echo win32-x64 ;;
+    darwin_x86_64|darwin_x86_64_2) echo darwin-x64 ;;
+    darwin_arm64|darwin_arm64_2) echo darwin-arm64 ;;
+    *)
+      echo "unknown PLATFORM_TAG: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+[[ $# -eq 1 ]] || usage
+MODE=$1
+
+PKG_VERSION="${PKG_VERSION:?PKG_VERSION is required}"
+PLATFORM_TAG="${PLATFORM_TAG:?PLATFORM_TAG is required}"
+JF_REPO="${JF_REPO:-database-npm-dev-local}"
+PREBUILD_TAG="$(map_prebuild_tag "$PLATFORM_TAG")"
+
+MAIN="aerospike-${PKG_VERSION}.tgz"
+PREBUILD="@aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+
+echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE}"
+
+jf rt dl --flat --fail-no-op "${JF_REPO}/aerospike/-/${MAIN}" .
+jf rt dl --flat --fail-no-op \
+  "${JF_REPO}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}" .
+
+if [[ ! -f "$MAIN" ]]; then
+  echo "missing main package: ${MAIN}" >&2
+  exit 1
+fi
+if [[ ! -f "$PREBUILD" ]]; then
+  echo "missing prebuild package: ${PREBUILD}" >&2
+  exit 1
+fi
+
+case "$MODE" in
+  download)
+    echo "downloaded ${MAIN} and ${PREBUILD}"
+    ;;
+  extract)
+    mkdir -p prebuilds
+    tmp="$(mktemp -d)"
+    tar xzf "$PREBUILD" -C "$tmp"
+    cp -R "${tmp}/package/prebuilds/." prebuilds/
+    rm -rf "$tmp"
+    echo "extracted prebuilds/${PREBUILD_TAG}"
+    ;;
+  install)
+    rm -rf .slim-install
+    mkdir .slim-install
+    (
+      cd .slim-install
+      echo '{"name":"slim-jfrog-smoke","private":true}' > package.json
+      npm install --no-save --ignore-scripts \
+        "file:${PWD}/../${MAIN}" \
+        "file:${PWD}/../${PREBUILD}"
+    )
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
Stage jobs assumed prebuilds lived inside the main aerospike tarball. Fetch main and platform prebuild packages from JFrog instead.