### PR TITLE
Fix stage JFrog fetch for slim prebuild release bundles.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -24,6 +24,10 @@ on:
         type: string
         description: Build version
         required: true
+      bundle-version:
+        type: string
+        description: Release bundle version (e.g. 7.0.0-dev.9)
+        required: true
       run_tests:
         type: boolean
         required: false
@@ -99,6 +103,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh install
       shell: bash
 
@@ -184,6 +189,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # macOS x86 doesn't have tree by default
         # tree .
@@ -288,6 +294,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
@@ -375,6 +382,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
@@ -469,6 +477,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh download
         # tree .
       shell: "bash -ex {0}"
@@ -591,6 +600,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
@@ -687,6 +697,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
@@ -764,6 +775,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
@@ -849,6 +861,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
@@ -933,6 +946,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"
@@ -1003,6 +1017,7 @@ jobs:
 
       - run: |
           PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+            BUNDLE_VERSION=${{ inputs.bundle-version }} \
             scripts/ci/jfrog-fetch-slim-packages.sh extract
           # tree .
         shell: "bash -ex {0}"
@@ -1090,6 +1105,7 @@ jobs:
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
+          BUNDLE_VERSION=${{ inputs.bundle-version }} \
           scripts/ci/jfrog-fetch-slim-packages.sh extract
         # tree .
       shell: "bash -ex {0}"

--- a/.github/workflows/stage-tests.yml
+++ b/.github/workflows/stage-tests.yml
@@ -12,6 +12,10 @@ on:
         type: string
         description: Build version
         required: true
+      bundle-version:
+        type: string
+        description: Release bundle version (e.g. 7.0.0-dev.9)
+        required: true
       server-tag:
         type: string
         required: false
@@ -25,6 +29,10 @@ on:
       version:
         type: string
         description: Build version
+        required: true
+      bundle-version:
+        type: string
+        description: Release bundle version (e.g. 7.0.0-dev.9)
         required: true
       server-tag:
         type: string
@@ -58,6 +66,7 @@ jobs:
       run_tests: ${{ inputs.run_tests }}
       server-tag: ${{ inputs.server-tag }}
       version: ${{ inputs.version }}
+      bundle-version: ${{ inputs.bundle-version }}
     secrets:
       soup_hat: ${{ secrets.soup_hat }}
       cell_girl: ${{ secrets.cell_girl }}

--- a/.github/workflows/stage-workflow.yml
+++ b/.github/workflows/stage-workflow.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/stage-tests.yml
     with:
       version: ${{ needs.stage-get-jfrog-version.outputs.dev_version }}
