### PR TITLE
Fix stage slim package fetch install mode and PM smoke tarballs.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -47,6 +47,10 @@ on:
 
 env:
   COMMIT_SHA_TO_BUILD_AND_TEST: ${{ github.sha }}
+  JF_URL: ${{ vars.JFROG_PLATFORM_URL }}
+  JF_PROJECT: ${{ vars.JFROG_PROJECT }}
+  JF_OIDC_PROVIDER: ${{ vars.JFROG_OIDC_PROVIDER }}
+  JF_OIDC_AUDIENCE: ${{ vars.JFROG_OIDC_AUDIENCE }}
 
 jobs:
   get-runner-os:
@@ -92,11 +96,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
@@ -183,11 +187,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -289,11 +293,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -381,11 +385,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -480,11 +484,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -602,11 +606,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
@@ -704,11 +708,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -783,11 +787,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -870,11 +874,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -956,11 +960,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -1028,11 +1032,11 @@ jobs:
       - name: Set up JFrog credentials
         uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
         env:
-          JF_URL: https://aerospike.jfrog.io
-          JF_PROJECT: database
+          JF_URL: ${{ env.JF_URL }}
+          JF_PROJECT: ${{ env.JF_PROJECT }}
         with:
-          oidc-provider-name: database-gh-aerospike
-          oidc-audience: database-gh-aerospike
+          oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
       - run: |
           PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \
@@ -1117,11 +1121,11 @@ jobs:
     - name: Set up JFrog credentials
       uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
       env:
-        JF_URL: https://aerospike.jfrog.io
-        JF_PROJECT: database
+        JF_URL: ${{ env.JF_URL }}
+        JF_PROJECT: ${{ env.JF_PROJECT }}
       with:
-        oidc-provider-name: database-gh-aerospike
-        oidc-audience: database-gh-aerospike
+        oidc-provider-name: ${{ env.JF_OIDC_PROVIDER }}
+        oidc-audience: ${{ env.JF_OIDC_AUDIENCE }}
 
     - run: |
         PKG_VERSION=${{ inputs.version }} PLATFORM_TAG=${{ inputs.platform-tag }} \

--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -310,12 +310,15 @@ jobs:
         pnpm --version
         mkdir pnpm
         cp ./scripts/basic_test.js pnpm/basic_test.js
-        mv aerospike-*.tgz @aerospike-prebuild-*.tgz pnpm/
+        shopt -s nullglob
+        for f in aerospike-*.tgz aerospike-prebuild-*.tgz @aerospike-prebuild-*.tgz prebuild-*.tgz; do
+          [[ -f "$f" ]] && mv "$f" pnpm/
+        done
         cd pnpm
         echo '{}' > package.json
-        MAIN_TGZ=(aerospike-*.tgz)
-        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
-        pnpm add "file:./${MAIN_TGZ[0]}" "file:./${PREBUILD_TGZ[0]}" --ignore-scripts
+        source ../scripts/ci/select-slim-tarballs.sh
+        select_slim_tarballs
+        pnpm add "file:./${MAIN_TGZ}" "file:./${PREBUILD_TGZ}" --ignore-scripts
         node basic_test.js
 
     # - name: Set final commit status
@@ -400,12 +403,15 @@ jobs:
         bun --version;
         mkdir bun;
         cp ./scripts/basic_test.js bun/basic_test.js;
-        mv aerospike-*.tgz @aerospike-prebuild-*.tgz bun/
+        shopt -s nullglob
+        for f in aerospike-*.tgz aerospike-prebuild-*.tgz @aerospike-prebuild-*.tgz prebuild-*.tgz; do
+          [[ -f "$f" ]] && mv "$f" bun/
+        done
         cd bun;
         echo '{}' > package.json;
-        MAIN_TGZ=(aerospike-*.tgz)
-        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
-        bun add "./${MAIN_TGZ[0]}" "./${PREBUILD_TGZ[0]}"
+        source ../scripts/ci/select-slim-tarballs.sh
+        select_slim_tarballs
+        bun add "./${MAIN_TGZ}" "./${PREBUILD_TGZ}"
         node basic_test.js;
 
     #- name: Debug server
