### PR TITLE
Client 5213 fix bundle fetch wrong artifact

### DIFF
--- a/.github/workflows/stage-comprehensive-tests.yml
+++ b/.github/workflows/stage-comprehensive-tests.yml
@@ -319,10 +319,7 @@ jobs:
           [[ -f "$f" ]] && mv "$f" pnpm/
         done
         cd pnpm
-        echo '{}' > package.json
-        source ../scripts/ci/select-slim-tarballs.sh
-        select_slim_tarballs
-        pnpm add "file:./${MAIN_TGZ}" "file:./${PREBUILD_TGZ}" --ignore-scripts
+        bash ../scripts/ci/install-slim-pm-smoke.sh pnpm
         node basic_test.js
 
     # - name: Set final commit status
@@ -412,10 +409,7 @@ jobs:
           [[ -f "$f" ]] && mv "$f" bun/
         done
         cd bun;
-        echo '{}' > package.json;
-        source ../scripts/ci/select-slim-tarballs.sh
-        select_slim_tarballs
-        bun add "./${MAIN_TGZ}" "./${PREBUILD_TGZ}"
+        bash ../scripts/ci/install-slim-pm-smoke.sh bun
         node basic_test.js;
 
     #- name: Debug server
@@ -510,10 +504,7 @@ jobs:
           [[ -f "$f" ]] && mv "$f" yarn/
         done
         cd yarn
-        echo '{}' > package.json
-        source ../scripts/ci/select-slim-tarballs.sh
-        select_slim_tarballs
-        yarn add "file:./${MAIN_TGZ}" "file:./${PREBUILD_TGZ}" --ignore-scripts
+        bash ../scripts/ci/install-slim-pm-smoke.sh yarn
         node basic_test.js
 
     #- name: Debug server

--- a/scripts/ci/install-slim-pm-smoke.sh
+++ b/scripts/ci/install-slim-pm-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install slim-layout tarballs for yarn/pnpm/bun smoke tests.
+#
+# Usage (from directory containing .tgz files):
+#   PREBUILD_TAG=linux-x64 scripts/ci/install-slim-pm-smoke.sh yarn|pnpm|bun
+#
+# yarn/pnpm/bun must not use bare "add file:..." on the main tarball — aerospike
+# optionalDependencies confuse them into pulling wrong @aerospike/prebuild-* packages.
+
+usage () {
+  echo "usage: PREBUILD_TAG=<platform> $0 yarn|pnpm|bun" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+PM=$1
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/select-slim-tarballs.sh"
+select_slim_tarballs
+
+if [[ -z "${PREBUILD_TAG:-}" ]]; then
+  PREBUILD_TAG="$(
+    basename "$PREBUILD_TGZ" \
+      | sed -E 's/^@?aerospike-prebuild-(.+)-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/\1/'
+  )"
+fi
+
+PREBUILD_PKG="@aerospike/prebuild-${PREBUILD_TAG}"
+
+cat > package.json <<EOF
+{
+  "private": true,
+  "dependencies": {
+    "aerospike": "file:./${MAIN_TGZ}",
+    "${PREBUILD_PKG}": "file:./${PREBUILD_TGZ}"
+  }
+}
+EOF
+
+echo "install-slim-pm-smoke: pm=${PM} main=${MAIN_TGZ} ${PREBUILD_PKG}=${PREBUILD_TGZ}" >&2
+
+case "$PM" in
+  yarn)
+    yarn install --ignore-optional --ignore-scripts
+    ;;
+  pnpm)
+    pnpm install --ignore-scripts --config.optional=false
+    ;;
+  bun)
+    bun install --ignore-scripts
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+(
+  cd node_modules/aerospike
+  node scripts/verify-prebuild-smoke.js
+)

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -82,6 +82,43 @@ ensure_jfrog_env () {
   fi
 }
 
