### PR TITLE
Fix stage JFrog fetch when GitHub JFROG_* vars are unset.

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -47,10 +47,10 @@ on:
 
 env:
   COMMIT_SHA_TO_BUILD_AND_TEST: ${{ github.sha }}
-  JF_URL: ${{ vars.JFROG_PLATFORM_URL }}
-  JF_PROJECT: ${{ vars.JFROG_PROJECT }}
-  JF_OIDC_PROVIDER: ${{ vars.JFROG_OIDC_PROVIDER }}
-  JF_OIDC_AUDIENCE: ${{ vars.JFROG_OIDC_AUDIENCE }}
+  JF_URL: ${{ vars.JFROG_PLATFORM_URL != '' && vars.JFROG_PLATFORM_URL || 'https://aerospike.jfrog.io' }}
+  JF_PROJECT: ${{ vars.JFROG_PROJECT != '' && vars.JFROG_PROJECT || 'database' }}
+  JF_OIDC_PROVIDER: ${{ vars.JFROG_OIDC_PROVIDER != '' && vars.JFROG_OIDC_PROVIDER || 'database-gh-aerospike' }}
+  JF_OIDC_AUDIENCE: ${{ vars.JFROG_OIDC_AUDIENCE != '' && vars.JFROG_OIDC_AUDIENCE || 'database-gh-aerospike' }}
 
 jobs:
   get-runner-os:

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -70,6 +70,18 @@ count_files () {
   find "$1" -type f 2>/dev/null | wc -l | tr -d ' '
 }
 
+ensure_jfrog_env () {
+  if [[ -z "${JF_URL}" ]]; then
+    JF_URL=https://aerospike.jfrog.io
+  fi
+  if [[ -z "${JF_PROJECT}" ]]; then
+    JF_PROJECT=database
+  fi
+  if [[ -z "${JF_REPO}" ]]; then
+    JF_REPO=database-npm-dev-local
+  fi
+}
+
 configure_jfrog_npm () {
   if ! command -v jf >/dev/null 2>&1; then
     echo "warning: jf CLI not available for npm registry fallback" >&2
@@ -314,11 +326,12 @@ BUNDLE_NAME="${BUNDLE_NAME:-aerospike-nodejs-client}"
 BUNDLE_VERSION="${BUNDLE_VERSION:-}"
 PREBUILD_TAG="$(map_prebuild_tag "$PLATFORM_TAG")"
 WORKSPACE_ROOT="$(pwd)"
+ensure_jfrog_env
 
 MAIN="aerospike-${PKG_VERSION}.tgz"
 PREBUILD="aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz"
 
-echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE} bundle=${BUNDLE_VERSION:-none}" >&2
+echo "jfrog-fetch-slim-packages: main=${MAIN} prebuild=${PREBUILD} mode=${MODE} bundle=${BUNDLE_VERSION:-none} project=${JF_PROJECT}" >&2
 
 if [[ "$MODE" != "install" && "$MODE" != "extract" ]]; then
   rm -f "./${MAIN}" "./${PREBUILD}"


### PR DESCRIPTION
Empty repository variables left JF_PROJECT blank, so jf rt dl --project failed on every fetch step. Add workflow fallbacks to database defaults and normalize empty env in jfrog-fetch-slim-packages.sh.