+      bundle-version: ${{ needs.stage-get-jfrog-version.outputs.tag_version }}
       run_tests: true
     needs: [
       stage-get-jfrog-version,

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -10,7 +10,11 @@ set -euo pipefail
 #   PKG_VERSION     npm package version (e.g. 7.0.0) used in .tgz filenames
 #   PLATFORM_TAG    CI platform tag (e.g. linux_x86_64)
 # Optional env:
+#   BUNDLE_VERSION  release bundle version (e.g. 7.0.0-dev.9); preferred source
+#   BUNDLE_NAME     default aerospike-nodejs-client
 #   JF_REPO         default database-npm-dev-local
+#   JF_URL          default https://aerospike.jfrog.io
+#   JF_PROJECT      default database
 
 usage () {
   echo "usage: $0 download|extract|install" >&2
@@ -31,22 +35,163 @@ map_prebuild_tag () {
   esac
 }
 
+copy_if_found () {
+  local src="$1" dest="$2"
+  if [[ -n "$src" && -f "$src" ]]; then
+    cp -f "$src" "$dest"
+    return 0
+  fi
+  return 1
+}
+
+find_artifact () {
+  local root="$1" pattern="$2"
+  find "$root" -type f -name "$pattern" 2>/dev/null | head -n 1
+}
+
+fetch_from_release_bundle () {
+  local root="$1"
+  rm -rf "$root"
+  mkdir -p "$root"
+
+  echo "fetching release bundle ${BUNDLE_NAME}/${BUNDLE_VERSION} (project=${JF_PROJECT})" >&2
+  if ! jf rt dl \
+    --bundle "${BUNDLE_NAME}/${BUNDLE_VERSION}" \
+    --project "$JF_PROJECT" \
+    "$root"; then
+    echo "warning: release bundle download failed" >&2
+    return 1
+  fi
+}
+
+fetch_from_npm_paths () {
+  local repo="$1"
+  local main_path="${repo}/aerospike/-/${MAIN}"
+  local prebuild_path="${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}"
+
+  echo "try npm path: ${main_path}" >&2
+  if jf rt dl --flat --project "$JF_PROJECT" "$main_path" "./${MAIN}"; then
+    :
+  else
+    rm -f "./${MAIN}"
+  fi
+
+  echo "try npm path: ${prebuild_path}" >&2
+  if jf rt dl --flat --project "$JF_PROJECT" "$prebuild_path" "./${PREBUILD}"; then
+    :
+  else
+    rm -f "./${PREBUILD}"
+  fi
+
+  # JFrog CLI has historically uploaded scoped tarballs without the @scope prefix.
+  local alt_prebuild="prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+  if [[ ! -f "$PREBUILD" ]]; then
+    local alt_path="${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${alt_prebuild}"
+    echo "try alternate npm path: ${alt_path}" >&2
+    if jf rt dl --flat --project "$JF_PROJECT" "$alt_path" "./${PREBUILD}"; then
+      :
+    else
+      rm -f "./${PREBUILD}"
+    fi
+  fi
+}
+
+fetch_from_npm_registry () {
+  local registry="${JF_URL%/}/artifactory/api/npm/${JF_REPO}/"
+  local optional="@aerospike/prebuild-${PREBUILD_TAG}@${PKG_VERSION}"
+
+  echo "try npm registry: ${registry}" >&2
+  rm -rf .npm-jfrog-fetch
+  mkdir .npm-jfrog-fetch
+  (
+    cd .npm-jfrog-fetch
+    echo '{"name":"jfrog-fetch","private":true}' > package.json
+    npm install --no-save --ignore-scripts \
+      "aerospike@${PKG_VERSION}" \
+      "${optional}" \
+      --registry "$registry"
+  )
+
+  if [[ "$MODE" == "download" ]]; then
+    (
+      cd .npm-jfrog-fetch
+      npm pack "aerospike@${PKG_VERSION}" --registry "$registry"
+      npm pack "${optional}" --registry "$registry"
+    )
+    copy_if_found ".npm-jfrog-fetch/aerospike-${PKG_VERSION}.tgz" "./${MAIN}" || true
+    copy_if_found ".npm-jfrog-fetch/${PREBUILD}" "./${PREBUILD}" || true
+  fi
+
+  if [[ "$MODE" == "install" ]]; then
+    rm -rf .slim-install
+    mv .npm-jfrog-fetch .slim-install
+    return 0
+  fi
+
+  if [[ "$MODE" == "extract" ]]; then
+    mkdir -p prebuilds
+    cp -R ".npm-jfrog-fetch/node_modules/@aerospike/prebuild-${PREBUILD_TAG}/prebuilds/." prebuilds/
+    rm -rf .npm-jfrog-fetch
+    return 0
+  fi
+
+  rm -rf .npm-jfrog-fetch
+}
+
 [[ $# -eq 1 ]] || usage
 MODE=$1
 
 PKG_VERSION="${PKG_VERSION:?PKG_VERSION is required}"
 PLATFORM_TAG="${PLATFORM_TAG:?PLATFORM_TAG is required}"
 JF_REPO="${JF_REPO:-database-npm-dev-local}"
+JF_URL="${JF_URL:-https://aerospike.jfrog.io}"
+JF_PROJECT="${JF_PROJECT:-database}"
+BUNDLE_NAME="${BUNDLE_NAME:-aerospike-nodejs-client}"
+BUNDLE_VERSION="${BUNDLE_VERSION:-}"
 PREBUILD_TAG="$(map_prebuild_tag "$PLATFORM_TAG")"
 
 MAIN="aerospike-${PKG_VERSION}.tgz"
 PREBUILD="@aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
 
-echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE}"
+echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE} bundle=${BUNDLE_VERSION:-none}" >&2
 
-jf rt dl --flat --fail-no-op "${JF_REPO}/aerospike/-/${MAIN}" .
-jf rt dl --flat --fail-no-op \
-  "${JF_REPO}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}" .
+if [[ "$MODE" != "install" && "$MODE" != "extract" ]]; then
+  rm -f "./${MAIN}" "./${PREBUILD}"
+fi
+
+if [[ -n "$BUNDLE_VERSION" ]]; then
+  bundle_root="$(mktemp -d)"
+  fetch_from_release_bundle "$bundle_root" || true
+  main_src="$(find_artifact "$bundle_root" "$MAIN")"
+  pre_src="$(find_artifact "$bundle_root" "$PREBUILD")"
+  if [[ -z "$pre_src" ]]; then
+    pre_src="$(find_artifact "$bundle_root" "prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz")"
+    if [[ -n "$pre_src" ]]; then
+      PREBUILD="$(basename "$pre_src")"
+    fi
+  fi
+  copy_if_found "$main_src" "./${MAIN}" || true
+  copy_if_found "$pre_src" "./${PREBUILD}" || true
+  rm -rf "$bundle_root"
+fi
+
+if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
+  fetch_from_npm_paths "$JF_REPO"
+fi
+
+if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
+  fetch_from_npm_registry
+fi
+
+if [[ "$MODE" == "install" && -d .slim-install/node_modules/aerospike ]]; then
+  echo "installed via npm registry into .slim-install" >&2
+  exit 0
+fi
+
+if [[ "$MODE" == "extract" && -d prebuilds/${PREBUILD_TAG} ]]; then
+  echo "extracted prebuilds/${PREBUILD_TAG} via npm registry" >&2
+  exit 0
+fi
 
 if [[ ! -f "$MAIN" ]]; then
   echo "missing main package: ${MAIN}" >&2
@@ -59,7 +204,7 @@ fi
 
 case "$MODE" in
   download)
-    echo "downloaded ${MAIN} and ${PREBUILD}"
+    echo "downloaded ${MAIN} and ${PREBUILD}" >&2
     ;;
   extract)
     mkdir -p prebuilds
@@ -67,7 +212,7 @@ case "$MODE" in
     tar xzf "$PREBUILD" -C "$tmp"
     cp -R "${tmp}/package/prebuilds/." prebuilds/
     rm -rf "$tmp"
-    echo "extracted prebuilds/${PREBUILD_TAG}"
+    echo "extracted prebuilds/${PREBUILD_TAG}" >&2
     ;;
   install)
     rm -rf .slim-install


### PR DESCRIPTION
Download main and platform prebuild packages from the dev release bundle (tag version) with npm path and registry fallbacks, instead of relying on flat scoped npm paths that Stage could not resolve.