+validate_main_tgz () {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  if ! tar -tzf "$file" package/package.json >/dev/null 2>&1; then
+    return 1
+  fi
+  local name
+  name="$(
+    tar -xOf "$file" package/package.json 2>/dev/null \
+      | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(s).name||'')}catch{process.exit(1)}})"
+  )"
+  [[ "$name" == "aerospike" ]]
+}
+
+validate_prebuild_tgz () {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  tar -tzf "$file" 2>/dev/null | grep -q "package/prebuilds/${PREBUILD_TAG}/"
+}
+
+reject_invalid_tarballs () {
+  if [[ -f "$MAIN" ]] && ! validate_main_tgz "$MAIN"; then
+    echo "warning: rejecting invalid main tarball ${MAIN}" >&2
+    rm -f "$MAIN"
+  fi
+  if [[ -f "$PREBUILD" ]] && ! validate_prebuild_tgz "$PREBUILD"; then
+    echo "warning: rejecting invalid prebuild tarball ${PREBUILD} (expected prebuilds/${PREBUILD_TAG}/)" >&2
+    rm -f "$PREBUILD"
+  fi
+}
+
+have_valid_tarballs () {
+  [[ -f "$MAIN" && -f "$PREBUILD" ]] \
+    && validate_main_tgz "$MAIN" \
+    && validate_prebuild_tgz "$PREBUILD"
+}
+
 configure_jfrog_npm () {
   if ! command -v jf >/dev/null 2>&1; then
     echo "warning: jf CLI not available for npm registry fallback" >&2
@@ -93,11 +130,13 @@ configure_jfrog_npm () {
 
 try_rt_dl_flat () {
   local spec="$1" dest="$2"
-  local extra=()
   if [[ -n "${BUNDLE_VERSION:-}" ]]; then
-    extra=(--bundle "${BUNDLE_NAME}/${BUNDLE_VERSION}")
+    jf rt dl --flat --project "$JF_PROJECT" \
+      --bundle "${BUNDLE_NAME}/${BUNDLE_VERSION}" \
+      "$spec" "$dest"
+  else
+    jf rt dl --flat --project "$JF_PROJECT" "$spec" "$dest"
   fi
-  jf rt dl --flat --project "$JF_PROJECT" "${extra[@]}" "$spec" "$dest"
 }
 
 resolve_prebuild_path () {
@@ -167,55 +206,19 @@ install_slim_from_tarballs () {
   verify_slim_install
 }
 
-fetch_from_bundle_paths () {
-  local repo="$1"
-  [[ -n "$BUNDLE_VERSION" ]] || return 1
+copy_bundle_artifacts () {
+  local root="$1"
+  local main_src pre_src
 
-  echo "try bundle-scoped npm paths for ${BUNDLE_NAME}/${BUNDLE_VERSION}" >&2
-
-  if [[ ! -f "$MAIN" ]]; then
-    try_rt_dl_flat "${repo}/aerospike/-/${MAIN}" "./${MAIN}" \
-      || rm -f "./${MAIN}"
+  main_src="$(find_artifact "$root" "$MAIN")"
+  pre_src="$(find_prebuild_artifact "$root")"
+  if [[ -n "$pre_src" ]]; then
+    PREBUILD="$(basename "$pre_src")"
   fi
-
-  if [[ ! -f "$PREBUILD" ]]; then
-    local spec dest="./${PREBUILD}"
-    for spec in \
-      "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/${PREBUILD}" \
-      "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/aerospike-prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
-      "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/-/prebuild-${PREBUILD_TAG}-${PKG_VERSION}.tgz" \
-      "${repo}/@aerospike/prebuild-${PREBUILD_TAG}/*/*.tgz"
-    do
-      rm -f "./${PREBUILD}" || true
-      shopt -s nullglob
-      rm -f ./*prebuild-"${PREBUILD_TAG}"*.tgz || true
-      shopt -u nullglob
-      if try_rt_dl_flat "$spec" "$dest"; then
-        break
-      fi
-      local got
-      got="$(find . -maxdepth 1 -type f -name "*prebuild-${PREBUILD_TAG}*${PKG_VERSION}.tgz" | head -n 1)"
-      if [[ -n "$got" ]]; then
-        if [[ "$got" != "./${PREBUILD}" ]]; then
-          mv "$got" "./${PREBUILD}"
-        fi
-        break
-      fi
-    done
-  fi
-
-  normalize_downloaded_prebuild || true
-  [[ -f "$MAIN" && -f "$PREBUILD" ]]
-}
-
-normalize_downloaded_prebuild () {
-  if [[ -f "$PREBUILD" ]]; then
-    return 0
-  fi
-
-  local resolved
-  resolved="$(resolve_prebuild_path)" || return 1
-  PREBUILD="$(basename "$resolved")"
+  copy_if_found "$main_src" "./${MAIN}" || true
+  copy_if_found "$pre_src" "./${PREBUILD}" || true
+  reject_invalid_tarballs
+  have_valid_tarballs
 }
 
 fetch_from_release_bundle () {
@@ -241,6 +244,16 @@ fetch_from_release_bundle () {
   echo "release bundle download fetched ${n} file(s)" >&2
 }
 
+normalize_downloaded_prebuild () {
+  if [[ -f "$PREBUILD" ]] && validate_prebuild_tgz "$PREBUILD"; then
+    return 0
+  fi
+
+  local resolved
+  resolved="$(resolve_prebuild_path)" || return 1
+  PREBUILD="$(basename "$resolved")"
+}
+
 fetch_from_npm_paths () {
   local repo="$1"
   BUNDLE_VERSION=""
@@ -254,13 +267,15 @@ fetch_from_npm_paths () {
 
   echo "try npm path: ${main_path}" >&2
   try_rt_dl_flat "$main_path" "./${MAIN}" || rm -f "./${MAIN}"
+  validate_main_tgz "$MAIN" || rm -f "./${MAIN}"
 
   for spec in "${prebuild_specs[@]}"; do
-    [[ -f "$PREBUILD" ]] && break
+    [[ -f "$PREBUILD" ]] && validate_prebuild_tgz "$PREBUILD" && break
     echo "try npm path: ${spec}" >&2
     try_rt_dl_flat "$spec" "./${PREBUILD}" || rm -f "./${PREBUILD}"
   done
 
+  reject_invalid_tarballs
   normalize_downloaded_prebuild || true
 }
 
@@ -337,35 +352,28 @@ if [[ "$MODE" != "install" && "$MODE" != "extract" ]]; then
   rm -f "./${MAIN}" "./${PREBUILD}"
 fi
 
-if [[ -n "$BUNDLE_VERSION" ]]; then
-  fetch_from_bundle_paths "$JF_REPO" || true
+reject_invalid_tarballs
 
-  if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
-    bundle_root="$(mktemp -d)"
-    if fetch_from_release_bundle "$bundle_root"; then
-      main_src="$(find_artifact "$bundle_root" "$MAIN")"
-      pre_src="$(find_prebuild_artifact "$bundle_root")"
-      if [[ -n "$pre_src" ]]; then
-        PREBUILD="$(basename "$pre_src")"
-      fi
-      copy_if_found "$main_src" "./${MAIN}" || true
-      copy_if_found "$pre_src" "./${PREBUILD}" || true
-    fi
-    rm -rf "$bundle_root"
+if [[ -n "$BUNDLE_VERSION" ]]; then
+  bundle_root="$(mktemp -d)"
+  if fetch_from_release_bundle "$bundle_root"; then
+    copy_bundle_artifacts "$bundle_root" || true
   fi
+  rm -rf "$bundle_root"
 fi
 
-if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
+if ! have_valid_tarballs; then
   fetch_from_npm_paths "$JF_REPO" || true
 fi
 
 normalize_downloaded_prebuild || true
 
-if [[ ! -f "$MAIN" || ! -f "$PREBUILD" ]]; then
+if ! have_valid_tarballs; then
   fetch_from_npm_registry || true
 fi
 
 normalize_downloaded_prebuild || true
+reject_invalid_tarballs
 
 if [[ "$MODE" == "install" && -d .slim-install/node_modules/aerospike ]]; then
   echo "installed via npm registry into .slim-install" >&2
@@ -377,14 +385,14 @@ if [[ "$MODE" == "extract" && -d prebuilds/${PREBUILD_TAG} ]]; then
   exit 0
 fi
 
-if [[ ! -f "$MAIN" ]]; then
-  echo "missing main package: ${MAIN}" >&2
+if [[ ! -f "$MAIN" ]] || ! validate_main_tgz "$MAIN"; then
+  echo "missing or invalid main package: ${MAIN}" >&2
   echo "hint: confirm release bundle ${BUNDLE_NAME}/${BUNDLE_VERSION:-?} exists in JFrog DEV" >&2
   exit 1
 fi
 
-if [[ ! -f "$PREBUILD" ]]; then
-  echo "missing prebuild package for ${PREBUILD_TAG} (expected ${PREBUILD})" >&2
+if [[ ! -f "$PREBUILD" ]] || ! validate_prebuild_tgz "$PREBUILD"; then
+  echo "missing or invalid prebuild package for ${PREBUILD_TAG} (expected ${PREBUILD})" >&2
   ls -la ./*prebuild* 2>/dev/null || true
   echo "hint: confirm @aerospike/prebuild-${PREBUILD_TAG}@${PKG_VERSION} is in bundle ${BUNDLE_VERSION:-?}" >&2
   exit 1

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -98,8 +98,13 @@ validate_main_tgz () {
 
 validate_prebuild_tgz () {
   local file="$1"
+  local abi
   [[ -f "$file" ]] || return 1
-  tar -tzf "$file" 2>/dev/null | grep -q "package/prebuilds/${PREBUILD_TAG}/"
+  tar -tzf "$file" 2>/dev/null | grep -q "package/prebuilds/${PREBUILD_TAG}/" || return 1
+  for abi in 115 127 137 141; do
+    tar -tzf "$file" 2>/dev/null \
+      | grep -q "package/prebuilds/${PREBUILD_TAG}/node.abi${abi}.node" || return 1
+  done
 }
 
 reject_invalid_tarballs () {
@@ -403,6 +408,7 @@ case "$MODE" in
     echo "downloaded ${MAIN} and ${PREBUILD}" >&2
     ;;
   extract)
+    rm -rf "prebuilds/${PREBUILD_TAG}"
     mkdir -p prebuilds
     tmp="$(mktemp -d)"
     tar xzf "$PREBUILD" -C "$tmp"


### PR DESCRIPTION
Stage failures against release bundle 7.0.0-dev.12 came from how artifacts are fetched and installed, not from missing Dev publishes. The JFrog bundle is correct: 6 packages at npm version 7.0.0 (main aerospike + five @aerospike/prebuild-* tarballs).

This PR fixes three Stage issues seen after PRs #1084 and #1087.