### PR TITLE
Fix yarn slim smoke by stripping main optionalDependencies.

### DIFF
--- a/scripts/ci/install-slim-pm-smoke.sh
+++ b/scripts/ci/install-slim-pm-smoke.sh
@@ -6,8 +6,11 @@ set -euo pipefail
 # Usage (from directory containing .tgz files):
 #   PREBUILD_TAG=linux-x64 scripts/ci/install-slim-pm-smoke.sh yarn|pnpm|bun
 #
-# yarn/pnpm/bun must not use bare "add file:..." on the main tarball — aerospike
-# optionalDependencies confuse them into pulling wrong @aerospike/prebuild-* packages.
+# The main aerospike tarball declares optionalDependencies for every platform
+# prebuild. Yarn 1 --ignore-optional only skips root optional deps, so yarn
+# still tries to fetch @aerospike/prebuild-* from the registry when installing
+# file:./aerospike-*.tgz. Strip optionalDependencies from an extracted copy of
+# the main package and install that directory plus the platform prebuild file.
 
 usage () {
   echo "usage: PREBUILD_TAG=<platform> $0 yarn|pnpm|bun" >&2
@@ -30,18 +33,35 @@ if [[ -z "${PREBUILD_TAG:-}" ]]; then
 fi
 
 PREBUILD_PKG="@aerospike/prebuild-${PREBUILD_TAG}"
+SLIM_MAIN_DIR=".slim-main-pkg"
+
+prepare_slim_main_package () {
+  rm -rf "$SLIM_MAIN_DIR"
+  mkdir -p "$SLIM_MAIN_DIR"
+  tar xzf "$MAIN_TGZ" -C "$SLIM_MAIN_DIR"
+  node <<NODE
+const fs = require('fs')
+const path = require('path')
+const pkgPath = path.join(process.cwd(), '${SLIM_MAIN_DIR}', 'package', 'package.json')
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+delete pkg.optionalDependencies
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\\n')
+NODE
+}
+
+prepare_slim_main_package
 
 cat > package.json <<EOF
 {
   "private": true,
   "dependencies": {
-    "aerospike": "file:./${MAIN_TGZ}",
+    "aerospike": "file:./${SLIM_MAIN_DIR}/package",
     "${PREBUILD_PKG}": "file:./${PREBUILD_TGZ}"
   }
 }
 EOF
 
-echo "install-slim-pm-smoke: pm=${PM} main=${MAIN_TGZ} ${PREBUILD_PKG}=${PREBUILD_TGZ}" >&2
+echo "install-slim-pm-smoke: pm=${PM} main=${SLIM_MAIN_DIR}/package ${PREBUILD_PKG}=${PREBUILD_TGZ}" >&2
 
 case "$PM" in
   yarn)

--- a/scripts/ci/jfrog-fetch-slim-packages.sh
+++ b/scripts/ci/jfrog-fetch-slim-packages.sh
@@ -235,24 +235,41 @@ verify_slim_install () {
   echo "slim install verified for ${PREBUILD_TAG}" >&2
 }
 
-install_slim_from_tarballs () {
-  local main_path="${WORKSPACE_ROOT}/${MAIN}"
-  local prebuild_path
-  prebuild_path="$(resolve_prebuild_path)"
+prepare_slim_main_for_install () {
+  rm -rf .slim-main-pkg
+  mkdir -p .slim-main-pkg
+  tar xzf "./${MAIN}" -C .slim-main-pkg
+  node <<'NODE'
+const fs = require('fs')
+const path = require('path')
+const pkgPath = path.join(process.cwd(), '.slim-main-pkg', 'package', 'package.json')
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+delete pkg.optionalDependencies
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+NODE
+}
 
-  if [[ ! -f "$main_path" ]]; then
-    echo "install_slim_from_tarballs: missing main tarball ${main_path}" >&2
+install_slim_from_tarballs () {
+  if [[ ! -f "./${MAIN}" ]]; then
+    echo "install_slim_from_tarballs: missing main tarball ${WORKSPACE_ROOT}/${MAIN}" >&2
     exit 1
   fi
+  if ! resolve_prebuild_path >/dev/null; then
+    echo "install_slim_from_tarballs: missing prebuild tarball ${WORKSPACE_ROOT}/${PREBUILD}" >&2
+    exit 1
+  fi
+
+  prepare_slim_main_for_install
 
   rm -rf .slim-install
   mkdir .slim-install
   (
     cd .slim-install
     echo '{"name":"slim-jfrog-smoke","private":true}' > package.json
-    npm install --no-save --ignore-scripts \
-      "file:${main_path}" \
-      "file:${prebuild_path}"
+    # Relative file: paths avoid Git Bash -> npm path mangling on Windows (D:\d\a\...).
+    npm install --no-save --ignore-scripts --omit=optional \
+      "file:../.slim-main-pkg/package" \
+      "file:../${PREBUILD}"
   )
   verify_slim_install
 }


### PR DESCRIPTION
Yarn 1 --ignore-optional does not skip optionalDependencies declared inside aerospike@file:...; install from an extracted main package with those entries removed plus the explicit platform prebuild file dependency.