@@ -495,12 +501,15 @@ jobs:
         yarn --version
         mkdir yarn
         cp ./scripts/basic_test.js yarn/basic_test.js
-        mv aerospike-*.tgz @aerospike-prebuild-*.tgz yarn/
+        shopt -s nullglob
+        for f in aerospike-*.tgz aerospike-prebuild-*.tgz @aerospike-prebuild-*.tgz prebuild-*.tgz; do
+          [[ -f "$f" ]] && mv "$f" yarn/
+        done
         cd yarn
         echo '{}' > package.json
-        MAIN_TGZ=(aerospike-*.tgz)
-        PREBUILD_TGZ=(@aerospike-prebuild-*.tgz)
-        yarn add "file:./${MAIN_TGZ[0]}" "file:./${PREBUILD_TGZ[0]}" --ignore-scripts
+        source ../scripts/ci/select-slim-tarballs.sh
+        select_slim_tarballs
+        yarn add "file:./${MAIN_TGZ}" "file:./${PREBUILD_TGZ}" --ignore-scripts
         node basic_test.js
 
     #- name: Debug server

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -49,11 +49,32 @@ find_artifact () {
   find "$root" -type f -name "$pattern" 2>/dev/null | head -n 1
 }
 
+find_prebuild_artifact () {
+  local root="$1"
+  local candidate found=""
+  for candidate in \
+    "aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
+    "@aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
+    "prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+  do
+    found="$(find_artifact "$root" "$candidate")"
+    if [[ -n "$found" ]]; then
+      echo "$found"
+      return 0
+    fi
+  done
+  find "$root" -type f -name "*prebuild-${PREBUILD_TAG}*${PKG_VERSION}.tgz" 2>/dev/null | head -n 1
+}
+
 count_files () {
   find "$1" -type f 2>/dev/null | wc -l | tr -d ' '
 }
 
 configure_jfrog_npm () {
+  if ! command -v jf >/dev/null 2>&1; then
+    echo "warning: jf CLI not available for npm registry fallback" >&2
+    return 1
+  fi
   echo "configuring npm client for ${JF_REPO} (project=${JF_PROJECT})" >&2
   jf npm config --repo-resolve="${JF_REPO}" --project="${JF_PROJECT}"
 }
@@ -65,6 +86,73 @@ try_rt_dl_flat () {
     extra=(--bundle "${BUNDLE_NAME}/${BUNDLE_VERSION}")
   fi
   jf rt dl --flat --project "$JF_PROJECT" "${extra[@]}" "$spec" "$dest"
+}
+
+resolve_prebuild_path () {
+  if [[ -f "${WORKSPACE_ROOT}/${PREBUILD}" ]]; then
+    echo "${WORKSPACE_ROOT}/${PREBUILD}"
+    return 0
+  fi
+
+  shopt -s nullglob
+  local matches=(
+    "${WORKSPACE_ROOT}"/aerospike-prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz
+    "${WORKSPACE_ROOT}"/@aerospike-prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz
+    "${WORKSPACE_ROOT}"/prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz
+    "${WORKSPACE_ROOT}"/*prebuild-"${PREBUILD_TAG}"*"${PKG_VERSION}".tgz
+  )
+  shopt -u nullglob
+
+  if [[ ${#matches[@]} -gt 0 && -f "${matches[0]}" ]]; then
+    PREBUILD="$(basename "${matches[0]}")"
+    echo "${WORKSPACE_ROOT}/${PREBUILD}"
+    return 0
+  fi
+
+  echo "resolve_prebuild_path: no prebuild tarball for ${PREBUILD_TAG} in ${WORKSPACE_ROOT}" >&2
+  return 1
+}
+
+verify_slim_install () {
+  if [[ ! -d .slim-install/node_modules/aerospike ]]; then
+    echo "slim install verification failed: missing .slim-install/node_modules/aerospike" >&2
+    find .slim-install -maxdepth 3 -type d 2>/dev/null || true
+    exit 1
+  fi
+
+  local optional=".slim-install/node_modules/@aerospike/prebuild-${PREBUILD_TAG}"
+  if [[ ! -d "$optional" ]]; then
+    echo "slim install verification failed: missing ${optional}" >&2
+    exit 1
+  fi
+
+  (
+    cd .slim-install/node_modules/aerospike
+    node scripts/verify-prebuild-smoke.js
+  )
+  echo "slim install verified for ${PREBUILD_TAG}" >&2
+}
+
+install_slim_from_tarballs () {
+  local main_path="${WORKSPACE_ROOT}/${MAIN}"
+  local prebuild_path
+  prebuild_path="$(resolve_prebuild_path)"
+
+  if [[ ! -f "$main_path" ]]; then
+    echo "install_slim_from_tarballs: missing main tarball ${main_path}" >&2
+    exit 1
+  fi
+
+  rm -rf .slim-install
+  mkdir .slim-install
+  (
+    cd .slim-install
+    echo '{"name":"slim-jfrog-smoke","private":true}' > package.json
+    npm install --no-save --ignore-scripts \
+      "file:${main_path}" \
+      "file:${prebuild_path}"
+  )
+  verify_slim_install
 }
 
 fetch_from_bundle_paths () {
@@ -82,6 +170,7 @@ fetch_from_bundle_paths () {
     local spec dest="./${PREBUILD}"
     for spec in \
       "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}" \
+      "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
       "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
       "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/*/*.tgz"
     do
@@ -94,14 +183,27 @@ fetch_from_bundle_paths () {
       fi
       local got
       got="$(find . -maxdepth 1 -type f -name "*prebuild-${PREBUILD_TAG}*${PKG_VERSION}.tgz" | head -n 1)"
-      if [[ -n "$got" && "$got" != "./${PREBUILD}" ]]; then
-        mv "$got" "./${PREBUILD}"
+      if [[ -n "$got" ]]; then
+        if [[ "$got" != "./${PREBUILD}" ]]; then
+          mv "$got" "./${PREBUILD}"
+        fi
         break
       fi
     done
   fi
 
+  normalize_downloaded_prebuild || true
   [[ -f "$MAIN" && -f "$PREBUILD" ]]
+}
+
+normalize_downloaded_prebuild () {
+  if [[ -f "$PREBUILD" ]]; then
+    return 0
+  fi
+
+  local resolved
+  resolved="$(resolve_prebuild_path)" || return 1
+  PREBUILD="$(basename "$resolved")"
 }
 
 fetch_from_release_bundle () {
@@ -132,20 +234,22 @@ fetch_from_npm_paths () {
   BUNDLE_VERSION=""
 
   local main_path="${repo}/aerospike/-/${MAIN}"
-  local prebuild_path="${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}"
+  local prebuild_specs=(
+    "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+    "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}"
+    "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+  )
 
   echo "try npm path: ${main_path}" >&2
   try_rt_dl_flat "$main_path" "./${MAIN}" || rm -f "./${MAIN}"
 
-  echo "try npm path: ${prebuild_path}" >&2
-  try_rt_dl_flat "$prebuild_path" "./${PREBUILD}" || rm -f "./${PREBUILD}"
+  for spec in "${prebuild_specs[@]}"; do
+    [[ -f "$PREBUILD" ]] && break
+    echo "try npm path: ${spec}" >&2
+    try_rt_dl_flat "$spec" "./${PREBUILD}" || rm -f "./${PREBUILD}"
+  done
 
-  local alt_prebuild="prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
-  if [[ ! -f "$PREBUILD" ]]; then
-    local alt_path="${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${alt_prebuild}"
-    echo "try alternate npm path: ${alt_path}" >&2
-    try_rt_dl_flat "$alt_path" "./${PREBUILD}" || rm -f "./${PREBUILD}"
-  fi
+  normalize_downloaded_prebuild || true
 }
 
 fetch_from_npm_registry () {
@@ -171,12 +275,20 @@ fetch_from_npm_registry () {
       npm pack "${optional}"
     )
     copy_if_found ".npm-jfrog-fetch/aerospike-${PKG_VERSION}.tgz" "./${MAIN}" || true
-    copy_if_found ".npm-jfrog-fetch/${PREBUILD}" "./${PREBUILD}" || true
+    shopt -s nullglob
+    for f in .npm-jfrog-fetch/aerospike-prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz \
+      .npm-jfrog-fetch/@aerospike-prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz \
+      .npm-jfrog-fetch/prebuild-"${PREBUILD_TAG}"-"${PKG_VERSION}".tgz; do
+      copy_if_found "$f" "./${PREBUILD}" && break
+    done
+    shopt -u nullglob
+    normalize_downloaded_prebuild || true
   fi
 
   if [[ "$MODE" == "install" ]]; then
     rm -rf .slim-install
     mv .npm-jfrog-fetch .slim-install
+    verify_slim_install
     return 0
   fi
 
@@ -201,9 +313,10 @@ JF_PROJECT="${JF_PROJECT:-database}"
 BUNDLE_NAME="${BUNDLE_NAME:-aerospike-nodejs-client}"
 BUNDLE_VERSION="${BUNDLE_VERSION:-}"
 PREBUILD_TAG="$(map_prebuild_tag "$PLATFORM_TAG")"
+WORKSPACE_ROOT="$(pwd)"
 
 MAIN="aerospike-${PKG_VERSION}.tgz"
-PREBUILD="@aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
+PREBUILD="aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
 
 echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE} bundle=${BUNDLE_VERSION:-none}" >&2
 
@@ -218,12 +331,9 @@ if [[ -n "$BUNDLE_VERSION" ]]; then
     bundle_root="$(mktemp -d)"
     if fetch_from_release_bundle "$bundle_root"; then
       main_src="$(find_artifact "$bundle_root" "$MAIN")"
-      pre_src="$(find_artifact "$bundle_root" "$PREBUILD")"
-      if [[ -z "$pre_src" ]]; then
-        pre_src="$(find_artifact "$bundle_root" "prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz")"
-        if [[ -n "$pre_src" ]]; then
-          PREBUILD="$(basename "$pre_src")"
-        fi
+      pre_src="$(find_prebuild_artifact "$bundle_root")"
+      if [[ -n "$pre_src" ]]; then
+        PREBUILD="$(basename "$pre_src")"
       fi
       copy_if_found "$main_src" "./${MAIN}" || true
       copy_if_found "$pre_src" "./${PREBUILD}" || true
@@ -236,9 +346,13 @@ if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
   fetch_from_npm_paths "$JF_REPO" || true
 fi
 
+normalize_downloaded_prebuild || true
+
 if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
   fetch_from_npm_registry || true
 fi
+
+normalize_downloaded_prebuild || true
 
 if [[ "$MODE" == "install" && -d .slim-install/node_modules/aerospike ]]; then
   echo "installed via npm registry into .slim-install" >&2
@@ -255,8 +369,10 @@ if [[ ! -f "$MAIN" ]]; then
   echo "hint: confirm release bundle ${BUNDLE_NAME}/${BUNDLE_VERSION:-?} exists in JFrog DEV" >&2
   exit 1
 fi
+
 if [[ ! -f "$PREBUILD" ]]; then
-  echo "missing prebuild package: ${PREBUILD}" >&2
+  echo "missing prebuild package for ${PREBUILD_TAG} (expected ${PREBUILD})" >&2
+  ls -la ./*prebuild* 2>/dev/null || true
   echo "hint: confirm @aerospike/prebuild-${PREBUILD_TAG}@${PKG_VERSION} is in bundle ${BUNDLE_VERSION:-?}" >&2
   exit 1
 fi
@@ -274,15 +390,7 @@ case "$MODE" in
     echo "extracted prebuilds/${PREBUILD_TAG}" >&2
     ;;
   install)
-    rm -rf .slim-install
-    mkdir .slim-install
-    (
-      cd .slim-install
-      echo '{"name":"slim-jfrog-smoke","private":true}' > package.json
-      npm install --no-save --ignore-scripts \
-        "file:${PWD}/../${MAIN}" \
-        "file:${PWD}/../${PREBUILD}"
-    )
+    install_slim_from_tarballs
     ;;
   *)
     usage

--- a/scripts/ci/select-slim-tarballs.sh
+++ b/scripts/ci/select-slim-tarballs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Resolve main and platform prebuild .tgz filenames in the current directory.
+# Sets MAIN_TGZ and PREBUILD_TGZ (single basename each). Exits 1 if either is missing.
+#
+# Optional env:
+#   PREBUILD_TAG    platform tag (e.g. linux-x64) to disambiguate multiple prebuilds
+
+select_slim_tarballs () {
+  set -euo pipefail
+  shopt -s nullglob
+
+  local main=()
+  local prebuild=()
+
+  for f in aerospike-*.tgz; do
+    case "$f" in
+      aerospike-[0-9]*.[0-9]*.[0-9]*.tgz)
+        main+=("$f")
+        ;;
+      aerospike-prebuild-*)
+        prebuild+=("$f")
+        ;;
+    esac
+  done
+
+  for f in @aerospike-prebuild-*.tgz prebuild-*.tgz; do
+    prebuild+=("$f")
+  done
+
+  if [[ ${#main[@]} -eq 0 ]]; then
+    echo "select-slim-tarballs: missing main aerospike-*.tgz in $(pwd)" >&2
+    ls -la *.tgz 2>/dev/null || ls -la >&2
+    return 1
+  fi
+
+  if [[ ${#prebuild[@]} -eq 0 ]]; then
+    echo "select-slim-tarballs: missing platform prebuild .tgz in $(pwd)" >&2
+    ls -la *.tgz 2>/dev/null || ls -la >&2
+    return 1
+  fi
+
+  if [[ -n "${PREBUILD_TAG:-}" ]]; then
+    local filtered=()
+    local f
+    for f in "${prebuild[@]}"; do
+      if [[ "$f" == *"${PREBUILD_TAG}"* ]]; then
+        filtered+=("$f")
+      fi
+    done
+    if [[ ${#filtered[@]} -gt 0 ]]; then
+      prebuild=("${filtered[@]}")
+    fi
+  fi
+
+  MAIN_TGZ="${main[0]}"
+  PREBUILD_TGZ="${prebuild[0]}"
+  export MAIN_TGZ PREBUILD_TGZ
+  echo "select-slim-tarballs: main=${MAIN_TGZ} prebuild=${PREBUILD_TGZ}" >&2
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  select_slim_tarballs
+fi

--- a/scripts/ci/test-slim-fetch-local.sh
+++ b/scripts/ci/test-slim-fetch-local.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local smoke for slim fetch/install without JFrog.
+# Builds tarballs from the current checkout (requires prebuilds/<platform>/) and
+# exercises extract + install modes of jfrog-fetch-slim-packages.sh.
+#
+# Usage:
+#   scripts/ci/test-slim-fetch-local.sh [platform-tag]
+#
+# Examples:
+#   scripts/ci/test-slim-fetch-local.sh darwin_arm64
+#   PLATFORM_TAG=linux_x86_64 scripts/ci/test-slim-fetch-local.sh
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+map_local_prebuild_tag () {
+  case "$1" in
+    linux_x86_64) echo linux-x64 ;;
+    linux_aarch64) echo linux-arm64 ;;
+    win32_x64) echo win32-x64 ;;
+    darwin_x86_64|darwin_x86_64_2) echo darwin-x64 ;;
+    darwin_arm64|darwin_arm64_2) echo darwin-arm64 ;;
+    *) echo "unknown PLATFORM_TAG: $1" >&2; exit 1 ;;
+  esac
+}
+
+PLATFORM_TAG="${1:-${PLATFORM_TAG:-darwin_arm64}}"
+PKG_VERSION="$(node -p "require('./package.json').version")"
+TAG="$(map_local_prebuild_tag "$PLATFORM_TAG")"
+
+if [[ ! -d "prebuilds/${TAG}" ]]; then
+  echo "test-slim-fetch-local: missing prebuilds/${TAG}; run a native build first" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+cleanup () { rm -rf "$WORK" "$ROOT/aerospike-${PKG_VERSION}.tgz" "$ROOT/packages/prebuild-${TAG}/"*.tgz 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "== pack slim tarballs for ${TAG} ==" >&2
+PREBUILD_SPLIT_PLATFORMS="$TAG" node scripts/ci/split-prebuild-packages.js
+MAIN_TGZ="$(npm pack --silent)"
+mv "$ROOT/$MAIN_TGZ" "$WORK/$MAIN_TGZ"
+pushd "$ROOT/packages/prebuild-${TAG}" >/dev/null
+PRE_TGZ="$(npm pack --silent)"
+popd >/dev/null
+mv "$ROOT/packages/prebuild-${TAG}/$PRE_TGZ" "$WORK/$PRE_TGZ"
+
+echo "== extract mode ==" >&2
+mkdir -p "$WORK/extract"
+(
+  cd "$WORK/extract"
+  cp "$WORK/$MAIN_TGZ" "$WORK/$PRE_TGZ" .
+  PKG_VERSION="$PKG_VERSION" PLATFORM_TAG="$PLATFORM_TAG" \
+    BUNDLE_VERSION= \
+    bash "$ROOT/scripts/ci/jfrog-fetch-slim-packages.sh" extract
+  test -d "prebuilds/${TAG}"
+  test -n "$(find "prebuilds/${TAG}" -name '*.node' | head -n 1)"
+  echo "extract layout ok"
+)
+
+echo "== install mode ==" >&2
+mkdir -p "$WORK/install"
+(
+  cd "$WORK/install"
+  cp "$WORK/$MAIN_TGZ" "$WORK/$PRE_TGZ" .
+  PKG_VERSION="$PKG_VERSION" PLATFORM_TAG="$PLATFORM_TAG" \
+    BUNDLE_VERSION= \
+    bash "$ROOT/scripts/ci/jfrog-fetch-slim-packages.sh" install
+)
+
+echo "== pm-style file install ==" >&2
+mkdir -p "$WORK/pm"
+(
+  cd "$WORK/pm"
+  cp "$WORK/$MAIN_TGZ" "$WORK/$PRE_TGZ" .
+  echo '{}' > package.json
+  # shellcheck disable=SC1091
+  source "$ROOT/scripts/ci/select-slim-tarballs.sh"
+  select_slim_tarballs
+  npm install --no-save --ignore-scripts "file:./${MAIN_TGZ}" "file:./${PREBUILD_TGZ}"
+  (
+    cd node_modules/aerospike
+    node scripts/verify-prebuild-smoke.js
+  )
+)
+
+echo "test-slim-fetch-local: ok (${PLATFORM_TAG} / ${TAG})" >&2

--- a/scripts/resolve-prebuild-root.js
+++ b/scripts/resolve-prebuild-root.js
@@ -18,6 +18,19 @@ function resolvePrebuildRoot (mainPackageRoot) {
   }
 
   const optionalName = `@aerospike/prebuild-${tag}`
+  let dir = mainPackageRoot
+  while (true) {
+    const optionalRoot = path.join(dir, 'node_modules', optionalName)
+    if (fs.existsSync(path.join(optionalRoot, 'package.json'))) {
+      return optionalRoot
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+
   try {
     const pkgJson = require.resolve(`${optionalName}/package.json`, {
       paths: [mainPackageRoot]

--- a/scripts/verify-prebuild-smoke.js
+++ b/scripts/verify-prebuild-smoke.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 'use strict'
 
+if (process.env.ELECTRON_RUN_AS_NODE) {
+  delete process.env.ELECTRON_RUN_AS_NODE
+}
+
 const fs = require('fs')
 const path = require('path')
 const { resolveNativeBinding } = require('./resolve-native-binding')


### PR DESCRIPTION
Use npm pack prebuild filenames (aerospike-prebuild-*), verify slim install layout after file/registry installs, and resolve optional prebuild packages from ancestor node_modules. Add local fetch smoke script.